### PR TITLE
[R-package] update roles in DESCRIPTION

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -5,9 +5,9 @@ Version: 3.0.0-1
 Date: 2020-08-06
 Authors@R: c(
     person("Guolin", "Ke", email = "guolin.ke@microsoft.com", role = c("aut", "cre")),
-    person("Damien", "Soukhavong", email = "damien.soukhavong@skema.edu", role = c("ctb")),
+    person("Damien", "Soukhavong", email = "damien.soukhavong@skema.edu", role = c("aut")),
     person("Yachen", "Yan", role = c("ctb")),
-    person("James", "Lamb", email="jaylamb20@gmail.com", role = c("ctb"))
+    person("James", "Lamb", email="jaylamb20@gmail.com", role = c("aut"))
     )
 Description: Tree based algorithms can be improved by introducing boosting frameworks. 'LightGBM' is one such framework, and this package offers an R interface to work with it.
     It is designed to be distributed and efficient with the following advantages:


### PR DESCRIPTION
@guolinke since the R package is so close to CRAN, I'd like to propose changing the DESCRIPTION entry for myself and @Laurae2 from `ctb` to `aut`.

From ["The Roles of R Package Authors and How to Refer to Them"](https://journal.r-project.org/archive/2012-1/RJournal_2012-1_Hornik~et~al.pdf)

**"aut" (Author)**

> Full authors who have made substantial contributions to the package and should show up in the package citation.

**"ctb" (Contributor)**

> Authors who have made smaller contributions (such as code patches) but should not show up in the package citation.

**"cre" (Creator)**

> Package maintainer


I think that contributions we have made to the R package could be considered "substantial". To be clear, the "citation" is about people citing the use of the R package specifically, not LightGBM generally. 

I was a little unsure about asking for this...if you disagree with the change, I completely understand. Thanks for considering it.