### PR TITLE
[ci][docs] Unpin Sphinx version

### DIFF
--- a/docs/requirements_base.txt
+++ b/docs/requirements_base.txt
@@ -1,2 +1,2 @@
-sphinx < 4
+sphinx
 sphinx_rtd_theme >= 0.5


### PR DESCRIPTION
This reverts commit a421217e4e5f15e8aa5380061ff5d153188cab62.

Sphinx `4.0.1` has been released.