### PR TITLE
fix behavior for default objective and metric

### DIFF
--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -415,10 +415,10 @@ test_that("Creating a Booster from a Dataset with an existing predictor should w
     expect_true(lgb.is.Booster(bst))
     expect_equal(bst$current_iter(), nrounds)
     expect_equal(bst$eval_train()[[1L]][["value"]], 0.1115352)
+    expect_true(lgb.is.Booster(bst_from_ds))
     expect_equal(bst_from_ds$current_iter(), nrounds)
+    expect_equal(bst_from_ds$eval_train()[[1L]][["value"]], 5.65704892)
     dumped_model <- jsonlite::fromJSON(bst$dump_model())
-    expect_identical(bst_from_ds$eval_train(), list())
-    expect_equal(bst_from_ds$current_iter(), nrounds)
 })
 
 test_that("Booster$eval() should work on a Dataset stored in a binary file", {

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -85,7 +85,7 @@ void GetObjectiveType(const std::unordered_map<std::string, std::string>& params
   }
 }
 
-void GetMetricType(const std::unordered_map<std::string, std::string>& params, std::vector<std::string>* metric) {
+void GetMetricType(const std::unordered_map<std::string, std::string>& params, const std::string& objective, std::vector<std::string>* metric) {
   std::string value;
   if (Config::GetString(params, "metric", &value)) {
     std::transform(value.begin(), value.end(), value.begin(), Common::tolower);
@@ -93,10 +93,7 @@ void GetMetricType(const std::unordered_map<std::string, std::string>& params, s
   }
   // add names of objective function if not providing metric
   if (metric->empty() && value.size() == 0) {
-    if (Config::GetString(params, "objective", &value)) {
-      std::transform(value.begin(), value.end(), value.begin(), Common::tolower);
-      ParseMetrics(value, metric);
-    }
+    ParseMetrics(objective, metric);
   }
 }
 
@@ -208,8 +205,8 @@ void Config::Set(const std::unordered_map<std::string, std::string>& params) {
 
   GetTaskType(params, &task);
   GetBoostingType(params, &boosting);
-  GetMetricType(params, &metric);
   GetObjectiveType(params, &objective);
+  GetMetricType(params, objective, &metric);
   GetDeviceType(params, &device_type);
   if (device_type == std::string("cuda")) {
     LGBM_config_::current_device = lgbm_device_cuda;

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2029,6 +2029,27 @@ def test_multiple_feval_cv():
     assert 'decreasing_metric-stdv' in cv_results
 
 
+def test_default_objective_and_metric():
+    X, y = load_breast_cancer(return_X_y=True)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+    train_dataset = lgb.Dataset(data=X_train, label=y_train)
+    validation_dataset = lgb.Dataset(data=X_test, label=y_test, reference=train_dataset)
+    evals_result = {}
+    params = {'verbose': -1}
+    lgb.train(
+        params=params,
+        train_set=train_dataset,
+        valid_sets=validation_dataset,
+        num_boost_round=5,
+        callbacks=[lgb.record_evaluation(evals_result)]
+    )
+
+    assert 'valid_0' in evals_result
+    assert len(evals_result['valid_0']) == 1
+    assert 'l2' in evals_result['valid_0']
+    assert len(evals_result['valid_0']['l2']) == 5
+
+
 @pytest.mark.skipif(psutil.virtual_memory().available / 1024 / 1024 / 1024 < 3, reason='not enough RAM')
 def test_model_size():
     X, y = load_boston(return_X_y=True)


### PR DESCRIPTION
Fixed #4655.

Configure metric after objective and use configured objective as a default metric if user doesn't provide any.
By default, `objective` is `regression` and can be omitted in params
https://github.com/microsoft/LightGBM/blob/f3987f37249ea4cc7b30b11cb83129ab73f5d588/include/LightGBM/config.h#L139