### PR TITLE
Replace deprecated `licenseUrl` field with `license` one in `.nuspec` file

### DIFF
--- a/.nuget/create_nuget.py
+++ b/.nuget/create_nuget.py
@@ -29,7 +29,6 @@ if __name__ == "__main__":
         <authors>Guolin Ke</authors>
         <owners>Guolin Ke</owners>
         <license type="expression">MIT</license>
-        <licenseUrl>https://github.com/microsoft/LightGBM/blob/master/LICENSE</licenseUrl>
         <projectUrl>https://github.com/microsoft/LightGBM</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>A fast, distributed, high performance gradient boosting framework</description>


### PR DESCRIPTION
> The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.
    https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5125
    https://docs.microsoft.com/en-us/nuget/reference/nuspec#license
    https://github.com/NuGet/Announcements/issues/32
    https://github.com/microsoft/LightGBM/pull/3872#issuecomment-804831079
    