### PR TITLE
[python] fix mypy error in setup.py

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -61,10 +61,10 @@ def copy_files(integrated_opencl: bool = False, use_gpu: bool = False) -> None:
         copy_files_helper('include')
         copy_files_helper('src')
         for submodule in (CURRENT_DIR.parent / 'external_libs').iterdir():
-            submodule = submodule.stem
-            if submodule == 'compute' and not use_gpu:
+            submodule_stem = submodule.stem
+            if submodule_stem == 'compute' and not use_gpu:
                 continue
-            copy_files_helper(Path('external_libs') / submodule)
+            copy_files_helper(Path('external_libs') / submodule_stem)
         (CURRENT_DIR / "compile" / "windows").mkdir(parents=True, exist_ok=True)
         copyfile(CURRENT_DIR.parent / "windows" / "LightGBM.sln",
                  CURRENT_DIR / "compile" / "windows" / "LightGBM.sln")


### PR DESCRIPTION
Contributes to #3867

The error that gets fixed through this PR:
```
python-package/setup.py:64: error: Incompatible types in assignment (expression has type "str", variable has type "Path")
```

### Changes introduced
- Replace the "Path" variable `submodule`, with a new variable `submodule_stem` to prevent incompatible assignment error.