### PR TITLE
[python] fix mypy error in engine.py

### DIFF
--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -188,12 +188,11 @@ def train(
 
     if num_boost_round <= 0:
         raise ValueError("num_boost_round should be greater than zero.")
+    predictor: Optional[_InnerPredictor] = None
     if isinstance(init_model, (str, Path)):
         predictor = _InnerPredictor(model_file=init_model, pred_parameter=params)
     elif isinstance(init_model, Booster):
         predictor = init_model._to_predictor(dict(init_model.params, **params))
-    else:
-        predictor = None
     init_iteration = predictor.num_total_iteration if predictor is not None else 0
     # check dataset
     if not isinstance(train_set, Dataset):


### PR DESCRIPTION
Contributes to #3867 

The error that gets fixed through this PR:
```
python-package/lightgbm/engine.py:196: error: Incompatible types in assignment (expression has type "None", variable has type "_InnerPredictor")
```

### Reason for the error
When a variable (here `predictor`) is used for the first time, mypy will infer it's type from the very first assignment it sees.
Hence, `predictor` is given the type `_InnerPredictor` by mypy, here.
So, mypy complains when it sees `predictor = None` later.

### Changes introduced
Forward declaring the variable `predictor` as
```
predictor: Optional[_InnerPredictor] = None
```

### Reference
[Stack Overflow link](https://stackoverflow.com/a/52860650/14765738)