### PR TITLE
[ci] Bump Google Test version from `1.10.0` to `1.11.0`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ if(BUILD_CPP_TEST)
     FetchContent_Declare(
       googletest
       GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG        release-1.10.0
+      GIT_TAG        release-1.11.0
     )
     FetchContent_MakeAvailable(googletest)
     add_library(GTest::GTest ALIAS gtest)


### PR DESCRIPTION
Refer to https://github.com/google/googletest/releases and #3763.