### PR TITLE
[R-package] Expand user paths in file names

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -76,6 +76,8 @@ Booster <- R6::R6Class(
             stop("lgb.Booster: Can only use a string as model file path")
           }
 
+          modelfile <- path.expand(modelfile)
+
           # Create booster from model
           handle <- .Call(
             LGBM_BoosterCreateFromModelfile_R
@@ -424,6 +426,8 @@ Booster <- R6::R6Class(
       if (is.null(num_iteration)) {
         num_iteration <- self$best_iter
       }
+
+      filename <- path.expand(filename)
 
       .Call(
         LGBM_BoosterSaveModel_R
@@ -857,6 +861,7 @@ lgb.load <- function(filename = NULL, model_str = NULL) {
     if (!is.character(filename)) {
       stop("lgb.load: filename should be character")
     }
+    filename <- path.expand(filename)
     if (!file.exists(filename)) {
       stop(sprintf("lgb.load: file '%s' passed to filename does not exist", filename))
     }
@@ -917,6 +922,7 @@ lgb.save <- function(booster, filename, num_iteration = NULL) {
   if (!(is.character(filename) && length(filename) == 1L)) {
     stop("lgb.save: filename should be a string")
   }
+  filename <- path.expand(filename)
 
   # Store booster
   return(

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -243,7 +243,7 @@ Dataset <- R6::R6Class(
 
           handle <- .Call(
             LGBM_DatasetCreateFromFile_R
-            , private$raw_data
+            , path.expand(private$raw_data)
             , params_str
             , ref_handle
           )
@@ -742,7 +742,7 @@ Dataset <- R6::R6Class(
       .Call(
         LGBM_DatasetSaveBinary_R
         , private$handle
-        , fname
+        , path.expand(fname)
       )
       return(invisible(self))
     }

--- a/R-package/R/lgb.Predictor.R
+++ b/R-package/R/lgb.Predictor.R
@@ -35,7 +35,7 @@ Predictor <- R6::R6Class(
         # Create handle on it
         handle <- .Call(
           LGBM_BoosterCreateFromModelfile_R
-          , modelfile
+          , path.expand(modelfile)
         )
         private$need_free_handle <- TRUE
 
@@ -95,6 +95,8 @@ Predictor <- R6::R6Class(
 
       # Check if data is a file name and not a matrix
       if (identical(class(data), "character") && length(data) == 1L) {
+
+        data <- path.expand(data)
 
         # Data is a filename, create a temporary file with a "lightgbm_" pattern in it
         tmp_filename <- tempfile(pattern = "lightgbm_")


### PR DESCRIPTION
Many R functions  take file paths as inputs, but will not expand paths like `~/myfile`, which this PR fixes. It comes without any tests because generating files in the user folder in examples and tests would be against CRAN policies.