### PR TITLE
[docs] Add avatar to Yu Shi in R docs

### DIFF
--- a/R-package/pkgdown/_pkgdown.yml
+++ b/R-package/pkgdown/_pkgdown.yml
@@ -17,18 +17,21 @@ development:
   mode: unreleased
 
 authors:
+  Yu Shi:
+    href: https://github.com/shiyu1994
+    html: <img src="https://avatars.githubusercontent.com/u/14541765?s=400&v=4" height="48" /> Yu Shi
   Guolin Ke:
     href: https://github.com/guolinke
-    html: <img src="https://avatars0.githubusercontent.com/u/16040950?s=400&v=4" height="48" /> Guolin Ke
+    html: <img src="https://avatars.githubusercontent.com/u/16040950?s=400&v=4" height="48" /> Guolin Ke
   Damien Soukhavong:
     href: https://github.com/Laurae2
-    html: <img src="https://avatars1.githubusercontent.com/u/9083669?s=460&v=4" height="48" /> Damien Soukhavong
+    html: <img src="https://avatars.githubusercontent.com/u/9083669?s=400&v=4" height="48" /> Damien Soukhavong
   Yachen Yan:
     href: https://github.com/yanyachen
-    html: <img src="https://avatars1.githubusercontent.com/u/6893682?s=460&v=4" height="48" /> Yachen Yan
+    html: <img src="https://avatars.githubusercontent.com/u/6893682?s=400&v=4" height="48" /> Yachen Yan
   James Lamb:
     href: https://github.com/jameslamb
-    html: <img src="https://avatars1.githubusercontent.com/u/7608904?s=400&v=4" height="48" /> James Lamb
+    html: <img src="https://avatars.githubusercontent.com/u/7608904?s=400&v=4" height="48" /> James Lamb
 
 navbar:
   title: LightGBM


### PR DESCRIPTION
Right now the first author and maintainer of R-package has no avatar:

![image](https://user-images.githubusercontent.com/25141164/137640586-70f7618e-544f-4655-99d4-49817e4d594a.png)
