### PR TITLE
[python] Improve error message for plot_metric with Booster

### DIFF
--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -343,7 +343,7 @@ def plot_metric(
     elif isinstance(booster, dict):
         eval_results = deepcopy(booster)
     elif isinstance(booster, Booster):
-        raise TypeError("booster must be dict or LGBMModel. To use plot_metrics with Booster type, first output the metrics using evals_result then pass that in to plot_metric as `booster`")
+        raise TypeError("booster must be dict or LGBMModel. To use plot_metric with Booster type, first record the metrics using record_evaluation callback then pass that to plot_metric as argument `booster`")
     else:
         raise TypeError('booster must be dict or LGBMModel.')
 


### PR DESCRIPTION
If plot_metric is used with the Booster type, throw an error explaining how to correctly plot metrics using Booster.

This addresses issue #4702 .