### PR TITLE
[docs] update comment about pre-installed Java version for SWIG build

### DIFF
--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -36,7 +36,7 @@ if ($env:TASK -ne "bdist") {
 }
 
 if ($env:TASK -eq "swig") {
-  $env:JAVA_HOME = $env:JAVA_HOME_8_X64  # there is pre-installed Zulu OpenJDK-8 somewhere
+  $env:JAVA_HOME = $env:JAVA_HOME_8_X64  # there is pre-installed Eclipse Temurin 8 somewhere
   $ProgressPreference = "SilentlyContinue"  # progress bar bug extremely slows down download speed
   Invoke-WebRequest -Uri "https://github.com/microsoft/LightGBM/releases/download/v2.0.12/swigwin-4.0.2.zip" -OutFile $env:BUILD_SOURCESDIRECTORY/swig/swigwin.zip -UserAgent "NativeHost"
   Add-Type -AssemblyName System.IO.Compression.FileSystem


### PR DESCRIPTION
Zulu OpenJDK has been replaced with Eclipse Temurin on Azure Pipelines (and  GitHub Actions) Windows images.

Refer to
- https://github.com/actions/virtual-environments/blob/main/images/win/Windows2016-Readme.md#java
- > Update June 30th, 2021: Zulu for Azure will no longer receive updates or support starting January 1st, 2022. Azure services are transitioning to Microsoft Build of OpenJDK for JDK 11 and Eclipse Temurin for JDK 8. 
   https://docs.microsoft.com/en-us/azure/developer/java/fundamentals/java-jdk-install
- https://devblogs.microsoft.com/java/end-of-updates-support-and-availability-of-zulu-for-azure/
- > -- Found Java: C:/hostedtoolcache/windows/Java_Temurin-Hotspot_jdk/8.0.302-8/x64/bin/java.exe (found version "1.8.0_302") 
      -- Found JNI: C:/hostedtoolcache/windows/Java_Temurin-Hotspot_jdk/8.0.302-8/x64/lib/jawt.lib 
      https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=11269&view=logs&j=457fb6cd-b9a6-52d5-ab83-9fdcfc761c31&t=302dfe64-6e46-5035-7255-9ce91154684d&l=187

cc @imatiach-msft 