### PR TITLE
[ci] fix CI Windows script to use downloaded SWIG, not the pre-installed one

### DIFF
--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -41,7 +41,7 @@ if ($env:TASK -eq "swig") {
   Invoke-WebRequest -Uri "https://github.com/microsoft/LightGBM/releases/download/v2.0.12/swigwin-4.0.2.zip" -OutFile $env:BUILD_SOURCESDIRECTORY/swig/swigwin.zip -UserAgent "NativeHost"
   Add-Type -AssemblyName System.IO.Compression.FileSystem
   [System.IO.Compression.ZipFile]::ExtractToDirectory("$env:BUILD_SOURCESDIRECTORY/swig/swigwin.zip", "$env:BUILD_SOURCESDIRECTORY/swig")
-  $env:PATH += ";$env:BUILD_SOURCESDIRECTORY/swig/swigwin-4.0.2"
+  $env:PATH = "$env:BUILD_SOURCESDIRECTORY/swig/swigwin-4.0.2;" + $env:PATH
   mkdir $env:BUILD_SOURCESDIRECTORY/build; cd $env:BUILD_SOURCESDIRECTORY/build
   cmake -A x64 -DUSE_SWIG=ON .. ; cmake --build . --target ALL_BUILD --config Release ; Check-Output $?
   if ($env:AZURE -eq "true") {


### PR DESCRIPTION
**Prepend** `PATH` variable (currently **appended**) with downloaded SWIG directory, to avoid using pre-installed unknown SWIG version.

`master` branch:
```
...
-- Found SWIG: C:/ProgramData/chocolatey/bin/swig.exe (found version "4.0.2")
...
```
https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=11269&view=logs&j=457fb6cd-b9a6-52d5-ab83-9fdcfc761c31&t=302dfe64-6e46-5035-7255-9ce91154684d&l=186

This PR:
```
...
-- Found SWIG: D:/a/1/s/swig/swigwin-4.0.2/swig.exe (found version "4.0.2")
...
```
https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=11312&view=logs&j=457fb6cd-b9a6-52d5-ab83-9fdcfc761c31&t=302dfe64-6e46-5035-7255-9ce91154684d&l=186