### PR TITLE
[docs] fix broken SynapseML link

### DIFF
--- a/docs/Parallel-Learning-Guide.rst
+++ b/docs/Parallel-Learning-Guide.rst
@@ -49,7 +49,7 @@ Apache Spark
 
 Apache Spark users can use `SynapseML`_ for machine learning workflows with LightGBM. This project is not maintained by LightGBM's maintainers.
 
-See `this SynapseML example`_ and `the SynapseML documentation`_ for additional information on using LightGBM on Spark.
+See `this SynapseML example`_ for additional information on using LightGBM on Spark.
 
 .. note::
 
@@ -488,8 +488,6 @@ See `the mars documentation`_ for usage examples.
 .. _the Dask worker documentation: https://distributed.dask.org/en/latest/worker.html#memory-management
 
 .. _the metrics functions from dask-ml: https://ml.dask.org/modules/api.html#dask-ml-metrics-metrics
-
-.. _the SynapseML Documentation: https://github.com/microsoft/SynapseML
 
 .. _these Dask examples: https://github.com/microsoft/lightgbm/tree/master/examples/python-guide/dask
 


### PR DESCRIPTION
SynapseML (formerly MMLSpark) maintainers recently did another docs re-organization (https://github.com/microsoft/SynapseML/pull/1221), and as a result a link in LightGBM's documentation is currently broken.

From the most recent `check-links` job.

> URL        `https://github.com/microsoft/SynapseML/blob/master/docs/lightgbm.md'
Name       `the SynapseML documentation'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Parallel-Learning-Guide.html, line 180, col 167
Real URL   https://github.com/microsoft/SynapseML/blob/master/docs/lightgbm.md
Check time 1.243 seconds
Result     Error: 404 Not Found

reference: https://github.com/microsoft/LightGBM/runs/3987915929?check_suite_focus=true

This has happened several times over the last year:

* #4303
* #4401
* #4564

To fix the broken link and avoid disruptions from future re-organizations in SynapseML, this PR proposes replacing the LightGBM-specific link that is now broken to just link to the root of the SynapseML repo instead.

cc @imatiach-msft 