### PR TITLE
[R-package] allow for small numerical differences in Booster test

### DIFF
--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -1,5 +1,6 @@
 context("Booster")
 
+ON_WINDOWS <- .Platform$OS.type == "windows"
 TOLERANCE <- 1e-6
 
 test_that("Booster$finalize() should not fail", {
@@ -466,7 +467,11 @@ test_that("Booster$eval() should work on a Dataset stored in a binary file", {
     )
 
     expect_true(abs(eval_in_mem[[1L]][["value"]] - 0.1744423) < TOLERANCE)
-    expect_equal(eval_in_mem, eval_from_file)
+    if (isTRUE(ON_WINDOWS)) {
+      expect_equal(eval_in_mem, eval_from_file)
+    } else {
+      expect_identical(eval_in_mem, eval_from_file)
+    }
 })
 
 test_that("Booster$rollback_one_iter() should work as expected", {


### PR DESCRIPTION
See #4680 for background on this PR.

On the submission of v3.3.0 to CRAN, one test in the R package failed in one CRAN test setup (`r-devel-windows-x86_64-gcc10-UCRT`).

> ── 1. Failure (test_lgb.Booster.R:469:5): Booster$eval() should work on a Datase
eval_in_mem not identical to eval_from_file.
Objects equal but not identical

This PR proposes using `testthat::expect_equal()` instead of `testthat::expect_identical()` on Windows in the relevant test, to reduce the risk of a rejected submission caused by small numerical precision differences.

### Notes for Reviewers

As noted in #4680, LightGBM's CI does not currently have a job replicating CRAN's UCRT tests, and I'm not aware of an easy way to replicate that job. Also, confusingly, CRAN re-ran the package's tests in that environment and the second time, they all passed: https://github.com/microsoft/LightGBM/issues/4680#issuecomment-949248010.

With this PR, I'm just trying to be overly-cautious in the hope that it reduces the risk of `{lightgbm}` being removed from CRAN. I think that most users of the R package would prefer very small numeric precision issues on Windows to the package being entirely unavailable.