### PR TITLE
remove 'log_evaluation' callback

### DIFF
--- a/docs/Python-API.rst
+++ b/docs/Python-API.rst
@@ -53,7 +53,6 @@ Callbacks
     :toctree: pythonapi/
 
     early_stopping
-    log_evaluation
     record_evaluation
     reset_parameter
 


### PR DESCRIPTION
remove 'log_evaluation' callback because adding it during model training raises AttributeError