### PR TITLE
[WIP] Add support for more than max(int_32_t) data points

### DIFF
--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -300,7 +300,7 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromMats(int32_t nmat,
  * \return 0 when succeed, -1 when failure happens
  */
 LIGHTGBM_C_EXPORT int LGBM_DatasetGetSubset(const DatasetHandle handle,
-                                            const int32_t* used_row_indices,
+                                            const int64_t *used_row_indices,
                                             int32_t num_used_row_indices,
                                             const char* parameters,
                                             DatasetHandle* out);

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -485,13 +485,13 @@ class Dataset {
 
   LIGHTGBM_EXPORT bool SetDoubleField(const char* field_name, const double* field_data, data_size_t num_element);
 
-  LIGHTGBM_EXPORT bool SetIntField(const char* field_name, const int* field_data, data_size_t num_element);
+  LIGHTGBM_EXPORT bool SetIntField(const char* field_name, const data_size_t* field_data, data_size_t num_element);
 
   LIGHTGBM_EXPORT bool GetFloatField(const char* field_name, data_size_t* out_len, const float** out_ptr);
 
   LIGHTGBM_EXPORT bool GetDoubleField(const char* field_name, data_size_t* out_len, const double** out_ptr);
 
-  LIGHTGBM_EXPORT bool GetIntField(const char* field_name, data_size_t* out_len, const int** out_ptr);
+  LIGHTGBM_EXPORT bool GetIntField(const char* field_name, data_size_t* out_len, const data_size_t** out_ptr);
 
   /*!
   * \brief Save current dataset into binary file, will save to "filename.bin"

--- a/include/LightGBM/dataset_loader.h
+++ b/include/LightGBM/dataset_loader.h
@@ -40,17 +40,17 @@ class DatasetLoader {
                                                         const std::unordered_set<int>& categorical_features);
 
  private:
-  Dataset* LoadFromBinFile(const char* data_filename, const char* bin_filename, int rank, int num_machines, int* num_global_data, std::vector<data_size_t>* used_data_indices);
+  Dataset* LoadFromBinFile(const char* data_filename, const char* bin_filename, int rank, int num_machines, data_size_t* num_global_data, std::vector<data_size_t>* used_data_indices);
 
   void SetHeader(const char* filename);
 
   void CheckDataset(const Dataset* dataset, bool is_load_from_binary);
 
-  std::vector<std::string> LoadTextDataToMemory(const char* filename, const Metadata& metadata, int rank, int num_machines, int* num_global_data, std::vector<data_size_t>* used_data_indices);
+  std::vector<std::string> LoadTextDataToMemory(const char* filename, const Metadata& metadata, int rank, int num_machines, data_size_t* num_global_data, std::vector<data_size_t>* used_data_indices);
 
   std::vector<std::string> SampleTextDataFromMemory(const std::vector<std::string>& data);
 
-  std::vector<std::string> SampleTextDataFromFile(const char* filename, const Metadata& metadata, int rank, int num_machines, int* num_global_data, std::vector<data_size_t>* used_data_indices);
+  std::vector<std::string> SampleTextDataFromFile(const char* filename, const Metadata& metadata, int rank, int num_machines, data_size_t* num_global_data, std::vector<data_size_t>* used_data_indices);
 
   void ConstructBinMappersFromTextData(int rank, int num_machines, const std::vector<std::string>& sample_data, const Parser* parser, Dataset* dataset);
 

--- a/include/LightGBM/meta.h
+++ b/include/LightGBM/meta.h
@@ -25,7 +25,7 @@
 namespace LightGBM {
 
 /*! \brief Type of data size, it is better to use signed type*/
-typedef int32_t data_size_t;
+typedef int64_t data_size_t;
 
 // Enable following macro to use double for score_t
 // #define SCORE_T_USE_DOUBLE

--- a/include/LightGBM/metric.h
+++ b/include/LightGBM/metric.h
@@ -78,7 +78,7 @@ class DCGCalculator {
   * \param num_data Number of data
   * \param out Output result
   */
-  static void CalDCG(const std::vector<data_size_t>& ks,
+  static void CalDCG(const std::vector<int>& ks,
     const label_t* label, const double* score,
     data_size_t num_data, std::vector<double>* out);
 
@@ -114,7 +114,7 @@ class DCGCalculator {
   * \param num_data Number of data
   * \param out Output result
   */
-  static void CalMaxDCG(const std::vector<data_size_t>& ks,
+  static void CalMaxDCG(const std::vector<int>& ks,
     const label_t* label, data_size_t num_data, std::vector<double>* out);
 
   /*!

--- a/include/LightGBM/train_share_states.h
+++ b/include/LightGBM/train_share_states.h
@@ -139,10 +139,10 @@ class MultiValBinWrapper {
   int num_threads_;
   int num_bin_;
   int num_bin_aligned_;
-  int n_data_block_;
-  int data_block_size_;
-  int min_block_size_;
-  int num_data_;
+  data_size_t n_data_block_;
+  data_size_t data_block_size_;
+  data_size_t min_block_size_;
+  data_size_t num_data_;
 
   hist_t* origin_hist_data_;
 

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -84,7 +84,7 @@ class Tree {
   */
   int SplitCategorical(int leaf, int feature, int real_feature, const uint32_t* threshold_bin, int num_threshold_bin,
                        const uint32_t* threshold, int num_threshold, double left_value, double right_value,
-                       int left_cnt, int right_cnt, double left_weight, double right_weight, float gain, MissingType missing_type);
+                       data_size_t left_cnt, data_size_t right_cnt, double left_weight, double right_weight, float gain, MissingType missing_type);
 
   /*! \brief Get the output of one leaf */
   inline double LeafOutput(int leaf) const { return leaf_value_[leaf]; }

--- a/include/LightGBM/utils/threading.h
+++ b/include/LightGBM/utils/threading.h
@@ -20,7 +20,7 @@ class Threading {
  public:
   template <typename INDEX_T>
   static inline void BlockInfo(INDEX_T cnt, INDEX_T min_cnt_per_block,
-                               int* out_nblock, INDEX_T* block_size) {
+                               INDEX_T* out_nblock, INDEX_T* block_size) {
     int num_threads = OMP_NUM_THREADS();
     BlockInfo<INDEX_T>(num_threads, cnt, min_cnt_per_block, out_nblock,
                        block_size);
@@ -28,11 +28,11 @@ class Threading {
 
   template <typename INDEX_T>
   static inline void BlockInfo(int num_threads, INDEX_T cnt,
-                               INDEX_T min_cnt_per_block, int* out_nblock,
+                               INDEX_T min_cnt_per_block, INDEX_T* out_nblock,
                                INDEX_T* block_size) {
-    *out_nblock = std::min<int>(
+    *out_nblock = std::min<INDEX_T>(
         num_threads,
-        static_cast<int>((cnt + min_cnt_per_block - 1) / min_cnt_per_block));
+        static_cast<INDEX_T>((cnt + min_cnt_per_block - 1) / min_cnt_per_block));
     if (*out_nblock > 1) {
       *block_size = SIZE_ALIGNED((cnt + (*out_nblock) - 1) / (*out_nblock));
     } else {
@@ -43,10 +43,10 @@ class Threading {
   template <typename INDEX_T>
   static inline void BlockInfoForceSize(int num_threads, INDEX_T cnt,
                                         INDEX_T min_cnt_per_block,
-                                        int* out_nblock, INDEX_T* block_size) {
-    *out_nblock = std::min<int>(
+                                        INDEX_T* out_nblock, INDEX_T* block_size) {
+    *out_nblock = std::min<INDEX_T>(
         num_threads,
-        static_cast<int>((cnt + min_cnt_per_block - 1) / min_cnt_per_block));
+        static_cast<INDEX_T>((cnt + min_cnt_per_block - 1) / min_cnt_per_block));
     if (*out_nblock > 1) {
       *block_size = (cnt + (*out_nblock) - 1) / (*out_nblock);
       // force the block size to the times of min_cnt_per_block
@@ -59,7 +59,7 @@ class Threading {
 
   template <typename INDEX_T>
   static inline void BlockInfoForceSize(INDEX_T cnt, INDEX_T min_cnt_per_block,
-                                        int* out_nblock, INDEX_T* block_size) {
+                                        INDEX_T* out_nblock, INDEX_T* block_size) {
     int num_threads = OMP_NUM_THREADS();
     BlockInfoForceSize<INDEX_T>(num_threads, cnt, min_cnt_per_block, out_nblock,
                                 block_size);
@@ -68,13 +68,13 @@ class Threading {
   template <typename INDEX_T>
   static inline int For(
       INDEX_T start, INDEX_T end, INDEX_T min_block_size,
-      const std::function<void(int, INDEX_T, INDEX_T)>& inner_fun) {
-    int n_block = 1;
+      const std::function<void(INDEX_T, INDEX_T, INDEX_T)>& inner_fun) {
+    INDEX_T n_block = 1;
     INDEX_T num_inner = end - start;
     BlockInfo<INDEX_T>(num_inner, min_block_size, &n_block, &num_inner);
     OMP_INIT_EX();
 #pragma omp parallel for schedule(static, 1)
-    for (int i = 0; i < n_block; ++i) {
+    for (data_size_t i = 0; i < n_block; ++i) {
       OMP_LOOP_EX_BEGIN();
       INDEX_T inner_start = start + num_inner * i;
       INDEX_T inner_end = std::min(end, inner_start + num_inner);
@@ -119,7 +119,7 @@ class ParallelPartitionRunner {
       INDEX_T cnt,
       const std::function<INDEX_T(int, INDEX_T, INDEX_T, INDEX_T*, INDEX_T*)>& func,
       INDEX_T* out) {
-    int nblock = 1;
+    INDEX_T nblock = 1;
     INDEX_T inner_size = cnt;
     if (FORCE_SIZE) {
       Threading::BlockInfoForceSize<INDEX_T>(num_threads_, cnt, min_block_size_,

--- a/src/boosting/goss.hpp
+++ b/src/boosting/goss.hpp
@@ -91,7 +91,7 @@ class GOSS: public GBDT {
     is_use_subset_ = false;
     if (config_->top_rate + config_->other_rate <= 0.5) {
       auto bag_data_cnt = static_cast<data_size_t>((config_->top_rate + config_->other_rate) * num_data_);
-      bag_data_cnt = std::max(1, bag_data_cnt);
+      bag_data_cnt = std::max<data_size_t>(1, bag_data_cnt);
       tmp_subset_.reset(new Dataset(bag_data_cnt));
       tmp_subset_->CopyFeatureMapperFrom(train_data_);
       is_use_subset_ = true;
@@ -113,7 +113,7 @@ class GOSS: public GBDT {
     }
     data_size_t top_k = static_cast<data_size_t>(cnt * config_->top_rate);
     data_size_t other_k = static_cast<data_size_t>(cnt * config_->other_rate);
-    top_k = std::max(1, top_k);
+    top_k = std::max<data_size_t>(1, top_k);
     ArrayArgs<score_t>::ArgMaxAtK(&tmp_gradients, 0, static_cast<int>(tmp_gradients.size()), top_k - 1);
     score_t threshold = tmp_gradients[top_k - 1];
 

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1384,11 +1384,11 @@ int LGBM_DatasetCreateFromCSC(const void* col_ptr,
 }
 
 int LGBM_DatasetGetSubset(
-  const DatasetHandle handle,
-  const int32_t* used_row_indices,
-  int32_t num_used_row_indices,
-  const char* parameters,
-  DatasetHandle* out) {
+        const DatasetHandle handle,
+        const data_size_t *used_row_indices,
+        int32_t num_used_row_indices,
+        const char* parameters,
+        DatasetHandle* out) {
   API_BEGIN();
   auto param = Config::Str2Map(parameters);
   Config config;
@@ -1398,7 +1398,7 @@ int LGBM_DatasetGetSubset(
   CHECK_GT(num_used_row_indices, 0);
   const int32_t lower = 0;
   const int32_t upper = full_dataset->num_data() - 1;
-  CheckElementsIntervalClosed(used_row_indices, lower, upper, num_used_row_indices, "Used indices of subset");
+  CheckElementsIntervalClosed<data_size_t>(used_row_indices, lower, upper, num_used_row_indices, "Used indices of subset");
   if (!std::is_sorted(used_row_indices, used_row_indices + num_used_row_indices)) {
     Log::Fatal("used_row_indices should be sorted in Subset");
   }
@@ -1481,7 +1481,7 @@ int LGBM_DatasetSetField(DatasetHandle handle,
   if (type == C_API_DTYPE_FLOAT32) {
     is_success = dataset->SetFloatField(field_name, reinterpret_cast<const float*>(field_data), static_cast<int32_t>(num_element));
   } else if (type == C_API_DTYPE_INT32) {
-    is_success = dataset->SetIntField(field_name, reinterpret_cast<const int*>(field_data), static_cast<int32_t>(num_element));
+    is_success = dataset->SetIntField(field_name, reinterpret_cast<const data_size_t*>(field_data), static_cast<int32_t>(num_element));
   } else if (type == C_API_DTYPE_FLOAT64) {
     is_success = dataset->SetDoubleField(field_name, reinterpret_cast<const double*>(field_data), static_cast<int32_t>(num_element));
   }
@@ -1491,7 +1491,7 @@ int LGBM_DatasetSetField(DatasetHandle handle,
 
 int LGBM_DatasetGetField(DatasetHandle handle,
                          const char* field_name,
-                         int* out_len,
+                         data_size_t* out_len,
                          const void** out_ptr,
                          int* out_type) {
   API_BEGIN();
@@ -1500,7 +1500,7 @@ int LGBM_DatasetGetField(DatasetHandle handle,
   if (dataset->GetFloatField(field_name, out_len, reinterpret_cast<const float**>(out_ptr))) {
     *out_type = C_API_DTYPE_FLOAT32;
     is_success = true;
-  } else if (dataset->GetIntField(field_name, out_len, reinterpret_cast<const int**>(out_ptr))) {
+  } else if (dataset->GetIntField(field_name, out_len, reinterpret_cast<const data_size_t**>(out_ptr))) {
     *out_type = C_API_DTYPE_INT32;
     is_success = true;
   } else if (dataset->GetDoubleField(field_name, out_len, reinterpret_cast<const double**>(out_ptr))) {

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -868,7 +868,7 @@ bool Dataset::SetDoubleField(const char* field_name, const double* field_data,
   return true;
 }
 
-bool Dataset::SetIntField(const char* field_name, const int* field_data,
+bool Dataset::SetIntField(const char* field_name, const data_size_t* field_data,
                           data_size_t num_element) {
   std::string name(field_name);
   name = Common::Trim(name);
@@ -918,7 +918,7 @@ bool Dataset::GetDoubleField(const char* field_name, data_size_t* out_len,
 }
 
 bool Dataset::GetIntField(const char* field_name, data_size_t* out_len,
-                          const int** out_ptr) {
+                          const data_size_t** out_ptr) {
   std::string name(field_name);
   name = Common::Trim(name);
   if (name == std::string("query") || name == std::string("group")) {
@@ -1070,7 +1070,7 @@ void Dataset::DumpTextFile(const char* text_filename) {
   fprintf(file, "num_features: %d\n", num_features_);
   fprintf(file, "num_total_features: %d\n", num_total_features_);
   fprintf(file, "num_groups: %d\n", num_groups_);
-  fprintf(file, "num_data: %d\n", num_data_);
+  fprintf(file, "num_data: %lld\n", num_data_);
   fprintf(file, "feature_names: ");
   for (auto n : feature_names_) {
     fprintf(file, "%s, ", n.c_str());

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -334,7 +334,7 @@ Dataset* DatasetLoader::LoadFromFileAlignWithOtherDataset(const char* filename, 
 }
 
 Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* bin_filename,
-                                        int rank, int num_machines, int* num_global_data,
+                                        int rank, int num_machines, data_size_t* num_global_data,
                                         std::vector<data_size_t>* used_data_indices) {
   auto dataset = std::unique_ptr<Dataset>(new Dataset());
   auto reader = VirtualFileReader::Make(bin_filename);
@@ -876,7 +876,7 @@ void DatasetLoader::CheckDataset(const Dataset* dataset, bool is_load_from_binar
 }
 
 std::vector<std::string> DatasetLoader::LoadTextDataToMemory(const char* filename, const Metadata& metadata,
-                                                             int rank, int num_machines, int* num_global_data,
+                                                             int rank, int num_machines, data_size_t* num_global_data,
                                                              std::vector<data_size_t>* used_data_indices) {
   TextReader<data_size_t> text_reader(filename, config_.header, config_.file_load_progress_interval_bytes);
   used_data_indices->clear();
@@ -938,7 +938,7 @@ std::vector<std::string> DatasetLoader::SampleTextDataFromMemory(const std::vect
 }
 
 std::vector<std::string> DatasetLoader::SampleTextDataFromFile(const char* filename, const Metadata& metadata,
-                                                               int rank, int num_machines, int* num_global_data,
+                                                               int rank, int num_machines, data_size_t* num_global_data,
                                                                std::vector<data_size_t>* used_data_indices) {
   const data_size_t sample_cnt = static_cast<data_size_t>(config_.bin_construct_sample_cnt);
   TextReader<data_size_t> text_reader(filename, config_.header, config_.file_load_progress_interval_bytes);

--- a/src/io/multi_val_dense_bin.hpp
+++ b/src/io/multi_val_dense_bin.hpp
@@ -149,7 +149,7 @@ class MultiValDenseBin : public MultiValBin {
     if (SUBROW) {
       CHECK_EQ(num_data_, num_used_indices);
     }
-    int n_block = 1;
+    data_size_t n_block = 1;
     data_size_t block_size = num_data_;
     Threading::BlockInfo<data_size_t>(num_data_, 1024, &n_block,
                                       &block_size);

--- a/src/io/multi_val_sparse_bin.hpp
+++ b/src/io/multi_val_sparse_bin.hpp
@@ -219,7 +219,7 @@ class MultiValSparseBin : public MultiValBin {
     if (SUBROW) {
       CHECK_EQ(num_data_, num_used_indices);
     }
-    int n_block = 1;
+    data_size_t n_block = 1;
     data_size_t block_size = num_data_;
     Threading::BlockInfo<data_size_t>(static_cast<int>(t_data_.size() + 1),
                                       num_data_, 1024, &n_block, &block_size);

--- a/src/io/train_share_states.cpp
+++ b/src/io/train_share_states.cpp
@@ -61,8 +61,8 @@ void MultiValBinWrapper::HistMove(const std::vector<hist_t,
 
 void MultiValBinWrapper::HistMerge(std::vector<hist_t,
   Common::AlignmentAllocator<hist_t, kAlignedSize>>* hist_buf) {
-  int n_bin_block = 1;
-  int bin_block_size = num_bin_;
+  data_size_t n_bin_block = 1;
+  data_size_t bin_block_size = num_bin_;
   Threading::BlockInfo<data_size_t>(num_threads_, num_bin_, 512, &n_bin_block,
                                   &bin_block_size);
   hist_t* dst = origin_hist_data_;
@@ -71,11 +71,11 @@ void MultiValBinWrapper::HistMerge(std::vector<hist_t,
   }
   #pragma omp parallel for schedule(static, 1) num_threads(num_threads_)
   for (int t = 0; t < n_bin_block; ++t) {
-    const int start = t * bin_block_size;
-    const int end = std::min(start + bin_block_size, num_bin_);
-    for (int tid = 1; tid < n_data_block_; ++tid) {
+    const data_size_t start = t * bin_block_size;
+    const data_size_t end = std::min<data_size_t>(start + bin_block_size, num_bin_);
+    for (data_size_t tid = 1; tid < n_data_block_; ++tid) {
       auto src_ptr = hist_buf->data() + static_cast<size_t>(num_bin_aligned_) * 2 * (tid - 1);
-      for (int i = start * 2; i < end * 2; ++i) {
+      for (data_size_t i = start * 2; i < end * 2; ++i) {
         dst[i] += src_ptr[i];
       }
     }

--- a/src/metric/dcg_calculator.cpp
+++ b/src/metric/dcg_calculator.cpp
@@ -75,7 +75,7 @@ double DCGCalculator::CalMaxDCGAtK(data_size_t k, const label_t* label, data_siz
   return ret;
 }
 
-void DCGCalculator::CalMaxDCG(const std::vector<data_size_t>& ks,
+void DCGCalculator::CalMaxDCG(const std::vector<int>& ks,
                               const label_t* label,
                               data_size_t num_data,
                               std::vector<double>* out) {
@@ -106,7 +106,7 @@ void DCGCalculator::CalMaxDCG(const std::vector<data_size_t>& ks,
   }
 }
 
-void DCGCalculator::CalDCG(const std::vector<data_size_t>& ks, const label_t* label,
+void DCGCalculator::CalDCG(const std::vector<int>& ks, const label_t* label,
                            const double * score, data_size_t num_data, std::vector<double>* out) {
   // get sorted indices by score
   std::vector<data_size_t> sorted_idx(num_data);

--- a/src/metric/map_metric.hpp
+++ b/src/metric/map_metric.hpp
@@ -156,7 +156,7 @@ class MapMetric:public Metric {
   /*! \brief Sum weights of queries */
   double sum_query_weights_;
   /*! \brief Evaluate position of Nmap */
-  std::vector<data_size_t> eval_at_;
+  std::vector<int> eval_at_;
   std::vector<std::string> name_;
   std::vector<data_size_t> npos_per_query_;
 };

--- a/src/metric/rank_metric.hpp
+++ b/src/metric/rank_metric.hpp
@@ -159,7 +159,7 @@ class NDCGMetric:public Metric {
   /*! \brief Sum weights of queries */
   double sum_query_weights_;
   /*! \brief Evaluate position of NDCG */
-  std::vector<data_size_t> eval_at_;
+  std::vector<int> eval_at_;
   /*! \brief Cache the inverse max dcg for all queries */
   std::vector<std::vector<double>> inverse_max_dcgs_;
 };

--- a/tests/cpp_tests/test_array_args.cpp
+++ b/tests/cpp_tests/test_array_args.cpp
@@ -16,7 +16,7 @@ using LightGBM::ArrayArgs;
 
 TEST(Partition, JustWorks) {
   std::vector<score_t> gradients({0.5f, 5.0f, 1.0f, 2.0f, 2.0f});
-  data_size_t middle_begin, middle_end;
+  int middle_begin, middle_end;
 
   ArrayArgs<score_t>::Partition(&gradients, 0, static_cast<int>(gradients.size()), &middle_begin, &middle_end);
 
@@ -27,14 +27,14 @@ TEST(Partition, JustWorks) {
 
 TEST(Partition, PartitionOneElement) {
   std::vector<score_t> gradients({0.5f});
-  data_size_t middle_begin, middle_end;
+  int middle_begin, middle_end;
   ArrayArgs<score_t>::Partition(&gradients, 0, static_cast<int>(gradients.size()), &middle_begin, &middle_end);
   EXPECT_EQ(gradients[middle_begin + 1], gradients[middle_end - 1]);
 }
 
 TEST(Partition, Empty) {
   std::vector<score_t> gradients;
-  data_size_t middle_begin, middle_end;
+  int middle_begin, middle_end;
   ArrayArgs<score_t>::Partition(&gradients, 0, static_cast<int>(gradients.size()), &middle_begin, &middle_end);
 
   EXPECT_EQ(middle_begin, -1);
@@ -43,7 +43,7 @@ TEST(Partition, Empty) {
 
 TEST(Partition, AllEqual) {
   std::vector<score_t> gradients({0.5f, 0.5f, 0.5f});
-  data_size_t middle_begin, middle_end;
+  int middle_begin, middle_end;
   ArrayArgs<score_t>::Partition(&gradients, 0, static_cast<int>(gradients.size()), &middle_begin, &middle_end);
 
   EXPECT_EQ(gradients[middle_begin + 1], gradients[middle_end - 1]);


### PR DESCRIPTION
Aimed to address https://github.com/microsoft/LightGBM/issues/4804 and https://github.com/microsoft/LightGBM/issues/2818

This is a WIP PR to start work on allowing more than the ~2B data points that `int_32_t` allows for.

For now I've simply replaced all references to `data_size_t` with `int_64_t` and made some post-hoc fixes in certain places replacing `int64_t` with `int32_t` where it was needed for the project to compile and tests to run.

Currently I see 20/20 tests passing but I also see this output when running them:

>[LightGBM] [Fatal] ChunkedArray chunk size must be larger than 0!
>[LightGBM] [Fatal] no conversion to double for: x1

Due to the prevalence of `data_size_t` it might be a better strategy to selectively update certain files/classes to move to `int64_t` to make reviewing easier and the changes more gradual (splitting up this PR into multiple ones). To do that I would need some guidance from the core devs as to which references to `data_size_t` are the best candidates to change to enable the support for `int_64_t`  data points.

Another area where devs could help is suggesting stress tests and how to measure performance/memory cost impact, perhaps running benchmarks or other performance checks.