### PR TITLE
Fixing treeshap calculation when data is weighted (fixes #5095)

### DIFF
--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -180,7 +180,7 @@ class Tree {
   inline int data_count(int node) const { return node >= 0 ? internal_count_[node] : leaf_count_[~node]; }
 
   /*! \brief Get the summed weights of data points that fall at or below this node*/
-  inline int data_weight(int node) const { return node >= 0 ? internal_weight_[node] : leaf_weight_[~node]; }
+  inline double data_weight(int node) const { return node >= 0 ? internal_weight_[node] : leaf_weight_[~node]; }
 
   /*!
   * \brief Shrinkage for the tree's output

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -179,6 +179,9 @@ class Tree {
   /*! \brief Get the number of data points that fall at or below this node*/
   inline int data_count(int node) const { return node >= 0 ? internal_count_[node] : leaf_count_[~node]; }
 
+  /*! \brief Get the summed weights of data points that fall at or below this node*/
+  inline int data_weight(int node) const { return node >= 0 ? internal_weight_[node] : leaf_weight_[~node]; }
+
   /*!
   * \brief Shrinkage for the tree's output
   *        shrinkage rate (a.k.a learning rate) is used to tune the training process
@@ -563,7 +566,7 @@ inline void Tree::Split(int leaf, int feature, int real_feature,
   leaf_parent_[leaf] = new_node_idx;
   leaf_parent_[num_leaves_] = new_node_idx;
   // save current leaf value to internal node before change
-  internal_weight_[new_node_idx] = leaf_weight_[leaf];
+  internal_weight_[new_node_idx] = left_weight + right_weight;
   internal_value_[new_node_idx] = leaf_value_[leaf];
   internal_count_[new_node_idx] = left_cnt + right_cnt;
   leaf_value_[leaf] = std::isnan(left_value) ? 0.0f : left_value;

--- a/src/io/tree.cpp
+++ b/src/io/tree.cpp
@@ -952,9 +952,9 @@ void Tree::TreeSHAP(const double *feature_values, double *phi,
   } else {
     const int hot_index = Decision(feature_values[split_feature_[node]], node);
     const int cold_index = (hot_index == left_child_[node] ? right_child_[node] : left_child_[node]);
-    const double w = data_count(node);
-    const double hot_zero_fraction = data_count(hot_index) / w;
-    const double cold_zero_fraction = data_count(cold_index) / w;
+    const double w = data_weight(node);
+    const double hot_zero_fraction = data_weight(hot_index) / w;
+    const double cold_zero_fraction = data_weight(cold_index) / w;
     double incoming_zero_fraction = 1;
     double incoming_one_fraction = 1;
 
@@ -1004,9 +1004,9 @@ void Tree::TreeSHAPByMap(const std::unordered_map<int, double>& feature_values, 
   } else {
     const int hot_index = Decision(feature_values.count(split_feature_[node]) > 0 ? feature_values.at(split_feature_[node]) : 0.0f, node);
     const int cold_index = (hot_index == left_child_[node] ? right_child_[node] : left_child_[node]);
-    const double w = data_count(node);
-    const double hot_zero_fraction = data_count(hot_index) / w;
-    const double cold_zero_fraction = data_count(cold_index) / w;
+    const double w = data_weight(node);
+    const double hot_zero_fraction = data_weight(hot_index) / w;
+    const double cold_zero_fraction = data_weight(cold_index) / w;
     double incoming_zero_fraction = 1;
     double incoming_one_fraction = 1;
 
@@ -1033,10 +1033,12 @@ void Tree::TreeSHAPByMap(const std::unordered_map<int, double>& feature_values, 
 
 double Tree::ExpectedValue() const {
   if (num_leaves_ == 1) return LeafOutput(0);
-  const double total_count = internal_count_[0];
+
+  const double total_weight = internal_weight_[0];
+
   double exp_value = 0.0;
   for (int i = 0; i < num_leaves(); ++i) {
-    exp_value += (leaf_count_[i] / total_count)*LeafOutput(i);
+    exp_value += (leaf_weight_[i] / total_weight)*LeafOutput(i);
   }
   return exp_value;
 }


### PR DESCRIPTION
Fixing Issue #5095

The bug is described in the issue. Continuing with the same example, after this commit, we have:

```python
import numpy as np
import lightgbm

X=np.array([[1,2,3,4,5,6]*100, [1, 1.2, 0.3, 0.8, 0.4, 5]*100], dtype=np.float).T
y=X.dot([0.5, 8])
w=np.array([1,1,1,1,1,10]*100, dtype=np.float)

data = lightgbm.Dataset(X)
data.set_label(y)
data.set_weight(w)

model = lightgbm.train(
    {
        'objective':'regression',
        'metric':'mse',
        'boosting':'gbdt',
        'num_leaves': 7,
        'learning_rate':0.001
    },
    data,
    num_boost_round=100,
)

model.predict(X, pred_contrib=True)
```
resulting in:
```python
array([[-2.23944737,  0.08394158, 31.13999999],
       [-2.17359526,  0.218026  , 31.13999999],
       [-2.40050732, -0.19295458, 31.13999999],
       ...,
       [-2.24611195,  0.08108533, 31.13999999],
       [-2.28244961, -0.13963819, 31.13999999],
       [ 1.07870497,  0.05046017, 31.13999999]])
```

Which is the correct behavior, now the same as the expanded version (see the related issue for expanded version):
```
print(np.average(model.predict(X), weights=w)) # 31.139999991989136
```

Also, the contributions now equal those of the expanded version:
```
# see related issue for X_expand and model2
model.predict(X, pred_contrib=True)[0] # array([-2.23944737,  0.08394158, 31.13999999])
model2.predict(X_expand, pred_contrib=True)[0] # array([-2.23944737,  0.08394158, 31.13999999])
```

-----

The commit modifies the codebase in two places. First, it modifies the SHAP calculation to reference a newly created `data_weight` function. Second, I needed to also fix the weight calculation for internal nodes *and* the expected value calculation as well, as the weights were calculated incorrectly for some reason, and the expected value didn't consider weights either.

Funny enough, beyond SHAP calculations, I couldn't find any other reference to either expected value or the internal weights storage (other than serialization and cuda->cpu / cpu->cuda transfer). I may have missed something though.

Also, it's not clear to me if anything else (like tests of some kind) is required to merge the PR. Please advise.