### PR TITLE
Continue training in CLI if one iteration produces a single-leaf tree

### DIFF
--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -231,10 +231,8 @@ void GBDT::Train(int snapshot_freq, const std::string& model_output_path) {
   bool is_finished = false;
   auto start_time = std::chrono::steady_clock::now();
   for (int iter = 0; iter < config_->num_iterations && !is_finished; ++iter) {
-    is_finished = TrainOneIter(nullptr, nullptr);
-    if (!is_finished) {
-      is_finished = EvalAndCheckEarlyStopping();
-    }
+    TrainOneIter(nullptr, nullptr);
+    is_finished = EvalAndCheckEarlyStopping();
     auto end_time = std::chrono::steady_clock::now();
     // output used time per iteration
     Log::Info("%f seconds elapsed, finished iteration %d", std::chrono::duration<double,
@@ -421,6 +419,8 @@ bool GBDT::TrainOneIter(const score_t* gradients, const score_t* hessians) {
     models_.push_back(std::move(new_tree));
   }
 
+  ++iter_;
+
   if (!should_continue) {
     Log::Warning("Stopped training because there are no more leaves that meet the split requirements");
     if (models_.size() > static_cast<size_t>(num_tree_per_iteration_)) {
@@ -431,7 +431,6 @@ bool GBDT::TrainOneIter(const score_t* gradients, const score_t* hessians) {
     return true;
   }
 
-  ++iter_;
   return false;
 }
 


### PR DESCRIPTION
As per discussion on #5051 and #5193 the python package does not stop training if a single leaf tree (stupm) is found and relies on early stopping methods to stop training. This commits removes the finish condition on training based on the result of `TrainOneIter()` and sets the `is_finished` flag on early stopping alone.