### PR TITLE
[python-package] add more type annotations in basic.py

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2331,7 +2331,7 @@ class Dataset:
     def set_field(
         self,
         field_name: str,
-        data: Optional[Union[List[float], List[int], np.ndarray, pd_Series, pd_DataFrame]]
+        data: Optional[Union[List[List[float]], List[List[int]], List[float], List[int], np.ndarray, pd_Series, pd_DataFrame]]
     ) -> "Dataset":
         """Set property into the Dataset.
 


### PR DESCRIPTION
Contributes to #3756.

Adds more type annotations in `basic.py`.

### How I tested this

Checked with `mypy`, confirmed that no new errors are introduced relative to `master`.

```shell
mypy --ignore-missing-imports python-package/lightgbm
```