### PR TITLE
[WIP] Add chosen metric argument to clarify early stopping behaviour

### DIFF
--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -397,6 +397,9 @@ struct Config {
   // desc = LightGBM allows you to provide multiple evaluation metrics. Set this to ``true``, if you want to use only the first metric for early stopping
   bool first_metric_only = false;
 
+  // desc = LightGBM allows you to provide multiple evaluation metrics. Set this to a specific metric name, if you want to use only this metric for early stopping
+  std::string chosen_metric_early_stopping;
+
   // alias = max_tree_output, max_leaf_output
   // desc = used to limit the max output of tree leaves
   // desc = ``<= 0`` means no constraint

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -279,15 +279,20 @@ class _EarlyStoppingCallback:
         first_metric_only: bool = False,
         verbose: bool = True,
         min_delta: Union[float, List[float]] = 0.0,
-        chosen_metric: str = None,
+        metric_name: Optional[str] = None,
     ) -> None:
         self.enabled = _should_enable_early_stopping(stopping_rounds)
 
         # Test if both parameters are used
-        if (first_metric_only + (chosen_metric is not None)) == 2:
-            error_message = """
-            Only one of first_metric_only and chosen_metric parameters should be used"""
-            raise ValueError(error_message)
+        if first_metric_only and (metric_name is not None):
+            error_msg = """
+            Only one of 'first_metric_only' and 'chosen_metric' should be used"""
+            raise ValueError(error_msg)
+
+        # If metric_name is used, min_delta must be a scalar
+        if isinstance(min_delta, list) and (metric_name is not None):
+            error_msg = "Use a scalar value for 'min_delta' when using 'chosen_metric'."
+            raise ValueError(error_msg)
 
         self.order = 30
         self.before_iteration = False
@@ -296,7 +301,7 @@ class _EarlyStoppingCallback:
         self.first_metric_only = first_metric_only
         self.verbose = verbose
         self.min_delta = min_delta
-        self.chosen_metric = chosen_metric
+        self.metric_name = metric_name
 
         self._reset_storages()
 
@@ -353,13 +358,13 @@ class _EarlyStoppingCallback:
 
         self._reset_storages()
 
-        list_metrics = {m[1] for m in env.evaluation_result_list}
-        if (self.chosen_metric is not None) and (self.chosen_metric not in list_metrics):
-            error_message = f"""Chosen callback metric: {self.chosen_metric} is not in the evaluation list.
-            The list of available metrics for early stopping is: {list_metrics}."""
+        set_metrics = {m[1] for m in env.evaluation_result_list}
+        if (self.metric_name is not None) and (self.metric_name not in set_metrics):
+            error_message = f"""Chosen callback metric:{self.metric_name} is not in the evaluation list.
+            The set of available metrics for early stopping is : {set_metrics}."""
             raise ValueError(error_message)
         
-        n_metrics = len(list_metrics)
+        n_metrics = len(set_metrics)
         n_datasets = len(env.evaluation_result_list) // n_metrics
         if isinstance(self.min_delta, list):
             if not all(t >= 0 for t in self.min_delta):
@@ -377,14 +382,11 @@ class _EarlyStoppingCallback:
                     raise ValueError("Must provide a single value for min_delta or as many as metrics.")
                 if self.first_metric_only and self.verbose:
                     _log_info(f"Using only {self.min_delta[0]} as early stopping min_delta.")
-                if (self.chosen_metric is not None) and self.verbose:
-                    index_chosen_metric = list_metrics.index(self.chosen_metric)
-                    _log_info(f"Using only {self.min_delta[index_chosen_metric]} as early stopping min_delta.")
                 deltas = self.min_delta * n_datasets
         else:
             if self.min_delta < 0:
                 raise ValueError("Early stopping min_delta must be non-negative.")
-            if self.min_delta > 0 and n_metrics > 1 and not self.first_metric_only and (self.index_chosen_metric is None) and self.verbose:
+            if self.min_delta > 0 and n_metrics > 1 and not self.first_metric_only and (self.metric_name is None) and self.verbose:
                 _log_info(f"Using {self.min_delta} as min_delta for all metrics.")
             deltas = [self.min_delta] * n_datasets * n_metrics
 
@@ -408,8 +410,8 @@ class _EarlyStoppingCallback:
                 )
                 if self.first_metric_only:
                     _log_info(f"Evaluated only: {eval_name_splitted[-1]}")
-                if self.chosen_metric is not None:
-                    _log_info(f"Evaluated only: {self.chosen_metric}")
+                if self.metric_name is not None:
+                    _log_info(f"Evaluated only: {self.metric_name}")
             raise EarlyStopException(self.best_iter[i], self.best_score_list[i])
 
     def __call__(self, env: CallbackEnv) -> None:
@@ -437,7 +439,7 @@ class _EarlyStoppingCallback:
             eval_name_splitted = env.evaluation_result_list[i][1].split(" ")
             if self.first_metric_only and self.first_metric != eval_name_splitted[-1]:
                 continue  # use only the first metric for early stopping
-            if (self.chosen_metric is not None) and self.chosen_metric != eval_name_splitted[-1]:
+            if (self.metric_name is not None) and self.metric_name != eval_name_splitted[-1]:
                 continue  # use only the first metric for early stopping
             if self._is_train_set(
                 ds_name=env.evaluation_result_list[i][0],
@@ -453,8 +455,8 @@ class _EarlyStoppingCallback:
                     _log_info(f"Early stopping, best iteration is:\n[{self.best_iter[i] + 1}]\t{eval_result_str}")
                     if self.first_metric_only:
                         _log_info(f"Evaluated only: {eval_name_splitted[-1]}")
-                    if self.chosen_metric is not None:
-                        _log_info(f"Evaluated only: {self.chosen_metric}")
+                    if self.metric_name is not None:
+                        _log_info(f"Evaluated only: {self.metric_name}")
                 raise EarlyStopException(self.best_iter[i], self.best_score_list[i])
             self._final_iteration_check(env, eval_name_splitted, i)
 
@@ -476,7 +478,7 @@ def early_stopping(
     first_metric_only: bool = False,
     verbose: bool = True,
     min_delta: Union[float, List[float]] = 0.0,
-    chosen_metric: str = None,
+    metric_name: Optional[str] = None,
 ) -> _EarlyStoppingCallback:
     """Create a callback that activates early stopping.
 
@@ -511,10 +513,18 @@ def early_stopping(
     callback : _EarlyStoppingCallback
         The callback that activates early stopping.
     """
+
+    if first_metric_only:
+        warning_message = """
+        'first_metric_only' parameter is deprecated.
+        It will be removed in a future release of lightgbm.
+        """
+        _log_warning(warning_message)
+
     return _EarlyStoppingCallback(
         stopping_rounds=stopping_rounds,
         first_metric_only=first_metric_only,
         verbose=verbose,
         min_delta=min_delta,
-        chosen_metric=chosen_metric
+        metric_name=metric_name
     )

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -191,7 +191,13 @@ def train(
     if params["early_stopping_round"] is None:
         params.pop("early_stopping_round")
     first_metric_only = params.get("first_metric_only", False)
-
+    chosen_metric_early_stopping = params.get("chosen_metric_early_stopping", None)
+    # Test if both parameters are used
+    if (first_metric_only + (chosen_metric_early_stopping is not None)) == 2:
+        error_message = """
+        Only one of first_metric_only and chosen_metric_early_stopping parameters should be used"""
+        raise ValueError(error_message)
+    
     predictor: Optional[_InnerPredictor] = None
     if isinstance(init_model, (str, Path)):
         predictor = _InnerPredictor.from_model_file(model_file=init_model, pred_parameter=params)
@@ -241,6 +247,7 @@ def train(
             callback.early_stopping(
                 stopping_rounds=params["early_stopping_round"],  # type: ignore[arg-type]
                 first_metric_only=first_metric_only,
+                chosen_metric=chosen_metric_early_stopping,
                 verbose=_choose_param_value(
                     main_param_name="verbosity",
                     params=params,
@@ -716,6 +723,12 @@ def cv(
     if params["early_stopping_round"] is None:
         params.pop("early_stopping_round")
     first_metric_only = params.get("first_metric_only", False)
+    chosen_metric_early_stopping = params.get("chosen_metric_early_stopping", None)
+    # Test if both parameters are used
+    if (first_metric_only + (chosen_metric_early_stopping is not None)) == 2:
+        error_message = """
+        Only one of first_metric_only and chosen_metric_early_stopping parameters should be used"""
+        raise ValueError(error_message)
 
     if isinstance(init_model, (str, Path)):
         predictor = _InnerPredictor.from_model_file(
@@ -765,6 +778,7 @@ def cv(
             callback.early_stopping(
                 stopping_rounds=params["early_stopping_round"],  # type: ignore[arg-type]
                 first_metric_only=first_metric_only,
+                chosen_metric=chosen_metric_early_stopping,
                 verbose=_choose_param_value(
                     main_param_name="verbosity",
                     params=params,

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -815,6 +815,7 @@ const std::unordered_map<std::string, std::vector<std::string>>& Config::paramet
     {"extra_seed", {}},
     {"early_stopping_round", {"early_stopping_rounds", "early_stopping", "n_iter_no_change"}},
     {"first_metric_only", {}},
+    {"chosen_metric_early_stopping", {}},
     {"max_delta_step", {"max_tree_output", "max_leaf_output"}},
     {"lambda_l1", {"reg_alpha", "l1_regularization"}},
     {"lambda_l2", {"reg_lambda", "lambda", "l2_regularization"}},


### PR DESCRIPTION
Related to issue #6423 (and also  #6223).

When mixing callable functions and string aliases in evaluation metrics and/or objective function, the first metric flag only selects the first built in metric if any, and after looks to callable functions as metrics.
It comes from the inner_eval function [inner_eval function](https://github.com/microsoft/LightGBM/blob/master/python-package/lightgbm/basic.py#L5150-L5164) that starts with any built-in metrics if there is any.

Selecting a custom metric for early stopping made me do adjustments to make it work.

The builtin metric can come from the LGBMRegressor instantiation, the built in objective function, or a str in the eval_metric list used in the fit method.

In order to have something that is easier to control, people should have either :
- objective and metrics coming from string
- objective and metrics coming from callable

The Booster API will handle some of the cases I mentionned above but not all, and the bug will also arise.

Since the built in metrics can come from anywhere, and it's hard to know which one is the first metric when calling the inner_eval function, I suggest to have an additional argument indicating the name of the chosen metric the early stopping callback should use.

Feel free to make any comment on this PR. I did not manage to check the C part of the code, but I want some feedback on the idea first before spending some time on making my local setup work for this !