### PR TITLE
[R-package] Allow for valid data to be a slice of the training data

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -21,6 +21,17 @@ NULL
   return(c("label", "weight", "init_score", "group"))
 }
 
+# [description] A more robust version of identical() for checking lgb.Dataset equivalence
+# [return] A single boolean.
+.datasets_are_equal <- function(ds1, ds2) {
+  handler1 <- ds1$.__enclos_env__$private$get_handle
+  handler2 <- ds2$.__enclos_env__$private$get_handle
+  if (is.null(handler1) || is.null(handler2)) {
+    return(FALSE)
+  }
+  return(identical(handler1(), handler2()))
+}
+
 #' @importFrom methods is
 #' @importFrom R6 R6Class
 #' @importFrom utils modifyList
@@ -647,7 +658,12 @@ Dataset <- R6::R6Class(
     set_reference = function(reference) {
 
       # setting reference to this same Dataset object doesn't require any changes
-      if (identical(private$reference, reference)) {
+      if (.datasets_are_equal(private$reference, reference)) {
+        return(invisible(self))
+      }
+
+      # The new reference and the existing object may be slices of a parent dataset
+      if (.datasets_are_equal(private$reference, reference$.__enclos_env__$private$reference)) {
         return(invisible(self))
       }
 

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -24,12 +24,13 @@ NULL
 # [description] A more robust version of identical() for checking lgb.Dataset equivalence
 # [return] A single boolean.
 .datasets_are_equal <- function(ds1, ds2) {
-  handler1 <- ds1$.__enclos_env__$private$get_handle
-  handler2 <- ds2$.__enclos_env__$private$get_handle
-  if (is.null(handler1) || is.null(handler2)) {
+  if (!.is_Dataset(ds1) || !.is_Dataset(ds2)) {
     return(FALSE)
   }
-  return(identical(handler1(), handler2()))
+  return(identical(
+    ds1$.__enclos_env__$private$handle
+    , ds2$.__enclos_env__$private$handle
+  ))
 }
 
 #' @importFrom methods is

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -187,11 +187,11 @@ lgb.train <- function(params = list(),
       # Update parameters
       valid_data$update_params(params)
 
-      # No need to set reference if one exists (e.g., a slice)
+      # No need to set reference if one exists
       if (is.null(valid_data$.__enclos_env__$private$reference)) {
         valid_data$set_reference(data)
       }
-      
+
       reduced_valid_sets[[key]] <- valid_data
 
     }

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -184,14 +184,9 @@ lgb.train <- function(params = list(),
         next
       }
 
-      # Update parameters
+      # Update parameters, data
       valid_data$update_params(params)
-
-      # No need to set reference if one exists
-      if (is.null(valid_data$.__enclos_env__$private$reference)) {
-        valid_data$set_reference(data)
-      }
-
+      valid_data$set_reference(data)
       reduced_valid_sets[[key]] <- valid_data
 
     }

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -184,9 +184,14 @@ lgb.train <- function(params = list(),
         next
       }
 
-      # Update parameters, data
+      # Update parameters
       valid_data$update_params(params)
-      valid_data$set_reference(data)
+
+      # No need to set reference if one exists (e.g., a slice)
+      if (is.null(valid_data$.__enclos_env__$private$reference)) {
+        valid_data$set_reference(data)
+      }
+      
       reduced_valid_sets[[key]] <- valid_data
 
     }

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3866,15 +3866,15 @@ test_that("lgb.train() can use slices of an lgb.Dataset for train and valid data
   data("iris")
 
   ds <- lgb.Dataset(
-    as.matrix(iris[, 1:3])
-    , label = iris[, 4]
+    as.matrix(iris[, seq_len(3L)])
+    , label = iris[, 4L]
   )
 
-  train <- lgb.slice.Dataset(ds, seq(1, 100))
-  test <- lgb.slice.Dataset(ds, seq(101, 150))
+  train <- lgb.slice.Dataset(ds, seq_len(100L))
+  test <- lgb.slice.Dataset(ds, seq_len(50L) + 100L)
 
-  test_mat <- as.matrix(iris[101:150, 1:3])
-  test_label <- iris[101:150, 4]
+  test_mat <- as.matrix(iris[seq_len(50L) + 100, seq_len(3L)])
+  test_label <- iris[seq_len(50L) + 100L, 4L]
 
   params <- list(
     metric = "l2"
@@ -3891,8 +3891,8 @@ test_that("lgb.train() can use slices of an lgb.Dataset for train and valid data
   )
 
   y_hat <- predict(model, newdata = test_mat)
-  model_l2 <- model$eval_valid()[[1]]$value
-  independent_l2 <- mean((test_label - y_hat) ** 2)
+  model_l2 <- model$eval_valid()[[1L]]$value
+  independent_l2 <- mean((test_label - y_hat) ** 2.0)
 
   expect_equal(model_l2, independent_l2, tolerance = 0.0001)
 })

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3863,7 +3863,6 @@ test_that("Evaluation metrics aren't printed as a single-element vector", {
 })
 
 test_that("lgb.train() can use slices of an lgb.Dataset for train and valid data", {
-
   data("iris")
 
   ds <- lgb.Dataset(
@@ -3891,7 +3890,7 @@ test_that("lgb.train() can use slices of an lgb.Dataset for train and valid data
     , valids = list(test = test)
   )
 
-  y_hat <- predict(model, newdata = test_mat) 
+  y_hat <- predict(model, newdata = test_mat)
   model_l2 <- model$eval_valid()[[1]]$value
   independent_l2 <- mean((test_label - y_hat) ** 2)
 

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3873,7 +3873,7 @@ test_that("lgb.train() can use slices of an lgb.Dataset for train and valid data
   train <- lgb.slice.Dataset(ds, seq_len(100L))
   test <- lgb.slice.Dataset(ds, seq_len(50L) + 100L)
 
-  test_mat <- as.matrix(iris[seq_len(50L) + 100, seq_len(3L)])
+  test_mat <- as.matrix(iris[seq_len(50L) + 100L, seq_len(3L)])
   test_label <- iris[seq_len(50L) + 100L, 4L]
 
   params <- list(


### PR DESCRIPTION
fixes #6008

Slices of datasets already contain a reference to the base data. This change only sets a reference to the base dataset if one does not already exist.