### PR TITLE
[R-package] Ensure print.lgb.Booster() works when objective is not explicitly set

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -1236,7 +1236,7 @@ print.lgb.Booster <- function(x, ...) {
   if (!handle_is_null) {
     obj <- x$params$objective
     if (is.null(obj)) {
-      obj <- x$.__enclos_env__$private$get_eval_info()
+      obj <- "(default)"
     }
     if (obj == "none") {
       obj <- "custom"

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -1235,6 +1235,9 @@ print.lgb.Booster <- function(x, ...) {
 
   if (!handle_is_null) {
     obj <- x$params$objective
+    if (is.null(obj)) {
+      obj <- x$.__enclos_env__$private$get_eval_info()
+    }
     if (obj == "none") {
       obj <- "custom"
     }

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -1667,7 +1667,7 @@ test_that("Booster's print, show, and summary work correctly when objective is n
   )
 
   log_txt <- capture.output(print(model))
-  expect_true(any("Objective: (default)" == log_txt))
+  expect_true(any(log_txt == "Objective: (default)"))
 
   .check_methods_work(model)
 })

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -1604,7 +1604,7 @@ test_that("Booster's print, show, and summary work correctly for built-in object
         , nrounds = 5L
     )
     .check_methods_work(model)
-  
+
     data("iris")
     model <- lgb.train(
         params = list(objective = "multiclass", num_class = 3L, num_threads = .LGB_MAX_THREADS)
@@ -1618,9 +1618,7 @@ test_that("Booster's print, show, and summary work correctly for built-in object
     .check_methods_work(model)
 })
 
-test_that("Booster's print, show, and summary work correctly for custom objective", {    
-
-    # with custom objective
+test_that("Booster's print, show, and summary work correctly for custom objective", {
     .logregobj <- function(preds, dtrain) {
         labels <- get_field(dtrain, "label")
         preds <- 1.0 / (1.0 + exp(-preds))
@@ -1656,8 +1654,7 @@ test_that("Booster's print, show, and summary work correctly for custom objectiv
     .check_methods_work(model)
 })
 
-test_that("Booster's print, show, and summary work correctly when objective is not provided", {    
-
+test_that("Booster's print, show, and summary work correctly when objective is not provided", {
   data("iris")
   model <- lgb.train(
       data = lgb.Dataset(

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -1,70 +1,3 @@
-.have_same_handle <- function(model, other_model) {
-  expect_equal(
-    model$.__enclos_env__$private$handle
-    , other_model$.__enclos_env__$private$handle
-  )
-}
-
-.has_expected_content_for_fitted_model <- function(printed_txt) {
-  expect_true(any(startsWith(printed_txt, "LightGBM Model")))
-  expect_true(any(startsWith(printed_txt, "Fitted to dataset")))
-}
-
-.has_expected_content_for_finalized_model <- function(printed_txt) {
-  expect_true(any(printed_txt == "LightGBM Model"))
-  expect_true(any(grepl("Booster handle is invalid", printed_txt, fixed = TRUE)))
-}
-
-.check_methods_work <- function(model) {
-
-   #--- should work for fitted models --- #
-
-   # print()
-   log_txt <- capture.output({
-     ret <- print(model)
-   })
-   .have_same_handle(ret, model)
-   .has_expected_content_for_fitted_model(log_txt)
-
-   # show()
-   log_txt <- capture.output({
-     ret <- show(model)
-   })
-   expect_null(ret)
-   .has_expected_content_for_fitted_model(log_txt)
-
-   # summary()
-   log_txt <- capture.output({
-     ret <- summary(model)
-   })
-   .have_same_handle(ret, model)
-   .has_expected_content_for_fitted_model(log_txt)
-
-   #--- should not fail for finalized models ---#
-   model$.__enclos_env__$private$finalize()
-
-   # print()
-   log_txt <- capture.output({
-     ret <- print(model)
-   })
-   .has_expected_content_for_finalized_model(log_txt)
-
-   # show()
-   .have_same_handle(ret, model)
-   log_txt <- capture.output({
-     ret <- show(model)
-   })
-   expect_null(ret)
-   .has_expected_content_for_finalized_model(log_txt)
-
-   # summary()
-   log_txt <- capture.output({
-     ret <- summary(model)
-   })
-   .have_same_handle(ret, model)
-   .has_expected_content_for_finalized_model(log_txt)
-}
-
 test_that("Booster's finalizer should not fail", {
     X <- as.matrix(as.integer(iris[, "Species"]), ncol = 1L)
     y <- iris[["Sepal.Length"]]
@@ -1585,6 +1518,73 @@ test_that("boosters with linear models at leaves can be written to RDS and re-lo
     expect_identical(preds, preds2)
 })
 
+.have_same_handle <- function(model, other_model) {
+  expect_equal(
+    model$.__enclos_env__$private$handle
+    , other_model$.__enclos_env__$private$handle
+  )
+}
+
+.has_expected_content_for_fitted_model <- function(printed_txt) {
+  expect_true(any(startsWith(printed_txt, "LightGBM Model")))
+  expect_true(any(startsWith(printed_txt, "Fitted to dataset")))
+}
+
+.has_expected_content_for_finalized_model <- function(printed_txt) {
+  expect_true(any(printed_txt == "LightGBM Model"))
+  expect_true(any(grepl("Booster handle is invalid", printed_txt, fixed = TRUE)))
+}
+
+.check_methods_work <- function(model) {
+
+   #--- should work for fitted models --- #
+
+   # print()
+   log_txt <- capture.output({
+     ret <- print(model)
+   })
+   .have_same_handle(ret, model)
+   .has_expected_content_for_fitted_model(log_txt)
+
+   # show()
+   log_txt <- capture.output({
+     ret <- show(model)
+   })
+   expect_null(ret)
+   .has_expected_content_for_fitted_model(log_txt)
+
+   # summary()
+   log_txt <- capture.output({
+     ret <- summary(model)
+   })
+   .have_same_handle(ret, model)
+   .has_expected_content_for_fitted_model(log_txt)
+
+   #--- should not fail for finalized models ---#
+   model$.__enclos_env__$private$finalize()
+
+   # print()
+   log_txt <- capture.output({
+     ret <- print(model)
+   })
+   .has_expected_content_for_finalized_model(log_txt)
+
+   # show()
+   .have_same_handle(ret, model)
+   log_txt <- capture.output({
+     ret <- show(model)
+   })
+   expect_null(ret)
+   .has_expected_content_for_finalized_model(log_txt)
+
+   # summary()
+   log_txt <- capture.output({
+     ret <- summary(model)
+   })
+   .have_same_handle(ret, model)
+   .has_expected_content_for_finalized_model(log_txt)
+}
+
 test_that("Booster's print, show, and summary work correctly for built-in objectives", {
     data("mtcars")
     model <- lgb.train(
@@ -1665,6 +1665,9 @@ test_that("Booster's print, show, and summary work correctly when objective is n
       , nrounds = 5L
       , params = list(num_threads = .LGB_MAX_THREADS)
   )
+
+  log_txt <- capture.output(print(model))
+  expect_true(any("Objective: (default)" == log_txt))
 
   .check_methods_work(model)
 })

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -1658,8 +1658,8 @@ test_that("Booster's print, show, and summary work correctly when objective is n
   data("iris")
   model <- lgb.train(
       data = lgb.Dataset(
-          as.matrix(iris[, 1:3])
-          , label = iris[, 4]
+          as.matrix(iris[, seq_len(3L)])
+          , label = iris[, 4L]
       )
       , verbose = .LGB_VERBOSITY
       , nrounds = 5L


### PR DESCRIPTION
Fixes #6848

This PR fixes an issue where `lgb.train()` creates a booster, the booster is printed, and no objective is specified. This led to an error due to a `NULL` value. I have handled this by extracting the default objective (looks to be `l2`) and printing that in the event a built-in or custom objective is not provided.