### PR TITLE
[python-package] Load parameters from model string

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3715,6 +3715,9 @@ class Booster:
             params = self._get_loaded_param()
         elif model_str is not None:
             self.model_from_string(model_str)
+            if params:
+                _log_warning("Ignoring params argument, using parameters from model string.")
+            params = self._get_loaded_param()
         else:
             raise TypeError(
                 "Need at least one training dataset or model file or model string to create Booster instance"

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -1026,9 +1026,6 @@ def test_string_serialized_params_retrieval(rng):
     new_model = lgb.Booster(model_str=model_serialized)
 
     assert(new_model.params) # Check not empty dict
-    # check the params we provided
-    print(new_model.params)
-    print(params)
     for k, v in params.items():
         assert(k in new_model.params)
         assert(new_model.params[k] == v)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -998,38 +998,3 @@ def test_equal_datasets_from_one_and_several_matrices_w_different_layouts(rng, t
 
     assert filecmp.cmp(one_path, several_path)
 
-
-def test_string_serialized_params_retrieval(rng):
-    # Random train data
-    train_x = rng.random((500, 20))
-    train_y = rng.integers(0, 1, 500)
-    train_data = lgb.Dataset(train_x, train_y)
-
-    # Parameters
-    params = {
-        "boosting": "gbdt",
-        "deterministic": True,
-        "feature_contri": [0.5] * train_x.shape[1],
-        "interaction_constraints": [[0, 1], [0]],
-        "objective": "binary",
-        "metric": ["auc"],
-        "num_leaves": 7,
-        "learning_rate": 0.05,
-        "feature_fraction": 0.9,
-        "bagging_fraction": 0.8,
-        "bagging_freq": 5,
-        "verbosity": -100,
-    }
-
-    # train a model and serialize it to a string in memory
-    model = lgb.train(params, train_data, num_boost_round=2)
-    model_serialized = model.model_to_string()
-
-    # load a new model with the string
-    new_model = lgb.Booster(model_str=model_serialized)
-
-    assert(new_model.params) # Check not empty dict
-    for k, v in params.items():
-        assert(k in new_model.params)
-        assert(new_model.params[k] == v)
-

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -997,3 +997,39 @@ def test_equal_datasets_from_one_and_several_matrices_w_different_layouts(rng, t
     lgb.Dataset(mat)._dump_text(one_path)
 
     assert filecmp.cmp(one_path, several_path)
+
+
+def test_string_serialized_params_retrieval():
+    # Random train data
+    train_x = np.random.rand(500, 20)
+    train_y = np.random.randint(0, 1, 500)
+    train_data = lgb.Dataset(train_x, train_y)
+
+    # Parameters
+    params = {
+        "boosting": "gbdt",
+        "objective": "binary",
+        "metric": ["auc"],
+        "num_leaves": 31,
+        "learning_rate": 0.05,
+        "feature_fraction": 0.9,
+        "bagging_fraction": 0.8,
+        "bagging_freq": 5,
+        "verbosity": -100,
+    }
+
+    # train a model and serialize it to a string in memory
+    model = lgb.train(params, train_data)
+    model_serialized = model.model_to_string()
+
+    # load a new model with the string
+    new_model = lgb.Booster(model_str=model_serialized)
+
+    assert(new_model.params) # Check not empty dict
+    # check the params we provided
+    print(new_model.params)
+    print(params)
+    for k, v in params.items():
+        assert(k in new_model.params)
+        assert(new_model.params[k] == v)
+

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -1008,12 +1008,12 @@ def test_string_serialized_params_retrieval(rng):
     # Parameters
     params = {
         "boosting": "gbdt",
-        "deterministic": true,
+        "deterministic": True,
         "feature_contri": [0.5] * train_x.shape[1],
         "interaction_constraints": [[0, 1], [0]],
         "objective": "binary",
         "metric": ["auc"],
-        "num_leaves": 7
+        "num_leaves": 7,
         "learning_rate": 0.05,
         "feature_fraction": 0.9,
         "bagging_fraction": 0.8,

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -1013,7 +1013,7 @@ def test_string_serialized_params_retrieval(rng):
         "interaction_constraints": [[0, 1], [0]],
         "objective": "binary",
         "metric": ["auc"],
-        "num_leaves": 31,
+        "num_leaves": 7
         "learning_rate": 0.05,
         "feature_fraction": 0.9,
         "bagging_fraction": 0.8,
@@ -1022,7 +1022,7 @@ def test_string_serialized_params_retrieval(rng):
     }
 
     # train a model and serialize it to a string in memory
-    model = lgb.train(params, train_data)
+    model = lgb.train(params, train_data, num_boost_round=2)
     model_serialized = model.model_to_string()
 
     # load a new model with the string

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -999,10 +999,10 @@ def test_equal_datasets_from_one_and_several_matrices_w_different_layouts(rng, t
     assert filecmp.cmp(one_path, several_path)
 
 
-def test_string_serialized_params_retrieval():
+def test_string_serialized_params_retrieval(rng):
     # Random train data
-    train_x = np.random.rand(500, 20)
-    train_y = np.random.randint(0, 1, 500)
+    train_x = rng.random((500, 20))
+    train_y = rng.integers(0, 1, 500)
     train_data = lgb.Dataset(train_x, train_y)
 
     # Parameters

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -1008,6 +1008,9 @@ def test_string_serialized_params_retrieval(rng):
     # Parameters
     params = {
         "boosting": "gbdt",
+        "deterministic": true,
+        "feature_contri": [0.5] * train_x.shape[1],
+        "interaction_constraints": [[0, 1], [0]],
         "objective": "binary",
         "metric": ["auc"],
         "num_leaves": 31,

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -997,4 +997,3 @@ def test_equal_datasets_from_one_and_several_matrices_w_different_layouts(rng, t
     lgb.Dataset(mat)._dump_text(one_path)
 
     assert filecmp.cmp(one_path, several_path)
-

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1542,7 +1542,7 @@ def test_string_serialized_params_retrieval(rng):
 
     assert(new_model.params) # Check not empty dict
     assert(new_model.params["boosting"] == "gbdt")
-    assert(new_model.params["deterministic"] == True)
+    assert(new_model.params["deterministic"])  # Linter doesn't like boolean compare
     assert(new_model.params["feature_contri"] == [0.5] * train_x.shape[1])
     assert(new_model.params["interaction_constraints"] == [[0, 1], [0]])
     assert(new_model.params["objective"] == "binary")

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1511,7 +1511,7 @@ def test_parameters_are_loaded_from_model_file(tmp_path, capsys, rng):
 
 def test_string_serialized_params_retrieval(rng):
     # Random train data
-    train_x = rng.random((500, 20))
+    train_x = rng.random((500, 3))
     train_y = rng.integers(0, 1, 500)
     train_data = lgb.Dataset(train_x, train_y)
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1508,6 +1508,41 @@ def test_parameters_are_loaded_from_model_file(tmp_path, capsys, rng):
     np.testing.assert_allclose(preds, orig_preds)
 
 
+def test_string_serialized_params_retrieval(rng):
+    # Random train data
+    train_x = rng.random((500, 20))
+    train_y = rng.integers(0, 1, 500)
+    train_data = lgb.Dataset(train_x, train_y)
+
+    # Parameters
+    params = {
+        "boosting": "gbdt",
+        "deterministic": True,
+        "feature_contri": [0.5] * train_x.shape[1],
+        "interaction_constraints": [[0, 1], [0]],
+        "objective": "binary",
+        "metric": ["auc"],
+        "num_leaves": 7,
+        "learning_rate": 0.05,
+        "feature_fraction": 0.9,
+        "bagging_fraction": 0.8,
+        "bagging_freq": 5,
+        "verbosity": -100,
+    }
+
+    # train a model and serialize it to a string in memory
+    model = lgb.train(params, train_data, num_boost_round=2)
+    model_serialized = model.model_to_string()
+
+    # load a new model with the string
+    new_model = lgb.Booster(model_str=model_serialized)
+
+    assert(new_model.params) # Check not empty dict
+    for k, v in params.items():
+        assert(k in new_model.params)
+        assert(new_model.params[k] == v)
+
+
 def test_save_load_copy_pickle(tmp_path):
     def train_and_predict(init_model=None, return_model=False):
         X, y = make_synthetic_regression()

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1536,7 +1536,7 @@ def test_string_serialized_params_retrieval(rng):
 
     # load a new model with the string
     with pytest.warns(UserWarning, match="Ignoring params argument, using parameters from model string."):
-        new_model = lgb.Booster(params={"num_leaves": 7}, model_str=model_serialized)
+        new_model = lgb.Booster(params={"num_leaves": 32}, model_str=model_serialized)
 
     assert new_model.params["boosting"] == "gbdt"
     assert new_model.params["deterministic"] is True

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1539,7 +1539,7 @@ def test_string_serialized_params_retrieval(rng):
         new_model = lgb.Booster(params={"num_leaves": 7}, model_str=model_serialized)
 
     assert new_model.params["boosting"] == "gbdt"
-    assert new_model.params["deterministic"]  # Linter doesn't like boolean compare
+    assert new_model.params["deterministic"] is True
     assert new_model.params["feature_contri"] == [0.5] * train_x.shape[1]
     assert new_model.params["interaction_constraints"] == [[0, 1], [0]]
     assert new_model.params["objective"] == "binary"

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1541,9 +1541,18 @@ def test_string_serialized_params_retrieval(rng):
         new_model = lgb.Booster(params={"num_leaves": 7}, model_str=model_serialized)
 
     assert(new_model.params) # Check not empty dict
-    for k, v in params.items():
-        assert(k in new_model.params)
-        assert(new_model.params[k] == v)
+    assert(new_model.params["boosting"] == "gbdt")
+    assert(new_model.params["deterministic"] == True)
+    assert(new_model.params["feature_contri"] == [0.5] * train_x.shape[1])
+    assert(new_model.params["interaction_constraints"] == [[0, 1], [0]])
+    assert(new_model.params["objective"] == "binary")
+    assert(new_model.params["metric"] == ["auc"])
+    assert(new_model.params["num_leaves"] == 7)
+    assert(new_model.params["learning_rate"] == 0.05)
+    assert(new_model.params["feature_fraction"] == 0.9)
+    assert(new_model.params["bagging_fraction"] == 0.8)
+    assert(new_model.params["bagging_freq"] == 5)
+    assert(new_model.params["verbosity"] == -100)
 
 
 def test_save_load_copy_pickle(tmp_path):

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1498,8 +1498,7 @@ def test_parameters_are_loaded_from_model_file(tmp_path, capsys, rng):
     assert bst.params["categorical_feature"] == [1, 2]
 
     # check that passing parameters to the constructor raises warning and ignores them
-    with pytest.warns(UserWarning,
-                      match="Ignoring params argument, using parameters from model file."):
+    with pytest.warns(UserWarning, match="Ignoring params argument, using parameters from model file."):
         bst2 = lgb.Booster(params={"num_leaves": 7}, model_file=model_file)
     assert bst.params == bst2.params
 
@@ -1536,22 +1535,21 @@ def test_string_serialized_params_retrieval(rng):
     model_serialized = model.model_to_string()
 
     # load a new model with the string
-    with pytest.warns(UserWarning,
-                      match="Ignoring params argument, using parameters from model string."):
+    with pytest.warns(UserWarning, match="Ignoring params argument, using parameters from model string."):
         new_model = lgb.Booster(params={"num_leaves": 7}, model_str=model_serialized)
 
-    assert(new_model.params["boosting"] == "gbdt")
-    assert(new_model.params["deterministic"])  # Linter doesn't like boolean compare
-    assert(new_model.params["feature_contri"] == [0.5] * train_x.shape[1])
-    assert(new_model.params["interaction_constraints"] == [[0, 1], [0]])
-    assert(new_model.params["objective"] == "binary")
-    assert(new_model.params["metric"] == ["auc"])
-    assert(new_model.params["num_leaves"] == 7)
-    assert(new_model.params["learning_rate"] == 0.05)
-    assert(new_model.params["feature_fraction"] == 0.9)
-    assert(new_model.params["bagging_fraction"] == 0.8)
-    assert(new_model.params["bagging_freq"] == 5)
-    assert(new_model.params["verbosity"] == -100)
+    assert new_model.params["boosting"] == "gbdt"
+    assert new_model.params["deterministic"]  # Linter doesn't like boolean compare
+    assert new_model.params["feature_contri"] == [0.5] * train_x.shape[1]
+    assert new_model.params["interaction_constraints"] == [[0, 1], [0]]
+    assert new_model.params["objective"] == "binary"
+    assert new_model.params["metric"] == ["auc"]
+    assert new_model.params["num_leaves"] == 7
+    assert new_model.params["learning_rate"] == 0.05
+    assert new_model.params["feature_fraction"] == 0.9
+    assert new_model.params["bagging_fraction"] == 0.8
+    assert new_model.params["bagging_freq"] == 5
+    assert new_model.params["verbosity"] == -100
 
 
 def test_save_load_copy_pickle(tmp_path):

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1540,7 +1540,6 @@ def test_string_serialized_params_retrieval(rng):
                       match="Ignoring params argument, using parameters from model string."):
         new_model = lgb.Booster(params={"num_leaves": 7}, model_str=model_serialized)
 
-    assert(new_model.params) # Check not empty dict
     assert(new_model.params["boosting"] == "gbdt")
     assert(new_model.params["deterministic"])  # Linter doesn't like boolean compare
     assert(new_model.params["feature_contri"] == [0.5] * train_x.shape[1])

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1498,7 +1498,8 @@ def test_parameters_are_loaded_from_model_file(tmp_path, capsys, rng):
     assert bst.params["categorical_feature"] == [1, 2]
 
     # check that passing parameters to the constructor raises warning and ignores them
-    with pytest.warns(UserWarning, match="Ignoring params argument"):
+    with pytest.warns(UserWarning,
+                      match="Ignoring params argument, using parameters from model file."):
         bst2 = lgb.Booster(params={"num_leaves": 7}, model_file=model_file)
     assert bst.params == bst2.params
 
@@ -1535,7 +1536,9 @@ def test_string_serialized_params_retrieval(rng):
     model_serialized = model.model_to_string()
 
     # load a new model with the string
-    new_model = lgb.Booster(model_str=model_serialized)
+    with pytest.warns(UserWarning,
+                      match="Ignoring params argument, using parameters from model string."):
+        new_model = lgb.Booster(params={"num_leaves": 7}, model_str=model_serialized)
 
     assert(new_model.params) # Check not empty dict
     for k, v in params.items():


### PR DESCRIPTION
This fixes #6851 by using the same workaround as when loading the model from a file (#5424).