### PR TITLE
prohibit use of regression_l1 objective with linear trees

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: ["--strict"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.5
+    rev: v0.9.10
     hooks:
       # Run the linter.
       - id: ruff
@@ -39,13 +39,13 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/crate-ci/typos
-    rev: v1.29.5
+    rev: v1.30.2
     hooks:
       - id: typos
         args: ["--force-exclude"]
         exclude: (\.gitignore$)|(^\.editorconfig$)
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: 2025.02.03
+    rev: 2025.03.10
     hooks:
       - id: validate-pyproject
         files: python-package/pyproject.toml$

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -428,7 +428,7 @@ void Config::CheckParamConflict(const std::unordered_map<std::string, std::strin
     if (zero_as_missing) {
       Log::Fatal("zero_as_missing must be false when fitting linear trees.");
     }
-    if (objective == std::string("regresson_l1")) {
+    if (objective == std::string("regression_l1")) {
       Log::Fatal("Cannot use regression_l1 objective when fitting linear trees.");
     }
   }

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -3799,6 +3799,22 @@ def test_linear_single_leaf():
     assert log_loss(y_train, y_pred) < 0.661
 
 
+def test_linear_raises_informative_errors_on_unsupported_params():
+    X, y = make_synthetic_regression()
+    with pytest.raises(lgb.basic.LightGBMError, match="Cannot use regression_l1 objective when fitting linear trees"):
+        lgb.train(
+            train_set=lgb.Dataset(X, label=y),
+            params={"linear_tree": True, "objective": "regression_l1"},
+            num_boost_round=1,
+        )
+    with pytest.raises(lgb.basic.LightGBMError, match="zero_as_missing must be false when fitting linear trees"):
+        lgb.train(
+            train_set=lgb.Dataset(X, label=y),
+            params={"linear_tree": True, "zero_as_missing": True},
+            num_boost_round=1,
+        )
+
+
 def test_predict_with_start_iteration():
     def inner_test(X, y, params, early_stopping_rounds):
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)


### PR DESCRIPTION
From the very first PR where @btrotta introduced linear trees here (#3299), it was never intended that they'd be used with the L1 loss. However, that's been technically possible the entire time because of a typo here:

https://github.com/microsoft/LightGBM/blob/6437645c4a0c17046be59e4f57d09952e2e0185f/src/io/config.cpp#L431-L433

This fixes that typo, and adds a test ensuring that LightGBM raises the expected errors when using unsupported parameters with linear trees.

## Notes for Reviewers

This bug was caught by the newest version of `crates-ci/typos`... pretty cool to see a spellchecker catching a real bug!!! (cc @borchero )

This PR also updates other `pre-commit` hooks to their latest versions (though they didn't catch any new issues).