### PR TITLE
[ci] [python-package] re-enable scikit-build-core binary stripping

### DIFF
--- a/.ci/check-python-dists.sh
+++ b/.ci/check-python-dists.sh
@@ -26,7 +26,7 @@ fi
 PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")
 if [ "$PY_MINOR_VER" -gt 7 ]; then
     echo "pydistcheck..."
-    pip install 'pydistcheck>=0.7.0'
+    pip install 'pydistcheck>=0.9.1'
     if { test "${TASK}" = "cuda" || test "${METHOD}" = "wheel"; }; then
         pydistcheck \
             --inspect \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -22,7 +22,7 @@ if [[ $OS_NAME == "macos" ]]; then
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
     else  # gcc
-        brew install 'gcc@12'
+        brew install 'gcc@14'
     fi
     if [[ $TASK == "mpi" ]]; then
         brew install open-mpi

--- a/.ci/test-windows.ps1
+++ b/.ci/test-windows.ps1
@@ -18,14 +18,14 @@ Remove-Item $env:TMPDIR -Force -Recurse -ErrorAction Ignore
 
 if ($env:TASK -eq "r-package") {
     & .\.ci\test-r-package-windows.ps1 ; Assert-Output $?
-    Exit 0
+    exit 0
 }
 
 if ($env:TASK -eq "cpp-tests") {
     cmake -B build -S . -DBUILD_CPP_TEST=ON -DUSE_DEBUG=ON -A x64
     cmake --build build --target testlightgbm --config Debug ; Assert-Output $?
     .\Debug\testlightgbm.exe ; Assert-Output $?
-    Exit 0
+    exit 0
 }
 
 if ($env:TASK -eq "swig") {
@@ -59,7 +59,7 @@ if ($env:TASK -eq "swig") {
     if ($env:AZURE -eq "true") {
         cp ./build/lightgbmlib.jar $env:BUILD_ARTIFACTSTAGINGDIRECTORY/lightgbmlib_win.jar ; Assert-Output $?
     }
-    Exit 0
+    exit 0
 }
 
 # setup for Python

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -14,8 +14,8 @@ ARCH=$(uname -m)
 LGB_VER=$(head -n 1 "${BUILD_DIRECTORY}/VERSION.txt")
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "gcc" ]]; then
-    export CXX=g++-12
-    export CC=gcc-12
+    export CXX=g++-14
+    export CC=gcc-14
 elif [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "clang" ]]; then
     export CXX=clang++
     export CC=clang

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -73,9 +73,7 @@ cmake.args = [
 build.verbose = false
 cmake.build-type = "Release"
 build.targets = ["_lightgbm"]
-# stripping binaries should be turned back on once this is fixed:
-# https://github.com/jameslamb/pydistcheck/issues/235
-install.strip = false
+install.strip = true
 logging.level = "INFO"
 sdist.reproducible = true
 wheel.py-api = "py3"


### PR DESCRIPTION
fixes #6609

`scikit-build-core` can be configured to strip debug symbols out of compiled objects. That's been turned off in LightGBM because it caused problems for `pydistcheck` (at a time when configuring `pydistcheck` to only run certain checks was not supported).

The relevant issue in `pydistcheck` (https://github.com/jameslamb/pydistcheck/issues/235) has been fixed in the recent 0.9.1 release of that tool, so this re-enables stripping.

## Notes for Reviewers

This change should not affect `lightgbm` wheels, as they're already build without debug symbols.

https://github.com/microsoft/LightGBM/blob/6437645c4a0c17046be59e4f57d09952e2e0185f/python-package/pyproject.toml#L74

Enabling automatic stripping in `scikit-build-core` is just an extra layer of protection against compiler flags like `-g` unintentionally making it into builds.