### PR TITLE
[docs] Fix docs of `Booster.update`'s return value `is_finished`

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -4125,7 +4125,8 @@ class Booster:
         Returns
         -------
         is_finished : bool
-            Whether the update was successfully finished.
+            Whether there were no possible splits meeting the splitting criteria. No
+            more training to be done.
         """
         # need reset training data
         if train_set is None and self.train_set_version != self.train_set.version:

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -4080,9 +4080,13 @@ class Booster:
 
         Returns
         -------
-        is_finished : bool
-            Whether there were no possible splits meeting the splitting criteria, that
-            is, there is no more training to be done.
+        produced_empty_tree : bool
+            ``True`` if the tree(s) produced by this iteration did not have any splits.
+            This usually means that training is "finished" (calling ``update()`` again
+            will not change the model's predictions). However, that is not always the
+            case. For example, if you have added any randomness (like column sampling by
+            setting ``feature_fraction_bynode < 1.0``), it is possible that another call
+            to ``update()`` would produce a non-empty tree.
         """
         # need reset training data
         if train_set is None and self.train_set_version != self.train_set.version:
@@ -4104,18 +4108,18 @@ class Booster:
             )
             self.__inner_predict_buffer[0] = None
             self.train_set_version = self.train_set.version
-        is_finished = ctypes.c_int(0)
+        produced_empty_tree = ctypes.c_int(0)
         if fobj is None:
             if self.__set_objective_to_none:
                 raise LightGBMError("Cannot update due to null objective function.")
             _safe_call(
                 _LIB.LGBM_BoosterUpdateOneIter(
                     self._handle,
-                    ctypes.byref(is_finished),
+                    ctypes.byref(produced_empty_tree),
                 )
             )
             self.__is_predicted_cur_iter = [False for _ in range(self.__num_dataset)]
-            return is_finished.value == 1
+            return produced_empty_tree.value == 1
         else:
             if not self.__set_objective_to_none:
                 self.reset_parameter({"objective": "none"}).__set_objective_to_none = True
@@ -4147,8 +4151,13 @@ class Booster:
 
         Returns
         -------
-        is_finished : bool
-            Whether the boost was successfully finished.
+        produced_empty_tree : bool
+            ``True`` if the tree(s) produced by this iteration did not have any splits.
+            This usually means that training is "finished" (calling ``update()`` again
+            will not change the model's predictions). However, that is not always the
+            case. For example, if you have added any randomness (like column sampling by
+            setting ``feature_fraction_bynode < 1.0``), it is possible that another call
+            to ``update()`` would produce a non-empty tree.
         """
         if self.__num_class > 1:
             grad = grad.ravel(order="F")
@@ -4166,17 +4175,17 @@ class Booster:
                 f"don't match training data length ({num_train_data}) * "
                 f"number of models per one iteration ({self.__num_class})"
             )
-        is_finished = ctypes.c_int(0)
+        produced_empty_tree = ctypes.c_int(0)
         _safe_call(
             _LIB.LGBM_BoosterUpdateOneIterCustom(
                 self._handle,
                 grad.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
                 hess.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
-                ctypes.byref(is_finished),
+                ctypes.byref(produced_empty_tree),
             )
         )
         self.__is_predicted_cur_iter = [False for _ in range(self.__num_dataset)]
-        return is_finished.value == 1
+        return produced_empty_tree.value == 1
 
     def rollback_one_iter(self) -> "Booster":
         """Rollback one iteration.

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -4125,8 +4125,8 @@ class Booster:
         Returns
         -------
         is_finished : bool
-            Whether there were no possible splits meeting the splitting criteria. No
-            more training to be done.
+            Whether there were no possible splits meeting the splitting criteria, that
+            is, there is no more training to be done.
         """
         # need reset training data
         if train_set is None and self.train_set_version != self.train_set.version:

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -4153,11 +4153,11 @@ class Booster:
         -------
         produced_empty_tree : bool
             ``True`` if the tree(s) produced by this iteration did not have any splits.
-            This usually means that training is "finished" (calling ``update()`` again
+            This usually means that training is "finished" (calling ``__boost()`` again
             will not change the model's predictions). However, that is not always the
             case. For example, if you have added any randomness (like column sampling by
             setting ``feature_fraction_bynode < 1.0``), it is possible that another call
-            to ``update()`` would produce a non-empty tree.
+            to ``__boost()`` would produce a non-empty tree.
         """
         if self.__num_class > 1:
             grad = grad.ravel(order="F")


### PR DESCRIPTION
The current docs are wrong. The return is `!should_continue`: https://github.com/microsoft/LightGBM/blob/18c11f861118aa889b9d4579c2888d5c908fd250/src/boosting/gbdt.cpp#L440-L452.