### PR TITLE
[python-package] Add specific error messages to `test_basic` and `test_dask` tests

### DIFF
--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -675,6 +675,8 @@ def test_list_to_1d_numpy(collection, dtype, rng):
         "2d_list": [[1], [2]],
     }
     y = collection2y[collection]
+    custom_name = "my_custom_variable"
+
     if collection.startswith("pd"):
         if not PANDAS_INSTALLED:
             pytest.skip("pandas is not installed")
@@ -682,21 +684,23 @@ def test_list_to_1d_numpy(collection, dtype, rng):
             y = pd_Series(y)
     if isinstance(y, np.ndarray) and len(y.shape) == 2:
         with pytest.warns(UserWarning, match="column-vector"):
-            lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name="list")
+            lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name=custom_name)
         return
     elif isinstance(y, list) and isinstance(y[0], list):
-        with pytest.raises(
-            TypeError, match=r"Wrong type\(list\) for list\.\nIt should be list, numpy 1-D array or pandas Series"
-        ):
-            lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name="list")
+        err_msg = (
+            rf"Wrong type\(list\) for {custom_name}.\n"
+            r"It should be list, numpy 1-D array or pandas Series"
+        )
+        with pytest.raises(TypeError, match=err_msg):
+            lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name=custom_name)
         return
     elif isinstance(y, pd_Series) and y.dtype == object:
         with pytest.raises(
             ValueError, match=r"pandas dtypes must be int, float or bool\.\nFields with bad pandas dtypes: 0: object"
         ):
-            lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name="list")
+            lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name=custom_name)
         return
-    result = lgb.basic._list_to_1d_numpy(y, dtype=dtype, name="list")
+    result = lgb.basic._list_to_1d_numpy(y, dtype=dtype, name=custom_name)
     assert result.size == 10
     assert result.dtype == dtype
 

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -685,11 +685,15 @@ def test_list_to_1d_numpy(collection, dtype, rng):
             lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name="list")
         return
     elif isinstance(y, list) and isinstance(y[0], list):
-        with pytest.raises(TypeError):
+        with pytest.raises(
+            TypeError, match=r"Wrong type\(list\) for list\.\nIt should be list, numpy 1-D array or pandas Series"
+        ):
             lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name="list")
         return
     elif isinstance(y, pd_Series) and y.dtype == object:
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match=r"pandas dtypes must be int, float or bool\.\nFields with bad pandas dtypes: 0: object"
+        ):
             lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name="list")
         return
     result = lgb.basic._list_to_1d_numpy(y, dtype=dtype, name="list")

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -2,6 +2,7 @@
 """Tests for lightgbm.dask module"""
 
 import inspect
+import re
 import socket
 from itertools import groupby
 from os import getenv
@@ -1016,7 +1017,11 @@ def test_training_works_if_client_not_provided_or_set_after_construction(task, c
         assert dask_model.client_ == client
 
         local_model = dask_model.to_local()
-        with pytest.raises(AttributeError):
+        no_client_attr_msg = re.compile(
+            f"{repr(type(local_model).__name__)} object has no attribute '(client|client_)'"
+        )
+
+        with pytest.raises(AttributeError, match=no_client_attr_msg):
             local_model.client
             local_model.client_
 
@@ -1040,7 +1045,7 @@ def test_training_works_if_client_not_provided_or_set_after_construction(task, c
         assert dask_model.client_ == client
 
         local_model = dask_model.to_local()
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match=no_client_attr_msg):
             local_model.client
             local_model.client_
 


### PR DESCRIPTION
Contributes to: https://github.com/microsoft/LightGBM/issues/6860

Adds specific error messages to:

- `test_list_to_1d_numpy`
- `test_training_works_if_client_not_provided_or_set_after_construction`