### PR TITLE
[python-package] Fix mypy checks in `compat.py`

### DIFF
--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -36,7 +36,7 @@ try:
         # validate_data() was added in scikit-learn 1.6, this function roughly imitates it for older versions.
         # It can be removed when lightgbm's minimum scikit-learn version is at least 1.6.
         def validate_data(
-            _estimator,
+            _estimator: Any,
             X: Any,
             y: Any = "no_validation",
             accept_sparse: bool = True,
@@ -44,7 +44,7 @@ try:
             ensure_all_finite: bool = False,
             ensure_min_samples: int = 1,
             # trap other keyword arguments that only work on scikit-learn >=1.6, like 'reset'
-            **ignored_kwargs,
+            **ignored_kwargs: Any,
         ) -> Any:
             # it's safe to import _num_features unconditionally because:
             #

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -37,15 +37,15 @@ try:
         # It can be removed when lightgbm's minimum scikit-learn version is at least 1.6.
         def validate_data(
             _estimator,
-            X,
-            y="no_validation",
+            X: Any,
+            y: Any = "no_validation",
             accept_sparse: bool = True,
             # 'force_all_finite' was renamed to 'ensure_all_finite' in scikit-learn 1.6
             ensure_all_finite: bool = False,
             ensure_min_samples: int = 1,
             # trap other keyword arguments that only work on scikit-learn >=1.6, like 'reset'
             **ignored_kwargs,
-        ):
+        ) -> Any:
             # it's safe to import _num_features unconditionally because:
             #
             #  * it was first added in scikit-learn 0.24.2


### PR DESCRIPTION
# Motivation

Contributes to #3867

`mypy` currently fails with 36 errors in 6 files. One of these files is `compat.py`.

# Changes

This PR fixes the typing issues in `compat.py`, eliminating 2 errors in 1 file. I don't think there is a strong drawback in using `Any` here, this is a "stub function" anyways.