### PR TITLE
[python-package] Add superfluous-else-raise (RET506) rule to Ruff

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -343,8 +343,7 @@ def setup(app: Sphinx) -> None:
         if first_run:
             app.connect("builder-inited", generate_r_docs)
         app.connect(
-            "build-finished",
-            lambda app, _: copytree(CURR_PATH.parent / "lightgbm_r" / "docs", Path(app.outdir) / "R"),
+            "build-finished", lambda app, _: copytree(CURR_PATH.parent / "lightgbm_r" / "docs", Path(app.outdir) / "R")
         )
     app.connect("builder-inited", replace_reference_to_r_docs)
     app.add_transform(InternalRefTransform)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -254,8 +254,7 @@ def generate_doxygen_xml(app: Sphinx) -> None:
         output = "\n".join([i.decode("utf-8") for i in (stdout, stderr) if i is not None])
         if process.returncode != 0:
             raise RuntimeError(output)
-        else:
-            print(output)
+        print(output)
     except BaseException as e:
         raise Exception(f"An error has occurred while executing Doxygen\n{e}")
 
@@ -303,9 +302,8 @@ def generate_r_docs(app: Sphinx) -> None:
         output = "\n".join([i for i in (stdout, stderr) if i is not None])
         if process.returncode != 0:
             raise RuntimeError(output)
-        else:
-            print(output)
-            print("Done building R-package documentation")
+        print(output)
+        print("Done building R-package documentation")
     except BaseException as e:
         raise Exception(f"An error has occurred while generating documentation for R-package\n{e}")
 
@@ -345,7 +343,8 @@ def setup(app: Sphinx) -> None:
         if first_run:
             app.connect("builder-inited", generate_r_docs)
         app.connect(
-            "build-finished", lambda app, _: copytree(CURR_PATH.parent / "lightgbm_r" / "docs", Path(app.outdir) / "R")
+            "build-finished",
+            lambda app, _: copytree(CURR_PATH.parent / "lightgbm_r" / "docs", Path(app.outdir) / "R"),
         )
     app.connect("builder-inited", replace_reference_to_r_docs)
     app.add_transform(InternalRefTransform)

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1130,7 +1130,7 @@ class _InnerPredictor:
         """
         if isinstance(data, Dataset):
             raise TypeError("Cannot use Dataset instance for prediction, please use raw data instead")
-        elif isinstance(data, pd_DataFrame) and validate_features:
+        if isinstance(data, pd_DataFrame) and validate_features:
             data_names = [str(x) for x in data.columns]
             ptr_names = (ctypes.c_char_p * len(data_names))()
             ptr_names[:] = [x.encode("utf-8") for x in data_names]
@@ -5097,8 +5097,7 @@ class Booster:
                 if split_feature == feature:
                     if isinstance(root["threshold"], str):
                         raise LightGBMError("Cannot compute split value histogram for the categorical feature")
-                    else:
-                        values.append(root["threshold"])
+                    values.append(root["threshold"])
                 add(root["left_child"])
                 add(root["right_child"])
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1761,9 +1761,9 @@ class LGBMRanker(LGBMModel):
         if eval_set is not None:
             if eval_group is None:
                 raise ValueError("Eval_group cannot be None when eval_set is not None")
-            elif len(eval_group) != len(eval_set):
+            if len(eval_group) != len(eval_set):
                 raise ValueError("Length of eval_group should be equal to eval_set")
-            elif (
+            if (
                 isinstance(eval_group, dict)
                 and any(i not in eval_group or eval_group[i] is None for i in range(len(eval_group)))
                 or isinstance(eval_group, list)

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -163,6 +163,8 @@ select = [
     "T",
     # pycodestyle (warnings)
     "W",
+    # superfluous-else-raise
+    "RET506",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -157,14 +157,14 @@ select = [
     "PL",
     # flake8-return: unnecessary assignment before return
     "RET504",
+    # flake8-return: superfluous-else-raise
+    "RET506",
     # flake8-simplify: use dict.get() instead of an if-else block
     "SIM401",
     # flake8-print
     "T",
     # pycodestyle (warnings)
     "W",
-    # superfluous-else-raise
-    "RET506",
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Closes #6903 

## Description

This pull request introduces support for the newly proposed RET506 rule (superfluous-else-raise) in Ruff.
The RET506 rule flags unnecessary else blocks following a raise statement, helping to simplify and clarify control flow.

## Changes
•Enabled the RET506 rule by adding it to ruff.toml.
•Updated code to fix violations detected by RET506, removing redundant else blocks after raise statements.