### PR TITLE
[docs] document use of EffVer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Light Gradient Boosting Machine
 [![Documentation Status](https://readthedocs.org/projects/lightgbm/badge/?version=latest)](https://lightgbm.readthedocs.io/)
 [![Link checks](https://github.com/microsoft/LightGBM/actions/workflows/linkchecker.yml/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions/workflows/linkchecker.yml)
 [![License](https://img.shields.io/github/license/microsoft/lightgbm.svg)](https://github.com/microsoft/LightGBM/blob/master/LICENSE)
+[![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 [![Python Versions](https://img.shields.io/pypi/pyversions/lightgbm.svg?logo=python&logoColor=white)](https://pypi.org/project/lightgbm)
 [![PyPI Version](https://img.shields.io/pypi/v/lightgbm.svg?logo=pypi&logoColor=white)](https://pypi.org/project/lightgbm)
 [![conda Version](https://img.shields.io/conda/vn/conda-forge/lightgbm?logo=conda-forge&logoColor=white&label=conda)](https://anaconda.org/conda-forge/lightgbm)

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -33,8 +33,8 @@ than all previous releases, and "older" than all future releases.
 For more details on why LightGBM uses EffVer instead of other schemes like semantic versioning,
 see https://jacobtomlinson.dev/effver/.
 
-Notes
-~~~~~
+General Installation Notes
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 All instructions below are aimed at compiling the 64-bit version of LightGBM.
 It is worth compiling the 32-bit version only in very rare special cases involving environmental limitations.

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -30,6 +30,10 @@ When built from source on an unreleased commit, this version takes the following
 That ``.99`` is added to ensure that a version built from an unreleased commit is considered "newer"
 than all previous releases, and "older" than all future releases.
 
+.. _nightly-builds:
+
+You can find such artifacts from the latest successful build on the ``master`` branch (nightly builds) here: |download artifacts|.
+
 For more details on why LightGBM uses EffVer instead of other schemes like semantic versioning,
 see https://jacobtomlinson.dev/effver/.
 
@@ -75,10 +79,6 @@ These values refer to the following supported sanitizers:
 Please note, that ThreadSanitizer cannot be used together with other sanitizers.
 For more info and additional sanitizers' parameters please refer to the `following docs`_.
 It is very useful to build `C++ unit tests <#build-c-unit-tests>`__ with sanitizers.
-
-.. _nightly-builds:
-
-You can download the artifacts of the latest successful build on master branch (nightly builds) here: |download artifacts|.
 
 .. contents:: **Contents**
     :depth: 1

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -1,6 +1,41 @@
 Installation Guide
 ==================
 
+Versioning
+~~~~~~~~~~
+
+LightGBM releases use a 3-part version number, with this format:
+
+.. code::
+
+   {major}.{minor}.{patch}
+
+This version follows a scheme called Intended Effort Versioning ("Effver" for short).
+Changes to a component of the version indicate how much effort it will likely take to update
+code using a previous version.
+
+* ``major`` = updating will require significant effort
+* ``minor`` = some effort
+* ``patch`` = no or very little effort
+
+This means that **new minor versions can contain breaking changes**, but these are typically
+small or limited to less-frequently-used parts of the project.
+
+When built from source on an unreleased commit, this version takes the following form:
+
+.. code::
+
+   {major}.{minor}.{patch}.99
+
+That ``.99`` is added to ensure that a version built from an unreleased commit is considered "newer"
+than all previous releases, and "older" than all future releases.
+
+For more details on why LightGBM uses EffVer instead of other schemes like semantic versioning,
+see https://jacobtomlinson.dev/effver/.
+
+Notes
+~~~~~
+
 All instructions below are aimed at compiling the 64-bit version of LightGBM.
 It is worth compiling the 32-bit version only in very rare special cases involving environmental limitations.
 The 32-bit version is slow and untested, so use it at your own risk and don't forget to adjust some of the commands below when installing.


### PR DESCRIPTION
For a long time now, this project has not been strictly following semantic versioning.

Look through https://github.com/microsoft/LightGBM/releases and you will find entries in the "Breaking" section for release v4.6.0, v4.5.0, v4.4.0, etc.

Without knowing it, for several years we've been following a scheme that my friend @jacobtomlinson calls **Intended Effort Versioning** ("EffVer"): https://jacobtomlinson.dev/effver/

In that scheme, you use a 3-part version where changes to each part answer the question "how much effort will it take for me to upgrade to this version?".

This PR proposes explicitly documenting that, so we have somewhere to point people who ask questions like *"why did you only update the minor version component if this release contains breaking changes?"*.

## Notes for Reviewers

### Why put this in the Installation Guide?

I think this type of information is useful in the Installation Guide because it helps users to decide how to create dependency pins on LightGBM.

If we don't like this here, I think it should go in the development docs: https://lightgbm.readthedocs.io/en/latest/Development-Guide.html

### I've added this branch (temporarily) to the readthedocs config

Builds: https://app.readthedocs.org/projects/lightgbm/builds/?version__slug=docs-effver