### PR TITLE
[python-package] Add specific error messages to _list_to_1d_numpy() tests

### DIFF
--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -685,7 +685,7 @@ def test_list_to_1d_numpy(collection, dtype, rng):
             lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name="list")
         return
     elif isinstance(y, list) and isinstance(y[0], list):
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="expected 1D array"):
             lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name="list")
         return
     elif isinstance(y, pd_Series) and y.dtype == object:

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -689,7 +689,7 @@ def test_list_to_1d_numpy(collection, dtype, rng):
             lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name="list")
         return
     elif isinstance(y, pd_Series) and y.dtype == object:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="cannot be converted"):
             lgb.basic._list_to_1d_numpy(y, dtype=np.float32, name="list")
         return
     result = lgb.basic._list_to_1d_numpy(y, dtype=dtype, name="list")

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1016,8 +1016,7 @@ def test_training_works_if_client_not_provided_or_set_after_construction(task, c
         assert dask_model.client_ == client
 
         local_model = dask_model.to_local()
-        with pytest.raises(AttributeError, match="client"):
-            # client is not set on the local model, so should raise an error if we try to access it
+        with pytest.raises(AttributeError):
             local_model.client
             local_model.client_
 
@@ -1041,7 +1040,7 @@ def test_training_works_if_client_not_provided_or_set_after_construction(task, c
         assert dask_model.client_ == client
 
         local_model = dask_model.to_local()
-        with pytest.raises(AttributeError, match="client"):
+        with pytest.raises(AttributeError):
             local_model.client
             local_model.client_
 
@@ -1127,7 +1126,7 @@ def test_model_and_local_version_are_picklable_whether_or_not_client_set_explici
             local_model = dask_model.to_local()
 
             assert "client" not in local_model.get_params()
-            with pytest.raises(AttributeError, match="client"):
+            with pytest.raises(AttributeError):
                 local_model.client
                 local_model.client_
 

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1016,7 +1016,8 @@ def test_training_works_if_client_not_provided_or_set_after_construction(task, c
         assert dask_model.client_ == client
 
         local_model = dask_model.to_local()
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="client"):
+            # client is not set on the local model, so should raise an error if we try to access it
             local_model.client
             local_model.client_
 
@@ -1040,7 +1041,7 @@ def test_training_works_if_client_not_provided_or_set_after_construction(task, c
         assert dask_model.client_ == client
 
         local_model = dask_model.to_local()
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="client"):
             local_model.client
             local_model.client_
 
@@ -1126,7 +1127,7 @@ def test_model_and_local_version_are_picklable_whether_or_not_client_set_explici
             local_model = dask_model.to_local()
 
             assert "client" not in local_model.get_params()
-            with pytest.raises(AttributeError):
+            with pytest.raises(AttributeError, match="client"):
                 local_model.client
                 local_model.client_
 


### PR DESCRIPTION
Contribute to the issue: #6860 

### Description
This pull request add ValueError and TypeError message to function:test_list_to_1d_numpy

### Changes
Added `match` error message argument for the pytest.raises for ValueError and TypeError in `test_list_to_1d_numpy`