### PR TITLE
[ci] skip self-hosted Linux CI jobs

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -49,104 +49,105 @@ resources:
         tools: true
         tasks: true
 jobs:
-  ###############
-  # Maintenance #
-  ###############
-  - job: Maintenance
-    pool: mariner-20240410-0
-    container: ubuntu-latest
-    # routine maintenance (like periodically deleting old files),
-    # to be run on 1 random CI runner in the self-hosted pool each runner
-    steps:
-      - script: |
-          print-diagnostics(){
-            echo "---- df -h -m ----"
-            df -h -m
-            echo "---- docker system df ----"
-            /tmp/docker system df
-            echo "---- docker images ----"
-            /tmp/docker images
-          }
-          # check disk usage
-          print-diagnostics
-          # remove old containers, container images, volumes
-          # ref: https://stackoverflow.com/a/32723127/3986677
-          # ref: https://depot.dev/blog/docker-clear-cache#removing-everything-with-docker-system-prune
-          echo "---- running 'docker system prune' ----"
-          /tmp/docker system prune \
-            --all \
-            --force \
-            --volumes \
-            --filter until=720h
-          # check disk usage again
-          print-diagnostics
-        displayName: Clean
-  #########
-  # Linux #
-  #########
-  - job: Linux
-    variables:
-      COMPILER: gcc
-      SETUP_CONDA: 'false'
-      OS_NAME: 'linux'
-      PRODUCES_ARTIFACTS: 'true'
-    pool: mariner-20240410-0
-    container: linux-artifact-builder
-    strategy:
-      matrix:
-        regular:
-          TASK: regular
-          PYTHON_VERSION: '3.11'
-        sdist:
-          TASK: sdist
-          PYTHON_VERSION: '3.9'
-        bdist:
-          TASK: bdist
-          PYTHON_VERSION: '3.10'
-        inference:
-          TASK: if-else
-        mpi_source:
-          TASK: mpi
-          METHOD: source
-          PYTHON_VERSION: '3.10'
-        gpu_source:
-          TASK: gpu
-          METHOD: source
-        swig:
-          TASK: swig
-    steps:
-      - script: |
-          echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
-          echo "##vso[task.prependpath]/usr/lib64/openmpi/bin"
-          echo "##vso[task.prependpath]$CONDA/bin"
-        displayName: 'Set variables'
-      - script: |
-          git clean -d -f -x
-        displayName: 'Clean source directory'
-      - script: |
-          echo '$(Build.SourceVersion)' > '$(Build.ArtifactStagingDirectory)/commit.txt'
-        displayName: 'Add commit hash to artifacts archive'
-      - task: Bash@3
-        displayName: Setup
-        inputs:
-          filePath: $(Build.SourcesDirectory)/.ci/setup.sh
-          targetType: filePath
-      - task: Bash@3
-        displayName: Test
-        inputs:
-          filePath: $(Build.SourcesDirectory)/.ci/test.sh
-          targetType: filePath
-      - task: PublishBuildArtifacts@1
-        condition: >
-          and(
-          succeeded(),
-          in(variables['TASK'], 'regular', 'sdist', 'bdist', 'swig'),
-          not(startsWith(variables['Build.SourceBranch'], 'refs/pull/'))
-          )
-        inputs:
-          pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-          artifactName: PackageAssets
-          artifactType: container
+  # TODO: add these jobs back when issues from https://github.com/microsoft/LightGBM/issues/6918 are resolved
+  # ###############
+  # # Maintenance #
+  # ###############
+  # - job: Maintenance
+  #   pool: mariner-20240410-0
+  #   container: ubuntu-latest
+  #   # routine maintenance (like periodically deleting old files),
+  #   # to be run on 1 random CI runner in the self-hosted pool each runner
+  #   steps:
+  #     - script: |
+  #         print-diagnostics(){
+  #           echo "---- df -h -m ----"
+  #           df -h -m
+  #           echo "---- docker system df ----"
+  #           /tmp/docker system df
+  #           echo "---- docker images ----"
+  #           /tmp/docker images
+  #         }
+  #         # check disk usage
+  #         print-diagnostics
+  #         # remove old containers, container images, volumes
+  #         # ref: https://stackoverflow.com/a/32723127/3986677
+  #         # ref: https://depot.dev/blog/docker-clear-cache#removing-everything-with-docker-system-prune
+  #         echo "---- running 'docker system prune' ----"
+  #         /tmp/docker system prune \
+  #           --all \
+  #           --force \
+  #           --volumes \
+  #           --filter until=720h
+  #         # check disk usage again
+  #         print-diagnostics
+  #       displayName: Clean
+  # #########
+  # # Linux #
+  # #########
+  # - job: Linux
+  #   variables:
+  #     COMPILER: gcc
+  #     SETUP_CONDA: 'false'
+  #     OS_NAME: 'linux'
+  #     PRODUCES_ARTIFACTS: 'true'
+  #   pool: mariner-20240410-0
+  #   container: linux-artifact-builder
+  #   strategy:
+  #     matrix:
+  #       regular:
+  #         TASK: regular
+  #         PYTHON_VERSION: '3.11'
+  #       sdist:
+  #         TASK: sdist
+  #         PYTHON_VERSION: '3.9'
+  #       bdist:
+  #         TASK: bdist
+  #         PYTHON_VERSION: '3.10'
+  #       inference:
+  #         TASK: if-else
+  #       mpi_source:
+  #         TASK: mpi
+  #         METHOD: source
+  #         PYTHON_VERSION: '3.10'
+  #       gpu_source:
+  #         TASK: gpu
+  #         METHOD: source
+  #       swig:
+  #         TASK: swig
+  #   steps:
+  #     - script: |
+  #         echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
+  #         echo "##vso[task.prependpath]/usr/lib64/openmpi/bin"
+  #         echo "##vso[task.prependpath]$CONDA/bin"
+  #       displayName: 'Set variables'
+  #     - script: |
+  #         git clean -d -f -x
+  #       displayName: 'Clean source directory'
+  #     - script: |
+  #         echo '$(Build.SourceVersion)' > '$(Build.ArtifactStagingDirectory)/commit.txt'
+  #       displayName: 'Add commit hash to artifacts archive'
+  #     - task: Bash@3
+  #       displayName: Setup
+  #       inputs:
+  #         filePath: $(Build.SourcesDirectory)/.ci/setup.sh
+  #         targetType: filePath
+  #     - task: Bash@3
+  #       displayName: Test
+  #       inputs:
+  #         filePath: $(Build.SourcesDirectory)/.ci/test.sh
+  #         targetType: filePath
+  #     - task: PublishBuildArtifacts@1
+  #       condition: >
+  #         and(
+  #         succeeded(),
+  #         in(variables['TASK'], 'regular', 'sdist', 'bdist', 'swig'),
+  #         not(startsWith(variables['Build.SourceBranch'], 'refs/pull/'))
+  #         )
+  #       inputs:
+  #         pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+  #         artifactName: PackageAssets
+  #         artifactType: container
   ################
   # Linux_latest #
   ################
@@ -364,7 +365,8 @@ jobs:
   ###########
   - job: Package
     dependsOn:
-      - Linux
+      # TODO: add 'Linux' jobs back when https://github.com/microsoft/LightGBM/issues/6918 is resolved
+      # - Linux
       - Linux_latest
       - macOS
       - Windows

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -148,82 +148,82 @@ jobs:
   #         pathtoPublish: '$(Build.ArtifactStagingDirectory)'
   #         artifactName: PackageAssets
   #         artifactType: container
-  ################
-  # Linux_latest #
-  ################
-  - job: Linux_latest
-    variables:
-      COMPILER: clang-17
-      DEBIAN_FRONTEND: 'noninteractive'
-      IN_UBUNTU_BASE_CONTAINER: 'true'
-      OS_NAME: 'linux'
-      SETUP_CONDA: 'true'
-    pool: mariner-20240410-0
-    container: ubuntu-latest
-    strategy:
-      matrix:
-        regular:
-          TASK: regular
-        sdist:
-          TASK: sdist
-        bdist:
-          TASK: bdist
-          PYTHON_VERSION: '3.11'
-        inference:
-          TASK: if-else
-        mpi_source:
-          TASK: mpi
-          METHOD: source
-        mpi_pip:
-          TASK: mpi
-          METHOD: pip
-          PYTHON_VERSION: '3.12'
-        mpi_wheel:
-          TASK: mpi
-          METHOD: wheel
-          PYTHON_VERSION: '3.10'
-        gpu_source:
-          TASK: gpu
-          METHOD: source
-          PYTHON_VERSION: '3.12'
-        gpu_pip:
-          TASK: gpu
-          METHOD: pip
-          PYTHON_VERSION: '3.11'
-        gpu_wheel:
-          TASK: gpu
-          METHOD: wheel
-          PYTHON_VERSION: '3.10'
-        cpp_tests:
-          TASK: cpp-tests
-          METHOD: with-sanitizers
-    steps:
-      - script: |
-          echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
-          CONDA=$HOME/miniforge
-          echo "##vso[task.setvariable variable=CONDA]$CONDA"
-          echo "##vso[task.prependpath]$CONDA/bin"
-        displayName: 'Set variables'
-      # https://github.com/microsoft/azure-pipelines-agent/issues/2043#issuecomment-687983301
-      - script: |
-          /tmp/docker exec -t -u 0 ci-container \
-          sh -c "apt-get update && apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
-        displayName: 'Install sudo'
-      - script: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends git
-          git clean -d -f -x
-        displayName: 'Clean source directory'
-      - task: Bash@3
-        displayName: Setup
-        inputs:
-          filePath: $(Build.SourcesDirectory)/.ci/setup.sh
-          targetType: 'filePath'
-      - task: Bash@3
-        displayName: Test
-        inputs:
-          filePath: $(Build.SourcesDirectory)/.ci/test.sh
-          targetType: 'filePath'
+  # ################
+  # # Linux_latest #
+  # ################
+  # - job: Linux_latest
+  #   variables:
+  #     COMPILER: clang-17
+  #     DEBIAN_FRONTEND: 'noninteractive'
+  #     IN_UBUNTU_BASE_CONTAINER: 'true'
+  #     OS_NAME: 'linux'
+  #     SETUP_CONDA: 'true'
+  #   pool: mariner-20240410-0
+  #   container: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       regular:
+  #         TASK: regular
+  #       sdist:
+  #         TASK: sdist
+  #       bdist:
+  #         TASK: bdist
+  #         PYTHON_VERSION: '3.11'
+  #       inference:
+  #         TASK: if-else
+  #       mpi_source:
+  #         TASK: mpi
+  #         METHOD: source
+  #       mpi_pip:
+  #         TASK: mpi
+  #         METHOD: pip
+  #         PYTHON_VERSION: '3.12'
+  #       mpi_wheel:
+  #         TASK: mpi
+  #         METHOD: wheel
+  #         PYTHON_VERSION: '3.10'
+  #       gpu_source:
+  #         TASK: gpu
+  #         METHOD: source
+  #         PYTHON_VERSION: '3.12'
+  #       gpu_pip:
+  #         TASK: gpu
+  #         METHOD: pip
+  #         PYTHON_VERSION: '3.11'
+  #       gpu_wheel:
+  #         TASK: gpu
+  #         METHOD: wheel
+  #         PYTHON_VERSION: '3.10'
+  #       cpp_tests:
+  #         TASK: cpp-tests
+  #         METHOD: with-sanitizers
+  #   steps:
+  #     - script: |
+  #         echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
+  #         CONDA=$HOME/miniforge
+  #         echo "##vso[task.setvariable variable=CONDA]$CONDA"
+  #         echo "##vso[task.prependpath]$CONDA/bin"
+  #       displayName: 'Set variables'
+  #     # https://github.com/microsoft/azure-pipelines-agent/issues/2043#issuecomment-687983301
+  #     - script: |
+  #         /tmp/docker exec -t -u 0 ci-container \
+  #         sh -c "apt-get update && apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
+  #       displayName: 'Install sudo'
+  #     - script: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y --no-install-recommends git
+  #         git clean -d -f -x
+  #       displayName: 'Clean source directory'
+  #     - task: Bash@3
+  #       displayName: Setup
+  #       inputs:
+  #         filePath: $(Build.SourcesDirectory)/.ci/setup.sh
+  #         targetType: 'filePath'
+  #     - task: Bash@3
+  #       displayName: Test
+  #       inputs:
+  #         filePath: $(Build.SourcesDirectory)/.ci/test.sh
+  #         targetType: 'filePath'
   #########
   # macOS #
   #########
@@ -365,9 +365,9 @@ jobs:
   ###########
   - job: Package
     dependsOn:
-      # TODO: add 'Linux' jobs back when https://github.com/microsoft/LightGBM/issues/6918 is resolved
+      # TODO: add jobs back when https://github.com/microsoft/LightGBM/issues/6918 is resolved
       # - Linux
-      - Linux_latest
+      # - Linux_latest
       - macOS
       - Windows
       - R_artifact


### PR DESCRIPTION
Proposes temporarily skipping the Linux CI jobs that run on self-hosted runners on Azure DevOps, to unblock development here until the #6918 is resolved.

## Notes for Reviewers

This skips jobs that upload artifacts, which means:

* nightly packages (mentioned at https://lightgbm.readthedocs.io/en/latest/Installation-Guide.htm) will be missing
* we MUST either revert this before the next release or move creation of packages for PyPI to some other CI jobs (like maybe using GitHub-hosted runners on GitHub Actions)

Hopefully #6918 will be resolved soon and we can simply revert this.