### PR TITLE
[ci] skip NuGet creation

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -407,19 +407,20 @@ jobs:
         inputs:
           artifactName: R-package
           downloadPath: $(Build.SourcesDirectory)/R
-      - script: |
-          python "$(Build.SourcesDirectory)/.ci/create-nuget.py" "$(Build.SourcesDirectory)/binaries/PackageAssets"
-        displayName: 'Create NuGet configuration files'
-      - task: NuGetCommand@2
-        inputs:
-          command: pack
-          packagesToPack: '$(Build.SourcesDirectory)/.ci/nuget/*.nuspec'
-          packDestination: '$(Build.ArtifactStagingDirectory)/nuget'
-      - task: PublishBuildArtifacts@1
-        inputs:
-          pathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
-          artifactName: NuGet
-          artifactType: container
+      # TODO: add scripts back when https://github.com/microsoft/LightGBM/issues/6918 is resolved
+      # - script: |
+      #     python "$(Build.SourcesDirectory)/.ci/create-nuget.py" "$(Build.SourcesDirectory)/binaries/PackageAssets"
+      #   displayName: 'Create NuGet configuration files'
+      # - task: NuGetCommand@2
+      #   inputs:
+      #     command: pack
+      #     packagesToPack: '$(Build.SourcesDirectory)/.ci/nuget/*.nuspec'
+      #     packDestination: '$(Build.ArtifactStagingDirectory)/nuget'
+      # - task: PublishBuildArtifacts@1
+      #   inputs:
+      #     pathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
+      #     artifactName: NuGet
+      #     artifactType: container
       - task: GitHubRelease@0
         displayName: 'Create GitHub Release'
         condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
@@ -430,10 +431,11 @@ jobs:
           target: '$(Build.SourceVersion)'
           tagSource: 'auto'
           title: '$(Build.SourceBranchName)'
+          # TODO: add '$(Build.ArtifactStagingDirectory)/nuget/*.nupkg' artifact
+          # back when https://github.com/microsoft/LightGBM/issues/6918 is resolved
           assets: |
             $(Build.SourcesDirectory)/binaries/PackageAssets/*
             $(Build.SourcesDirectory)/R/R-package/*
-            $(Build.ArtifactStagingDirectory)/nuget/*.nupkg
             $(Build.ArtifactStagingDirectory)/archives/*
           assetUploadMode: 'delete'
           isDraft: true


### PR DESCRIPTION
Hotfix after #6919.

Fixes the following error in master:
```
/usr/bin/bash --noprofile --norc /home/vsts/work/_temp/06cd32f1-a0bb-428f-811d-965de847e670.sh
Traceback (most recent call last):
  File "/home/vsts/work/1/s/.ci/create-nuget.py", line 20, in <module>
    copyfile(source / "lib_lightgbm.so", linux_folder_path / "lib_lightgbm.so")
  File "/usr/lib/python3.10/shutil.py", line 254, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/home/vsts/work/1/s/binaries/PackageAssets/lib_lightgbm.so'
```
https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=17792&view=logs&j=1d2f55de-c984-5e06-0d18-75388f298a89&t=085f7f2b-f470-5c05-ab6d-e7d0f29f99ca&l=12