### PR TITLE
[swig] fix memory leak in swig interface

### DIFF
--- a/swig/lightgbmlib.i
+++ b/swig/lightgbmlib.i
@@ -33,6 +33,9 @@
   $1 = jenv;
 %}
 
+%newobject LGBM_BoosterSaveModelToStringSWIG;
+%newobject LGBM_BoosterDumpModelSWIG;
+
 %inline %{
   char * LGBM_BoosterSaveModelToStringSWIG(BoosterHandle handle,
                                            int start_iteration,


### PR DESCRIPTION
Add %newobject declaractions for some functions returning strings, so generated wrappers release the respective memory accordingly.