### PR TITLE
[ci] [R-package] Add period after specified linter names in `nolint` comments

### DIFF
--- a/.ci/install-r-deps.R
+++ b/.ci/install-r-deps.R
@@ -115,7 +115,7 @@ msg <- sprintf(
 )
 cat(msg)
 
-install.packages(  # nolint[undesirable_function]
+install.packages(  # nolint: undesirable_function.
     pkgs = deps_to_install
     , dependencies = c("Depends", "Imports", "LinkingTo")
     , lib = Sys.getenv("R_LIB_PATH", unset = .libPaths()[[1L]])

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -1,13 +1,13 @@
 .is_Booster <- function(x) {
-  return(all(c("R6", "lgb.Booster") %in% class(x)))  # nolint: class_equals
+  return(all(c("R6", "lgb.Booster") %in% class(x)))  # nolint: class_equals.
 }
 
 .is_Dataset <- function(x) {
-  return(all(c("R6", "lgb.Dataset") %in% class(x)))  # nolint: class_equals
+  return(all(c("R6", "lgb.Dataset") %in% class(x)))  # nolint: class_equals.
 }
 
 .is_Predictor <- function(x) {
-  return(all(c("R6", "lgb.Predictor") %in% class(x)))  # nolint: class_equals
+  return(all(c("R6", "lgb.Predictor") %in% class(x)))  # nolint: class_equals.
 }
 
 .is_null_handle <- function(x) {
@@ -224,7 +224,7 @@
 
 #' @importFrom parallel detectCores
 .get_default_num_threads <- function() {
-  if (requireNamespace("RhpcBLASctl", quietly = TRUE)) {  # nolint: undesirable_function
+  if (requireNamespace("RhpcBLASctl", quietly = TRUE)) {  # nolint: undesirable_function.
     return(RhpcBLASctl::get_num_cores())
   } else {
     msg <- "Optional package 'RhpcBLASctl' not found."

--- a/R-package/inst/make-r-def.R
+++ b/R-package/inst/make-r-def.R
@@ -24,7 +24,7 @@ message(sprintf("Creating '%s' from '%s'", OUT_DEF_FILE, IN_DLL_FILE))
 .pipe_shell_command_to_stdout <- function(command, args, out_file) {
     has_processx <- suppressMessages({
       suppressWarnings({
-        require("processx")  # nolint: undesirable_function
+        require("processx")  # nolint: undesirable_function.
       })
     })
     if (has_processx) {
@@ -71,7 +71,7 @@ invisible(file.remove(OBJDUMP_FILE))
 # see https://www.cs.colorado.edu/~main/cs1300/doc/mingwfaq.html
 start_index <- which(
     grepl(
-        pattern = "[Ordinal/Name Pointer] Table"  # nolint: non_portable_path
+        pattern = "[Ordinal/Name Pointer] Table"  # nolint: non_portable_path.
         , x = objdump_results
         , fixed = TRUE
     )

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -31,7 +31,7 @@ inst_dir <- file.path(R_PACKAGE_SOURCE, "inst", fsep = "/")
     on_windows <- .Platform$OS.type == "windows"
     has_processx <- suppressMessages({
       suppressWarnings({
-        require("processx")  # nolint: undesirable_function
+        require("processx")  # nolint: undesirable_function, unused_import.
       })
     })
     if (has_processx && on_windows) {

--- a/R-package/tests/testthat.R
+++ b/R-package/tests/testthat.R
@@ -1,5 +1,5 @@
 library(testthat)
-library(lightgbm)  # nolint: [unused_import]
+library(lightgbm)  # nolint: unused_import.
 
 test_check(
     package = "lightgbm"

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -29,7 +29,7 @@ test_that(".params2str() passes through duplicated params", {
         params = list(
             objective = "regression"
             , bagging_fraction = 0.8
-            , bagging_fraction = 0.5  # nolint: duplicate_argument
+            , bagging_fraction = 0.5  # nolint: duplicate_argument.
         )
     )
     expect_equal(out_str, "objective=regression bagging_fraction=0.8 bagging_fraction=0.5")

--- a/build_r.R
+++ b/build_r.R
@@ -24,7 +24,7 @@ TEMP_SOURCE_DIR <- file.path(TEMP_R_DIR, "src")
     , "make_args" = character(0L)
   )
   for (arg in args) {
-    if (any(grepl("^\\-j[0-9]+", arg))) {  # nolint: non_portable_path
+    if (any(grepl("^\\-j[0-9]+", arg))) {  # nolint: non_portable_path.
         out_list[["make_args"]] <- arg
     } else if (any(grepl("=", arg, fixed = TRUE))) {
       split_arg <- strsplit(arg, "=", fixed = TRUE)[[1L]]
@@ -147,7 +147,7 @@ if (length(parsed_args[["make_args"]]) > 0L) {
     on_windows <- .Platform$OS.type == "windows"
     has_processx <- suppressMessages({
       suppressWarnings({
-        require("processx")  # nolint: undesirable_function
+        require("processx")  # nolint: undesirable_function.
       })
     })
     if (has_processx && on_windows) {

--- a/build_r.R
+++ b/build_r.R
@@ -147,7 +147,7 @@ if (length(parsed_args[["make_args"]]) > 0L) {
     on_windows <- .Platform$OS.type == "windows"
     has_processx <- suppressMessages({
       suppressWarnings({
-        require("processx")  # nolint: undesirable_function.
+        require("processx")  # nolint: undesirable_function, unused_import.
       })
     })
     if (has_processx && on_windows) {


### PR DESCRIPTION
Fixes: #6948

Adds periods after specified linter names in `nolint` comments so that only those linters are ignored. This was fairly straightforward, just a couple things to note:

- In a couple places square brackets were used for linters e.g. `[unused_import]`. For these, I've removed the square brackets which is consistent with how linters are specified in the majority of other `nolint` comments.
- Almost all lines without the trailing period only violated their specified linter so didn't have to change code or specify extra linters (with the exception of two lines that `require("processx")`).

Made sure there are no other `nolint` lines without the trailing period with:

```sh
grep -R "nolint:" . | grep -v '\.$'
```

