### PR TITLE
[ci] stop testing on Windows Server 2019

### DIFF
--- a/.ci/test-windows.ps1
+++ b/.ci/test-windows.ps1
@@ -110,7 +110,8 @@ if ($env:TASK -eq "regular") {
     Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors
 
     conda activate $env:CONDA_ENV
-    sh "build-python.sh" bdist_wheel --integrated-opencl ; Assert-Output $?
+    # TODO: restore --integrated-opencl as part of https://github.com/microsoft/LightGBM/issues/6968
+    sh "build-python.sh" bdist_wheel ; Assert-Output $?
     sh ./.ci/check-python-dists.sh ./dist ; Assert-Output $?
     Set-Location dist; pip install @(Get-ChildItem *py3-none-win_amd64.whl) ; Assert-Output $?
     cp @(Get-ChildItem *py3-none-win_amd64.whl) "$env:BUILD_ARTIFACTSTAGINGDIRECTORY"
@@ -130,7 +131,8 @@ if (($env:TASK -eq "sdist") -or (($env:APPVEYOR -eq "true") -and ($env:TASK -eq 
 }
 if ($env:TASK -eq "bdist") {
     # Make sure we can do both CPU and GPU; see tests/python_package_test/test_dual.py
-    $env:LIGHTGBM_TEST_DUAL_CPU_GPU = "1"
+    # TODO: set LIGHTGBM_TEST_DUAL_CPU_GPU back to "1" as part of https://github.com/microsoft/LightGBM/issues/6968
+    env:LIGHTGBM_TEST_DUAL_CPU_GPU = "0"
 }
 
 pytest $tests ; Assert-Output $?

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -102,11 +102,10 @@ jobs:
             task: r-package
             compiler: MSVC
             toolchain: MSVC
-            r_version: 4.3
+            r_version: 3.6
             build_type: cmake
             container: null
-          # Visual Studio 2025
-          - os: windows-2025
+          - os: windows-2022
             task: r-package
             compiler: MSVC
             toolchain: MSVC

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -97,16 +97,16 @@ jobs:
             r_version: 4.3
             build_type: cmake
             container: null
-          # Visual Studio 2019
-          - os: windows-2019
+          # Visual Studio 2022
+          - os: windows-2022
             task: r-package
             compiler: MSVC
             toolchain: MSVC
-            r_version: 3.6
+            r_version: 4.3
             build_type: cmake
             container: null
-          # Visual Studio 2022
-          - os: windows-2022
+          # Visual Studio 2025
+          - os: windows-2025
             task: r-package
             compiler: MSVC
             toolchain: MSVC

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -286,7 +286,7 @@ jobs:
   ###########
   - job: Windows
     pool:
-      vmImage: 'windows-2019'
+      vmImage: 'windows-2022'
     strategy:
       matrix:
         regular:

--- a/cmake/IntegratedOpenCL.cmake
+++ b/cmake/IntegratedOpenCL.cmake
@@ -66,8 +66,14 @@ set(BOOST_INCLUDE "${BOOST_BASE}/source" CACHE PATH "")
 set(BOOST_LIBRARY "${BOOST_BASE}/source/stage/lib" CACHE PATH "")
 if(WIN32)
   if(MSVC)
+    # references:
+    #
+    #  * range of MSVC versions: https://learn.microsoft.com/en-us/cpp/overview/compiler-versions
+    #  * MSVC toolchain IDs: not sure...
+    #    comments like https://learn.microsoft.com/en-us/answers/questions/769911/visual-studio-2019-build-tools-v143
+    #
     if(${MSVC_VERSION} GREATER 1929)
-      message(FATAL_ERROR "Unrecognized MSVC version number: ${MSVC_VERSION}")
+      set(MSVC_TOOLCHAIN_ID "143")
     elseif(${MSVC_VERSION} GREATER 1919)
       set(MSVC_TOOLCHAIN_ID "142")
     elseif(${MSVC_VERSION} GREATER 1909)
@@ -75,7 +81,7 @@ if(WIN32)
     elseif(${MSVC_VERSION} GREATER 1899)
       set(MSVC_TOOLCHAIN_ID "140")
     else()
-      message(FATAL_ERROR "Unrecognized MSVC version number: ${MSVC_VERSION}")
+      message(FATAL_ERROR "Unsupported MSVC version number: ${MSVC_VERSION}")
     endif()
     list(
       APPEND


### PR DESCRIPTION
Fixes #6947

Azure DevOps / GitHub Actions are dropping support for `windows-2019` hosted runners (Windows Server 2019).

This updates the jobs using that version to the oldest still-supported version (Windows Server 2022).