### PR TITLE
 [python-package] Add specific error messages to `test_dask` tests

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1131,7 +1131,10 @@ def test_model_and_local_version_are_picklable_whether_or_not_client_set_explici
             local_model = dask_model.to_local()
 
             assert "client" not in local_model.get_params()
-            with pytest.raises(AttributeError):
+            no_client_attr_msg = re.compile(
+                f"{repr(type(local_model).__name__)} object has no attribute '(client|client_)'"
+            )
+            with pytest.raises(AttributeError, match=no_client_attr_msg):
                 local_model.client
                 local_model.client_
 


### PR DESCRIPTION
Contributes to: #6860

Adds specific error message to `test_model_and_local_version_are_picklable_whether_or_not_client_set_explicitly`.
