### PR TITLE
[docs] add GBNet to External Repositories list

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ lleaves (LLVM-based model compiler for efficient inference): https://github.com/
 
 Hummingbird (model compiler into tensor computations): https://github.com/microsoft/hummingbird
 
+GBNet (use `LightGBM` as a [PyTorch Module](https://docs.pytorch.org/docs/stable/generated/torch.nn.Module.html)): https://github.com/mthorrell/gbnet
+
 cuML Forest Inference Library (GPU-accelerated inference): https://github.com/rapidsai/cuml
 
 daal4py (Intel CPU-accelerated inference): https://github.com/intel/scikit-learn-intelex/tree/master/daal4py


### PR DESCRIPTION
Proposes adding https://github.com/mthorrell/gbnet to the list of external repositories.

@mthorrell presented this at SciPy today (https://cfp.scipy.org/scipy2025/talk/9MUQMM/)... this library allows the use of XGBoost / LightGBM as a PyTorch Module.