### PR TITLE
[python-package] Follow symlinks to lib_lightgbm in library-loading

### DIFF
--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -26,7 +26,7 @@ except ImportError:
     pass
 
 
-_version_path = Path(__file__).absolute().parent / "VERSION.txt"
+_version_path = Path(__file__).resolve().parent / "VERSION.txt"
 if _version_path.is_file():
     __version__ = _version_path.read_text(encoding="utf-8").strip()
 

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -18,7 +18,7 @@ def _find_lib_path() -> List[str]:
     lib_path: list of str
        List of all found library paths to LightGBM.
     """
-    curr_path = Path(__file__).absolute()
+    curr_path = Path(__file__).resolve()
     dll_path = [
         curr_path.parents[1],
         curr_path.parents[0] / "bin",


### PR DESCRIPTION
# Motivation

When working with the `LightGBM` python package in an environment referenced via symlinks, the `_find_lib_path()` function fails to find the `LightGBM` library files.

For example, if I'm working in `/path/to/my/environment/my/app/lgbm_code.py`, but a symlink exists from

```
/path/to/my/environment -> /path/to/the/real/environment
```

Then `_find_lib_path()` looks for the LightGBM library files in `/path/to/my/environment/*` instead of `/path/to/the/real/environment/*`.

I've come across this problem when trying to use LightGBM with Databricks' notebook UI while running on a compute created with a custom Docker image.

# Changes

Changes the two existing `Path.absolute()` calls to `Path.resolve()`

# References

According the docs, [`Path.abosulte()`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.absolute):

> `Path.absolute()`
> Make the path absolute, without normalization or resolving symlinks. Returns a new path object:

And [`Path.resolve()`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.resolve)

> `Path.resolve(strict=False)`
> Make the path absolute, resolving any symlinks. A new path object is returned:

