### PR TITLE
[docs] [ci] skip scikit-learn 1.7.1 in docs build, make tests compatible with pandas 3.0, use new Azure DevOps pool

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -53,7 +53,7 @@ jobs:
   # Maintenance #
   ###############
   - job: Maintenance
-    pool: lgb_agent_pool_ado
+    pool: lightgbm_agent_pool_ado
     container: ubuntu-latest
     # routine maintenance (like periodically deleting old files),
     # to be run on 1 random CI runner in the self-hosted pool each runner
@@ -90,7 +90,7 @@ jobs:
       SETUP_CONDA: 'false'
       OS_NAME: 'linux'
       PRODUCES_ARTIFACTS: 'true'
-    pool: lgb_agent_pool_ado
+    pool: lightgbm_agent_pool_ado
     container: linux-artifact-builder
     strategy:
       matrix:
@@ -157,7 +157,7 @@ jobs:
       IN_UBUNTU_BASE_CONTAINER: 'true'
       OS_NAME: 'linux'
       SETUP_CONDA: 'true'
-    pool: lgb_agent_pool_ado
+    pool: lightgbm_agent_pool_ado
     container: ubuntu-latest
     strategy:
       matrix:

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -13,6 +13,7 @@ dependencies:
   - r-matrix=1.6_5
   - r-pkgdown=2.1.1
   - r-roxygen2=7.3.2
-  - scikit-learn>=1.6.1
+  # skipping scikit-learn 1.7.1 because of the problems described in https://github.com/microsoft/LightGBM/issues/6978
+  - scikit-learn>=1.6.1,!=1.7.1
   - sphinx>=8.1.3
   - sphinx_rtd_theme>=3.0.1


### PR DESCRIPTION
Fixes all of the blocking CI problems.

## Problem 1 - docs build broken by `scikit-learn` 1.7.1

Fixes #6978 

It looks like this was a formatting mistake in `scikit-learn` 1.7.1 docstrings (https://github.com/scikit-learn/scikit-learn/issues/31804) that will be fixed in the next release of `scikit-learn` (https://github.com/scikit-learn/scikit-learn/pull/31805).

So simply skipping that version in LightGBM's docs build should be enough to avoid this.

## Problem 2 - tests failing on latest `pandas` 3.0 nightlies

Fixes #6980

In the latest `pandas` 3.0 nightlies, it seems like `pd.Series(["a", "b"])` returns a series with the new `StringDType` instead of the `object` dtype, which breaks one of LightGBM's tests (via changing the `repr()` of the `Series` in an error message).

That's blocking CI, so this fixes that too.

## Problem 3 - Azure DevOps jobs not running

See https://github.com/microsoft/LightGBM/issues/6949#issuecomment-3121444254