### PR TITLE
[python-package] Suppress confusing warning in dask module

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -549,8 +549,9 @@ def _train(
     for param_alias in _ConfigAliases.get("num_machines", "num_threads"):
         if param_alias in params:
             # Only warn if user-set parameter will be overwritten
-            if params[param_alias] not in (-1, None):
-                _log_warning(f"Parameter {param_alias} will be ignored.")
+            val = params[param_alias]
+            if val not in (-1, None):
+                _log_warning(f"Parameter {param_alias}={val} will be ignored. This is automatically adjusted to match the Dask cluster. To suppress this warning, pass {param_alias}=-1 or remove {param_alias} entirely.")
             params.pop(param_alias)
 
     # Split arrays/dataframes into parts. Arrange parts into dicts to enforce co-locality

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -548,7 +548,9 @@ def _train(
     #   * 'num_threads': overridden to match nthreads on each Dask process
     for param_alias in _ConfigAliases.get("num_machines", "num_threads"):
         if param_alias in params:
-            _log_warning(f"Parameter {param_alias} will be ignored.")
+            # Only warn if user-set parameter will be overwritten
+            if params[param_alias] not in (-1, None):
+                _log_warning(f"Parameter {param_alias} will be ignored.")
             params.pop(param_alias)
 
     # Split arrays/dataframes into parts. Arrange parts into dicts to enforce co-locality


### PR DESCRIPTION
This commit prevents `UserWarning: Parameter n_jobs will be ignored.` from being emitted each time a model is trained with the `lightgbm.dask` estimators.

The warning is now only shown if a user provides a specific, non-default value (neither None nor -1).

Fixes #6797