### PR TITLE
[ci] use 'pre-commit' to run 'cmakelint'

### DIFF
--- a/.ci/lint-cpp.sh
+++ b/.ci/lint-cpp.sh
@@ -9,19 +9,6 @@ cpplint \
 || exit 1
 echo "done running cpplint"
 
-echo "running cmakelint"
-find \
-    . \
-    -type f \
-    \( -name CMakeLists.txt -o -path "./cmake/*.cmake" \) \
-    -not -path './external_libs/*' \
-    -exec cmakelint \
-    --linelength=120 \
-    --filter=-convention/filename,-package/stdargs,-readability/wonkycase \
-    {} \+ \
-|| exit 1
-echo "done running cmakelint"
-
 echo "checking that all OpenMP pragmas specify num_threads()"
 get_omp_pragmas_without_num_threads() {
     grep \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -105,7 +105,6 @@ if [[ $TASK == "lint" ]]; then
     conda create -q -y -n "${CONDA_ENV}" \
         "${CONDA_PYTHON_REQUIREMENT}" \
         'biome>=1.9.3' \
-        'cmakelint>=1.4.3' \
         'cpplint>=1.6.0' \
         'matplotlib-base>=3.9.1' \
         'mypy>=1.11.1' \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,11 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/cmake-lint/cmake-lint
+    rev: '1.4.3'
+    hooks:
+      - id: cmakelint
+        args: ["--linelength=120", "--filter=-convention/filename,-package/stdargs,-readability/wonkycase"]
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.37.1
     hooks:


### PR DESCRIPTION
Similar to #6989, this proposes moving `cmakelint` into `pre-commit`, to simplify test scripts