### PR TITLE
[docs] [python-package] document how to run Python tests

### DIFF
--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -348,13 +348,11 @@ To check that a contribution to the package matches its style expectations, run 
 
     bash .ci/lint-python-bash.sh
 
-To run the tests locally and compute test coverage, run the following from the root of the repo.
+To run the tests locally and compute test coverage, install the Python package using one of the options mentioned above.
+Then run the following from the root of the repo.
 
 .. code:: sh
 
-    cmake -B build -S .
-    cmake --build build --target _lightgbm -j4
-    sh build-python.sh install --precompile
     pytest \
         --cov=lightgbm \
         --cov-report="term" \

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -348,6 +348,21 @@ To check that a contribution to the package matches its style expectations, run 
 
     bash .ci/lint-python-bash.sh
 
+To run the tests locally and compute test coverage, run the following from the root of the repo.
+
+.. code:: sh
+
+    cmake -B build -S .
+    cmake --build build --target _lightgbm -j4
+    sh build-python.sh install --precompile
+    pytest \
+        --cov=lightgbm \
+        --cov-report="term" \
+        --cov-report="html:htmlcov" \
+        tests/python_package_test/
+
+Then open `htmlcov/index.html` to view a clickable coverage report.
+
 .. |License| image:: https://img.shields.io/github/license/microsoft/lightgbm.svg
    :target: https://github.com/microsoft/LightGBM/blob/master/LICENSE
 .. |Python Versions| image:: https://img.shields.io/pypi/pyversions/lightgbm.svg?logo=python&logoColor=white


### PR DESCRIPTION
Contributes to #6350

Proposes adding docs for how to run the Python tests and calculate test coverage.

## Notes for Reviewers

I've enabled this branch at https://app.readthedocs.org/projects/lightgbm/, so we can see the rendered docs

And here is the coverage report as of latest `master`:

[htmlcov.zip](https://github.com/user-attachments/files/21650546/htmlcov.zip)

With all optional dependencies installed, we have pretty good statement coverage!

<img width="785" height="218" alt="image" src="https://github.com/user-attachments/assets/d47c4e63-f0d0-4514-8b33-38e4d7a5533b" />

*(I'll open a separate issue tracking some areas that need more tests)*