### PR TITLE
[python-package] Remove insecure pickle usage & add runtime warnings to prevent RCE

### DIFF
--- a/examples/python-guide/advanced_example.py
+++ b/examples/python-guide/advanced_example.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import copy
 import json
-import pickle
 from pathlib import Path
 
 import numpy as np
@@ -87,18 +86,6 @@ y_pred = bst.predict(X_test)
 auc_loaded_model = roc_auc_score(y_test, y_pred)
 print(f"The ROC AUC of loaded model's prediction is: {auc_loaded_model}")
 
-print("Dumping and loading model with pickle...")
-# dump model with pickle
-with open("model.pkl", "wb") as fout:
-    pickle.dump(gbm, fout)
-# load model with pickle to predict
-with open("model.pkl", "rb") as fin:
-    pkl_bst = pickle.load(fin)
-# can predict with any iteration when loaded in pickle way
-y_pred = pkl_bst.predict(X_test, num_iteration=7)
-# eval with loaded model
-auc_pickled_model = roc_auc_score(y_test, y_pred)
-print(f"The ROC AUC of pickled model's prediction is: {auc_pickled_model}")
 
 # continue training
 # init_model accepts:

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3706,6 +3706,11 @@ class Booster:
         return this
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
+        _log_warning(
+            "Starting from version 4.0.0, LightGBM models saved as pickle files might contain "
+            "malicious code and lead to security risks. "
+            "Consider loading models from text files to avoid this issue."
+        )
         model_str = state.get("_handle", state.get("handle", None))
         if model_str is not None:
             handle = ctypes.c_void_p()


### PR DESCRIPTION
This PR combines patches that:
- Add runtime warnings when unpickling LightGBM models to highlight security risks.
- Remove unsafe pickle examples from documentation and examples.
- Update docs to recommend safer alternatives for model serialization.