### PR TITLE
[ci] [python-package] skip ranking Dask tests on macOS

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -668,6 +668,13 @@ def test_regressor_custom_objective(output, cluster):
         assert_eq(p2, y, **assert_precision)
 
 
+@pytest.mark.xfail(
+    platform.lower().startswith("darwin"),
+    reason=(
+        "learning-to-rank Dask tests are unreliable on macOS. "
+        "See https://github.com/microsoft/LightGBM/issues/4074#issuecomment-3124996317"
+    ),
+)
 @pytest.mark.parametrize("output", ["array", "dataframe", "dataframe-with-categorical"])
 @pytest.mark.parametrize("group", [None, group_sizes])
 @pytest.mark.parametrize("boosting_type", boosting_types)


### PR DESCRIPTION
Over the last few months, we've observed that one Python test covering `DaskLGBMRanker` is very flaky on macOS: https://github.com/microsoft/LightGBM/issues/4074#issuecomment-2989878257

This has been happening so frequently that it's really adding friction to development.

This PR proposes xfailing that test, so that it's still run (so we can observe how often it fails) but its failures don't result in a non-0 exit code and CI job failures.

## Notes for Reviewers

`pytest` docs on how `xfail` works: https://docs.pytest.org/en/stable/how-to/skipping.html

### How I tested this

Ran just this test on my Mac:

```shell
pytest tests/python_package_test/test_dask.py::test_ranker
```

Produced output like this:

```text
======================================================================= test session starts =======================================================================
platform darwin -- Python 3.11.9, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/jlamb/repos/LightGBM
plugins: cov-6.2.1, hypothesis-6.115.2
collected 48 items                                                                                                                                                

tests/python_package_test/test_dask.py XXXxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXxXXXXXXxXXXX                                                                     [100%]

======================================================================== warnings summary =========================================================================
tests/python_package_test/test_dask.py: 48 warnings
  /Users/jlamb/miniforge3/envs/lgb-dev/lib/python3.11/site-packages/lightgbm/dask.py:551: UserWarning: Parameter n_jobs will be ignored.
    _log_warning(f"Parameter {param_alias} will be ignored.")

tests/python_package_test/test_dask.py: 98 warnings
  /Users/jlamb/miniforge3/envs/lgb-dev/lib/python3.11/site-packages/sklearn/utils/validation.py:2739: UserWarning: X does not have valid feature names, but LGBMRanker was fitted with feature names
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==== 3 xfailed, 45 xpassed, 146 warnings in 37.33s ========
```

That last line varied a bit on each run, consistent with this test being flaky (e.g. sometimes all 48 cases `xpassed`).
