### PR TITLE
[docs] [ci] automatically re-generate parameter docs via pre-commit

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -139,12 +139,6 @@ if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
         linkchecker --config=./docs/.linkcheckerrc ./docs/_build/html/*.html || exit 1
         exit 0
     fi
-    # check the consistency of parameters' descriptions and other stuff
-    cp ./docs/Parameters.rst ./docs/Parameters-backup.rst
-    cp ./src/io/config_auto.cpp ./src/io/config_auto-backup.cpp
-    python ./.ci/parameter-generator.py || exit 1
-    diff ./docs/Parameters-backup.rst ./docs/Parameters.rst || exit 1
-    diff ./src/io/config_auto-backup.cpp ./src/io/config_auto.cpp || exit 1
     exit 0
 fi
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,15 @@ repos:
     hooks:
       - id: yamllint
         args: ["--strict"]
+  - repo: local
+    hooks:
+      - id: regenerate-parameters
+        name: regenerate-parameters
+        entry: python
+        args:
+          - ./.ci/parameter-generator.py
+        language: python
+        pass_filenames: false
   - repo: https://github.com/rstcheck/rstcheck
     rev: v6.2.5
     hooks:


### PR DESCRIPTION
This project uses a script to auto-generate https://lightgbm.readthedocs.io/en/latest/Parameters.html from comments in https://github.com/microsoft/LightGBM/blob/master/include/LightGBM/config.h

To check that that's been done, we have some code that manually checks specific files with `diff`

https://github.com/microsoft/LightGBM/blob/97ff708708d9e8b00cc98834b916d6c7493e1321/.ci/test.sh#L142-L147

This is often missed and has to be taught to new contributors, for example: https://github.com/microsoft/LightGBM/pull/6863#pullrequestreview-2678992510

To help simplify CI scripts and hopefully reduce friction for contributors, this proposes automatically re-running that via `pre-commit`.

_(thanks to my colleague @KyleFromNVIDIA for introducing me to this pattern)_

## Notes for Reviewers

### How I tested this

Changed a comment in `config.h`, ran `pre-commit run --all-files`, and saw `pre-commit` fail (exit code 1) like this:

```text
regenerate-parameters....................................................Failed
- hook id: regenerate-parameters
- files were modified by this hook
```