### PR TITLE
[ci] separate configs and scripts for linting and docs CI

### DIFF
--- a/.ci/lint-all.sh
+++ b/.ci/lint-all.sh
@@ -26,8 +26,5 @@ bash ./.ci/run-pre-commit-mypy.sh || exit 1
 echo "Linting R code"
 Rscript ./.ci/lint-r-code.R "$(pwd)" || exit 1
 
-echo "Linting C++ code"
-bash ./.ci/lint-cpp.sh || exit 1
-
 echo "Linting JavaScript code"
 bash ./.ci/lint-js.sh || exit 1

--- a/.ci/lint-all.sh
+++ b/.ci/lint-all.sh
@@ -19,7 +19,6 @@ conda create -q -y -n test-env \
 # shellcheck disable=SC1091
 source activate test-env
 
-echo "Linting Python and bash code"
 bash ./.ci/run-pre-commit-mypy.sh || exit 1
 
 echo "Linting R code"

--- a/.ci/lint-all.sh
+++ b/.ci/lint-all.sh
@@ -9,7 +9,6 @@ pwsh -file ./.ci/lint-powershell.ps1 || exit 1
 conda create -q -y -n test-env \
     "python=3.13[build=*_cp*]" \
     'biome>=1.9.3' \
-    'cpplint>=1.6.0' \
     'matplotlib-base>=3.9.1' \
     'mypy>=1.11.1' \
     'pre-commit>=3.8.0' \

--- a/.ci/lint-all.sh
+++ b/.ci/lint-all.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e -E -u -o pipefail
+
+pwsh -command "Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -SkipPublisherCheck"
+echo "Linting PowerShell code"
+pwsh -file ./.ci/lint-powershell.ps1 || exit 1
+
+conda create -q -y -n test-env \
+    "python=3.13[build=*_cp*]" \
+    'biome>=1.9.3' \
+    'cpplint>=1.6.0' \
+    'matplotlib-base>=3.9.1' \
+    'mypy>=1.11.1' \
+    'pre-commit>=3.8.0' \
+    'pyarrow-core>=17.0' \
+    'scikit-learn>=1.5.2' \
+    'r-lintr>=3.1.2'
+
+# shellcheck disable=SC1091
+source activate test-env
+
+echo "Linting Python and bash code"
+bash ./.ci/run-pre-commit-mypy.sh || exit 1
+
+echo "Linting R code"
+Rscript ./.ci/lint-r-code.R "$(pwd)" || exit 1
+
+echo "Linting C++ code"
+bash ./.ci/lint-cpp.sh || exit 1
+
+echo "Linting JavaScript code"
+bash ./.ci/lint-js.sh || exit 1

--- a/.ci/test-docs.sh
+++ b/.ci/test-docs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e -E -u -o pipefail
+
+conda env create \
+    --name test-env \
+    --file ./docs/env.yml \
+|| exit 1
+
+# shellcheck disable=SC1091
+source activate test-env
+
+# build docs
+make -C docs html || exit 1
+
+if [[ $TASK == "check-links" ]]; then
+    # check docs for broken links
+    pip install 'linkchecker>=10.5.0'
+    linkchecker --config=./docs/.linkcheckerrc ./docs/_build/html/*.html || exit 1
+fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -98,50 +98,6 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-if [[ $TASK == "lint" ]]; then
-    pwsh -command "Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -SkipPublisherCheck"
-    echo "Linting PowerShell code"
-    pwsh -file ./.ci/lint-powershell.ps1 || exit 1
-    conda create -q -y -n "${CONDA_ENV}" \
-        "${CONDA_PYTHON_REQUIREMENT}" \
-        'biome>=1.9.3' \
-        'cpplint>=1.6.0' \
-        'matplotlib-base>=3.9.1' \
-        'mypy>=1.11.1' \
-        'pre-commit>=3.8.0' \
-        'pyarrow-core>=17.0' \
-        'scikit-learn>=1.5.2' \
-        'r-lintr>=3.1.2'
-    # shellcheck disable=SC1091
-    source activate "${CONDA_ENV}"
-    echo "Linting Python and bash code"
-    bash ./.ci/run-pre-commit-mypy.sh || exit 1
-    echo "Linting R code"
-    Rscript ./.ci/lint-r-code.R "${BUILD_DIRECTORY}" || exit 1
-    echo "Linting C++ code"
-    bash ./.ci/lint-cpp.sh || exit 1
-    echo "Linting JavaScript code"
-    bash ./.ci/lint-js.sh || exit 1
-    exit 0
-fi
-
-if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
-    conda env create \
-        -n "${CONDA_ENV}" \
-        --file ./docs/env.yml || exit 1
-    # shellcheck disable=SC1091
-    source activate "${CONDA_ENV}"
-    # build docs
-    make -C docs html || exit 1
-    if [[ $TASK == "check-links" ]]; then
-        # check docs for broken links
-        pip install 'linkchecker>=10.5.0'
-        linkchecker --config=./docs/.linkcheckerrc ./docs/_build/html/*.html || exit 1
-        exit 0
-    fi
-    exit 0
-fi
-
 if [[ $PYTHON_VERSION == "3.9" ]]; then
     CONDA_REQUIREMENT_FILE="${BUILD_DIRECTORY}/.ci/conda-envs/ci-core-py39.txt"
 else

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -10,7 +10,6 @@ on:
 env:
   COMPILER: gcc
   OS_NAME: 'linux'
-  PYTHON_VERSION: '3.13'
   TASK: 'check-links'
 
 jobs:
@@ -25,8 +24,7 @@ jobs:
           submodules: false
       - name: Setup and run tests
         run: |
-          export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export CONDA=${HOME}/miniforge
           export PATH=${CONDA}/bin:${HOME}/.local/bin:${PATH}
           $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
-          $GITHUB_WORKSPACE/.ci/test.sh || exit 1
+          $GITHUB_WORKSPACE/.ci/test-docs.sh || exit 1

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -40,8 +40,8 @@ jobs:
           export PATH=${CONDA}/bin:$HOME/.local/bin:${PATH}
           $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
           $GITHUB_WORKSPACE/.ci/lint-all.sh || exit 1
-  python-check-docs:
-    name: python-check-docs
+  check-docs:
+    name: check-docs
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -98,7 +98,7 @@ jobs:
   all-static-analysis-jobs-successful:
     if: always()
     runs-on: ubuntu-latest
-    needs: [lint, python-check-docs, r-check-docs]
+    needs: [lint, check-docs, r-check-docs]
     steps:
       - name: Note that all tests succeeded
         uses: re-actors/alls-green@v1.2.2

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -33,9 +33,8 @@ jobs:
           submodules: false
       - name: Setup and run tests
         shell: bash
-        env:
-          TASK: lint
         run: |
+          export TASK=lint
           export CONDA=${HOME}/miniforge
           export PATH=${CONDA}/bin:$HOME/.local/bin:${PATH}
           $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
@@ -52,9 +51,8 @@ jobs:
           submodules: false
       - name: Setup and run tests
         shell: bash
-        env:
-          TASK: check-docs
         run: |
+          export TASK=check-docs
           export CONDA=${HOME}/miniforge
           export PATH=${CONDA}/bin:$HOME/.local/bin:${PATH}
           $GITHUB_WORKSPACE/.ci/setup.sh || exit 1

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -19,19 +19,12 @@ env:
   COMPILER: 'gcc'
   MAKEFLAGS: '-j4'
   OS_NAME: 'linux'
-  PYTHON_VERSION: '3.13'
 
 jobs:
-  test:
-    name: ${{ matrix.task }}
+  lint:
+    name: lint
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - task: lint
-          - task: check-docs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,13 +33,32 @@ jobs:
           submodules: false
       - name: Setup and run tests
         shell: bash
+        env:
+          TASK: lint
         run: |
-          export TASK="${{ matrix.task }}"
-          export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export CONDA=${HOME}/miniforge
           export PATH=${CONDA}/bin:$HOME/.local/bin:${PATH}
           $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
-          $GITHUB_WORKSPACE/.ci/test.sh || exit 1
+          $GITHUB_WORKSPACE/.ci/lint-all.sh || exit 1
+  python-check-docs:
+    name: python-check-docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 5
+          submodules: false
+      - name: Setup and run tests
+        shell: bash
+        env:
+          TASK: check-docs
+        run: |
+          export CONDA=${HOME}/miniforge
+          export PATH=${CONDA}/bin:$HOME/.local/bin:${PATH}
+          $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
+          $GITHUB_WORKSPACE/.ci/test-docs.sh || exit 1
   r-check-docs:
     name: r-package-check-docs
     timeout-minutes: 60
@@ -86,7 +98,7 @@ jobs:
   all-static-analysis-jobs-successful:
     if: always()
     runs-on: ubuntu-latest
-    needs: [test, r-check-docs]
+    needs: [lint, python-check-docs, r-check-docs]
     steps:
       - name: Note that all tests succeeded
         uses: re-actors/alls-green@v1.2.2


### PR DESCRIPTION
Contributes to #6949 and #6901, by moving more logic out of `test.sh` and splitting the linting and docs-testing jobs out into separate CI configs and scripts.