### PR TITLE
[ci] [python-package] work around missing pyarrow manylinux nightlies

### DIFF
--- a/.ci/pip-envs/requirements-latest.txt
+++ b/.ci/pip-envs/requirements-latest.txt
@@ -12,7 +12,7 @@ cffi>=1.17.1
 matplotlib>=3.11.0.dev0
 numpy>=2.4.0.dev0
 pandas>=3.0.0.dev0
-pyarrow>=22.0.0.dev0
+pyarrow>=21.0.0.dev0
 scikit-learn>=1.8.dev0
 scipy>=1.17.0.dev0
 


### PR DESCRIPTION
The `test-python-latest` CI job is failing on multiple PRs:

```text
ERROR: Ignored the following versions that require a different python version: 1.21.2 Requires-Python >=3.7,<3.11; 1.21.3 Requires-Python >=3.7,<3.11; 1.21.4 Requires-Python >=3.7,<3.11; 1.21.5 Requires-Python >=3.7,<3.11; 1.21.6 Requires-Python >=3.7,<3.11; 1.26.0 Requires-Python >=3.9,<3.13; 1.26.1 Requires-Python >=3.9,<3.13
ERROR: Could not find a version that satisfies the requirement pyarrow>=22.0.0.dev0 (from versions: 0.9.0, 0.10.0, 0.11.0, 0.11.1, 0.12.0, 0.12.1, 0.13.0, 0.14.0, 0.15.1, 0.16.0, 0.17.0, 0.17.1, 1.0.0, 1.0.1, 2.0.0, 3.0.0, 4.0.0, 4.0.1, 5.0.0, 6.0.0, 6.0.1, 7.0.0, 8.0.0, 9.0.0, 10.0.0, 10.0.1, 11.0.0, 12.0.0, 12.0.1, 13.0.0, 14.0.0, 14.0.1, 14.0.2, 15.0.0, 15.0.1, 15.0.2, 16.0.0, 16.1.0, 17.0.0, 18.0.0, 18.1.0, 19.0.0, 19.0.1, 20.0.0, 21.0.0)
ERROR: No matching distribution found for pyarrow>=22.0.0.dev0
```

([build link](https://github.com/microsoft/LightGBM/actions/runs/17116123756/job/48547460283?pr=7002#step:4:62))

Look at https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pyarrow/ ... the only Linux wheels are `*-cp313-cp313t-*` (free-threading).

Relaxing the spec in that CI job to `pyarrow>=21.0.0.dev0` will allow the job to pick up `pyarrow==21.0.0` from `pypi.org`, and also to pick up newer nightlies if they end up on that index again.

## Notes for Reviewers

I've reported this at https://github.com/apache/arrow/issues/47381 as well

Not sure if it's intentional or not.