### PR TITLE
Draft: [python-package] Sample from Sequence objects in batches, rather than row-by-row

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -911,8 +911,9 @@ class Sequence(abc.ABC):
 
         # Get total row number.
         >>> len(seq)
-        # Random access by row index. Used for data sampling.
+        # Random access by row index, or by list of indexes. Used for data sampling.
         >>> seq[10]
+        >>> seq[[0, 2, 5, 7, 12]]
         # Range data access. Used to read data in batch when constructing Dataset.
         >>> seq[0:100]
         # Optionally specify batch_size to control range data read size.


### PR DESCRIPTION
Currently, when the Python package's `Dataset` class is constructed with a list of user-supplied `Sequence` objects, the `Dataset` samples rows at random in a row-by-row manner. (The number of samples is controlled by the `bin_construct_sample_cnt` parameter.)

With this MR, the `Dataset` class will sample rows in batched fashion, by batching the randomly-generated row indices according to the `Sequence` objects' length and batch size. In cases where all rows are being sampled, the `Sequence` objects are indexed with slices.

The goal is to allow user-defined `Sequence` classes to provide data more efficiently or with better overall performance. 

See #7006 .