### PR TITLE
[CUDA] [fix] enable max_depth in cuda tree learner - fix build

### DIFF
--- a/include/LightGBM/cuda/cuda_tree.hpp
+++ b/include/LightGBM/cuda/cuda_tree.hpp
@@ -99,7 +99,7 @@ class CUDATree : public Tree {
 
   double* cuda_leaf_value_ref() const { return cuda_leaf_value_; }
 
-  int host_leaf_depth(int leaf_index) { 
+  int host_leaf_depth(int leaf_index) {
     if (leaf_index >= 0 && leaf_index < num_leaves_) {
       return host_leaf_depth_[leaf_index];
     } else {

--- a/src/treelearner/cuda/cuda_best_split_finder.cpp
+++ b/src/treelearner/cuda/cuda_best_split_finder.cpp
@@ -339,7 +339,7 @@ void CUDABestSplitFinder::FindBestSplitsForLeaf(
   const uint8_t larger_num_bits_in_histogram_bins) {
   const bool is_smaller_leaf_valid = (num_data_in_smaller_leaf > min_data_in_leaf_ &&
     sum_hessians_in_smaller_leaf > min_sum_hessian_in_leaf_ &&
-    ((max_depth_ > 0 && smaller_leaf_depth > 0 && smaller_leaf_depth < max_depth_) || (max_depth_ <= 0)));
+    ((max_depth_ > 0 && smaller_leaf_depth > 0 && smaller_leaf_depth <= max_depth_) || (max_depth_ <= 0)));
   const bool is_larger_leaf_valid = (num_data_in_larger_leaf > min_data_in_leaf_ &&
     sum_hessians_in_larger_leaf > min_sum_hessian_in_leaf_ && larger_leaf_index >= 0 &&
     ((max_depth_ > 0 && larger_leaf_depth > 0 && larger_leaf_depth < max_depth_) || (max_depth_ <= 0)));

--- a/src/treelearner/cuda/cuda_best_split_finder.cpp
+++ b/src/treelearner/cuda/cuda_best_split_finder.cpp
@@ -331,7 +331,7 @@ void CUDABestSplitFinder::FindBestSplitsForLeaf(
   const data_size_t num_data_in_larger_leaf,
   const double sum_hessians_in_smaller_leaf,
   const double sum_hessians_in_larger_leaf,
-  const int small_leaf_depth,
+  const int smaller_leaf_depth,
   const int larger_leaf_depth,
   const score_t* grad_scale,
   const score_t* hess_scale,
@@ -339,10 +339,10 @@ void CUDABestSplitFinder::FindBestSplitsForLeaf(
   const uint8_t larger_num_bits_in_histogram_bins) {
   const bool is_smaller_leaf_valid = (num_data_in_smaller_leaf > min_data_in_leaf_ &&
     sum_hessians_in_smaller_leaf > min_sum_hessian_in_leaf_ &&
-    (max_depth > 0 && smaller_leaf_depth > 0 && smaller_leaf_depth < max_depth));
+    (max_depth_ > 0 && smaller_leaf_depth > 0 && smaller_leaf_depth < max_depth_));
   const bool is_larger_leaf_valid = (num_data_in_larger_leaf > min_data_in_leaf_ &&
     sum_hessians_in_larger_leaf > min_sum_hessian_in_leaf_ && larger_leaf_index >= 0 &&
-    (max_depth > 0 && larger_leaf_depth > 0 && larger_leaf_depth < max_depth));
+    (max_depth_ > 0 && larger_leaf_depth > 0 && larger_leaf_depth < max_depth_));
   if (grad_scale != nullptr && hess_scale != nullptr) {
     LaunchFindBestSplitsDiscretizedForLeafKernel(smaller_leaf_splits, larger_leaf_splits,
       smaller_leaf_index, larger_leaf_index, is_smaller_leaf_valid, is_larger_leaf_valid,

--- a/src/treelearner/cuda/cuda_best_split_finder.cpp
+++ b/src/treelearner/cuda/cuda_best_split_finder.cpp
@@ -339,10 +339,10 @@ void CUDABestSplitFinder::FindBestSplitsForLeaf(
   const uint8_t larger_num_bits_in_histogram_bins) {
   const bool is_smaller_leaf_valid = (num_data_in_smaller_leaf > min_data_in_leaf_ &&
     sum_hessians_in_smaller_leaf > min_sum_hessian_in_leaf_ &&
-    (max_depth_ > 0 && smaller_leaf_depth > 0 && smaller_leaf_depth < max_depth_));
+    ((max_depth_ > 0 && smaller_leaf_depth > 0 && smaller_leaf_depth < max_depth_) || (max_depth_ <= 0)));
   const bool is_larger_leaf_valid = (num_data_in_larger_leaf > min_data_in_leaf_ &&
     sum_hessians_in_larger_leaf > min_sum_hessian_in_leaf_ && larger_leaf_index >= 0 &&
-    (max_depth_ > 0 && larger_leaf_depth > 0 && larger_leaf_depth < max_depth_));
+    ((max_depth_ > 0 && larger_leaf_depth > 0 && larger_leaf_depth < max_depth_) || (max_depth_ <= 0)));
   if (grad_scale != nullptr && hess_scale != nullptr) {
     LaunchFindBestSplitsDiscretizedForLeafKernel(smaller_leaf_splits, larger_leaf_splits,
       smaller_leaf_index, larger_leaf_index, is_smaller_leaf_valid, is_larger_leaf_valid,

--- a/src/treelearner/cuda/cuda_best_split_finder.cpp
+++ b/src/treelearner/cuda/cuda_best_split_finder.cpp
@@ -342,7 +342,7 @@ void CUDABestSplitFinder::FindBestSplitsForLeaf(
     ((max_depth_ > 0 && smaller_leaf_depth > 0 && smaller_leaf_depth <= max_depth_) || (max_depth_ <= 0)));
   const bool is_larger_leaf_valid = (num_data_in_larger_leaf > min_data_in_leaf_ &&
     sum_hessians_in_larger_leaf > min_sum_hessian_in_leaf_ && larger_leaf_index >= 0 &&
-    ((max_depth_ > 0 && larger_leaf_depth > 0 && larger_leaf_depth < max_depth_) || (max_depth_ <= 0)));
+    ((max_depth_ > 0 && larger_leaf_depth > 0 && larger_leaf_depth <= max_depth_) || (max_depth_ <= 0)));
   if (grad_scale != nullptr && hess_scale != nullptr) {
     LaunchFindBestSplitsDiscretizedForLeafKernel(smaller_leaf_splits, larger_leaf_splits,
       smaller_leaf_index, larger_leaf_index, is_smaller_leaf_valid, is_larger_leaf_valid,

--- a/src/treelearner/cuda/cuda_best_split_finder.hpp
+++ b/src/treelearner/cuda/cuda_best_split_finder.hpp
@@ -68,6 +68,8 @@ class CUDABestSplitFinder {
     const data_size_t num_data_in_larger_leaf,
     const double sum_hessians_in_smaller_leaf,
     const double sum_hessians_in_larger_leaf,
+    const int smaller_leaf_depth,
+    const int larger_leaf_depth,
     const score_t* grad_scale,
     const score_t* hess_scale,
     const uint8_t smaller_num_bits_in_histogram_bins,

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -945,7 +945,7 @@ def test_max_depth_is_enforced(capsys):
         .value_counts()
         .index.max()
         <= 7
-    ), "Trained model contains trees deeper than max_depth = 6"
+    ), "Trained model contains splits deeper than max_depth = 6"
 
 
 # NOTE: this intentionally contains values where num_leaves <, ==, and > (max_depth^2)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -913,15 +913,38 @@ def test_feature_names_are_set_correctly_when_no_feature_names_passed_into_Datas
     assert ds.construct().feature_name == ["Column_0", "Column_1", "Column_2"]
 
 
-@pytest.mark.parametrize("max_depth", [4, 8, 12, 16])
-def test_max_depth_is_enforced(capsys, max_depth):
-    X, y = make_blobs(n_samples=1_000, n_features=1, centers=2)
-    model = lgb.LGBMRegressor(objective="binary", max_depth=max_depth, device=getenv("TASK"), verbose=0)
+def test_max_depth_is_enforced(capsys):
+    params = {
+        "objective": "binary",
+        "min_data": 10,
+        "num_leaves": 15,
+        "verbose": -1,
+        "num_threads": 1,
+        "max_bin": 255,
+        "gpu_use_dp": True,
+        "deterministic": True,
+        "random_state": 2,
+    }
+    X, y = make_blobs(n_samples=1_000, n_features=1, centers=2, random_state=2)
+    model = lgb.LGBMRegressor(**params)
     model.fit(X, y)
-    assert (
+    fitted_max_depth = (
         model.booster_.trees_to_dataframe().groupby("tree_index")["node_depth"].max().value_counts().index.max()
-        <= max_depth
-    ), f"Trained model contains trees deeper than max_depth = {max_depth}"
+    )
+    assert fitted_max_depth == 9, (
+        "This data generation and model fitting procedure should be deterministic within backends. Both cpu and cuda should result in models with maximal tree depth 9."
+    )
+    # set a constraining value of max_depth, i.e. lower than 9
+    constrained_model = lgb.LGBMRegressor(max_depth=6, **params)
+    constrained_model.fit(X, y)
+    assert (
+        constrained_model.booster_.trees_to_dataframe()
+        .groupby("tree_index")["node_depth"]
+        .max()
+        .value_counts()
+        .index.max()
+        <= 6
+    ), "Trained model contains trees deeper than max_depth = 6"
 
 
 # NOTE: this intentionally contains values where num_leaves <, ==, and > (max_depth^2)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -944,7 +944,7 @@ def test_max_depth_is_enforced(capsys):
         .max()
         .value_counts()
         .index.max()
-        <= 6
+        <= 7
     ), "Trained model contains trees deeper than max_depth = 6"
 
 

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -916,7 +916,7 @@ def test_feature_names_are_set_correctly_when_no_feature_names_passed_into_Datas
 @pytest.mark.parametrize("max_depth", [4, 8, 12, 16])
 def test_max_depth_is_enforced(capsys, max_depth):
     X, y = make_blobs(n_samples=1_000, n_features=1, centers=2)
-    model = lgb.LGBMRegressor(objective="binary", max_depth=max_depth, device=getenv("TASK"), verbose=0)
+    model = lgb.LGBMRegressor(objective="binary", max_depth=max_depth, verbose=0)
     model.fit(X, y)
     assert (
         model.booster_.trees_to_dataframe().groupby("tree_index")["node_depth"].max().value_counts().index.max()


### PR DESCRIPTION
Small changes to fix the cuda build for the PR https://github.com/microsoft/LightGBM/pull/6994. I also added a test checking the `max_depth` parameter is indeed enforced to the python package tests.

I tested this locally as follows:

## 1. Clone, modify and install `lightgbm` locally
```
git clone --recursive https://github.com/microsoft/LightGBM.git
cd LightGBM
git checkout fix-6969
# specific settings for my system
export CMAKE_ARGS="-DCMAKE_CUDA_ARCHITECTURES=80 -DCMAKE_CUDA_COMPILER=/usr/local/cuda-12.6/bin/nvcc -DCMAKE_CXX_FLAGS=-w"
sh ./build-python.sh install --cuda
```

My system:
- GPU: NVIDIA A100-SXM4-80GB
- Driver Version: 565.57.01
- CUDA Version: 12.6
- gcc Version: 13.4.0

## 2. Test that `max_depth` is indeed enforced (cf. Issue https://github.com/microsoft/LightGBM/issues/6969)

### Reproducible example
```python
import lightgbm as lgb
from sklearn.datasets import make_regression

# Generate synthetic regression data
X, y = make_regression(n_samples=1000, n_features=20, noise=0.1, random_state=42)

# Create and fit the LGBMRegressor with GPU support
model = lgb.LGBMRegressor(
    objective="regression",
    device="cuda",  # Use CUDA
    max_depth=10,
)
model.fit(X, y)

print("lightgbm version:", lgb.__version__)
print(model.booster_.trees_to_dataframe().groupby("tree_index")["node_depth"].max().value_counts().sort_index())
```

```
lightgbm version: 4.6.0.99
node_depth
8      3
9     11
10    86
Name: count, dtype: int64
```