### PR TITLE
[ci] skip conda setup on cpp-tests jobs

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -144,7 +144,7 @@ else  # Linux
     fi
 fi
 
-if [[ "${TASK}" != "r-package" ]]; then
+if [[ "${TASK}" != "cpp-tests" ]] && [[ "${TASK}" != "r-package" ]]; then
     if [[ $SETUP_CONDA != "false" ]]; then
         curl \
             -sL \


### PR DESCRIPTION
`cpp-tests` CI jobs just build LightGBM + its C++ tests and run them. They don't require Python or anything else provided via conda.

This proposes skipping conda setup on such jobs.

## Notes for Reviewers

### Benefits of this change

* faster CI
* reduced risk of accidentally using anything from conda (compilers, shared libraries, etc.) in those jobs