### PR TITLE
[ci] Add sha of cpplint commit to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,5 @@
 1b792e716682254c33ddb5eb845357e84018636d
 # enable ruff-format on main library Python code (#6336)
 dd31208ab7a7aea86762830697b00666f843ded9
+# enable whitespace/indent_namespace rule from cpplint (#7056)
+50f11a9f3c066eadee475ea567f9e9d49e6bb827


### PR DESCRIPTION
Refer to https://github.com/microsoft/LightGBM/pull/7056#pullrequestreview-3332789249.

> After this is merged, would you consider doing a followup PR adding this PR's commit to https://github.com/microsoft/LightGBM/blob/master/.git-blame-ignore-revs?