### PR TITLE
[python-package] Add test for converting a `ctypes` int64 pointer array to a NumPy array

### DIFF
--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2033,7 +2033,7 @@ def test_predict_contrib_int64():
     }
     booster = lgb.train(params, train_set=train_data, num_boost_round=5)
 
-    preds = booster.predict(X_test, pred_contrib=True, num_iteration=booster.best_iteration)
+    preds = booster.predict(X_test, pred_contrib=True)
 
     assert preds is not None
     assert preds.shape[0] == X_test.shape[0]


### PR DESCRIPTION
Contributes to: #7031

Adds test for `_cint64_array_to_numpy`:

https://github.com/microsoft/LightGBM/blob/5dbfcdc40900208e857e3acade22c34ae403be19/python-package/lightgbm/basic.py#L504-L509