### PR TITLE
[ci] resolve 'invalid spec' conda errors in Windows jobs

### DIFF
--- a/.ci/test-windows.ps1
+++ b/.ci/test-windows.ps1
@@ -69,7 +69,7 @@ if ($env:TASK -eq "swig") {
 conda init powershell
 conda activate
 conda config --set always_yes yes --set changeps1 no
-conda update -q -y conda "python=$env:PYTHON_VERSION[build=*_cp*]"
+conda install -q -y conda "python=$env:PYTHON_VERSION[build=*_cp*]"
 
 # print output of 'conda info', to help in submitting bug reports
 Write-Output "conda info:"


### PR DESCRIPTION
Fixes #6940

## Notes for Reviewers

### How I tested this

Looked at the logs on an Appveyor run, saw that the error did not appear and the correct Python version (CPython and the correct version) was installed.

```text
...
    python-3.9.23              |h8c5b53a_0_cpython        16.2 MB  conda-forge
    python_abi-3.9             |           8_cp39           7 KB  conda-forge
...
```

([MSVC build logs](https://ci.appveyor.com/project/guolinke/lightgbm/builds/53122015/job/ucq7prq9sssg9bml?fullLog=true#L167))


```text
...
    python-3.9.23              |h8c5b53a_0_cpython        16.2 MB  conda-forge
    python_abi-3.9             |           8_cp39           7 KB  conda-forge
...
```

([MINGW build logs](https://ci.appveyor.com/project/guolinke/lightgbm/builds/53122015/job/dtn6p4bls1lww9su?fullLog=true#L167))