### PR TITLE
[ci] [R-package] implement efficiency suggestions from lintr 3.3.0-1

### DIFF
--- a/.ci/lint-all.sh
+++ b/.ci/lint-all.sh
@@ -9,7 +9,7 @@ pwsh -file ./.ci/lint-powershell.ps1 || exit 1
 conda create -q -y -n test-env \
     "python=3.13[build=*_cp*]" \
     'pre-commit>=3.8.0' \
-    'r-lintr>=3.1.2'
+    'r-lintr>=3.3.0'
 
 # shellcheck disable=SC1091
 source activate test-env

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -150,7 +150,7 @@ Dataset <- R6::R6Class(
             cate_indices <- as.list(match(private$categorical_feature, private$colnames) - 1L)
 
             # Provided indices, but some indices are missing?
-            if (sum(is.na(cate_indices)) > 0L) {
+            if (anyNA(cate_indices)) {
               stop(
                 "lgb.Dataset.construct: supplied an unknown feature in categorical_feature: "
                 , sQuote(private$categorical_feature[is.na(cate_indices)], q = FALSE)

--- a/R-package/R/lgb.interprete.R
+++ b/R-package/R/lgb.interprete.R
@@ -83,7 +83,7 @@ lgb.interprete <- function(model,
   tree_index_mat_list <- lapply(
     X = leaf_index_mat_list
     , FUN = function(x) {
-      matrix(seq_len(length(x)) - 1L, ncol = num_class, byrow = TRUE)
+      matrix(seq_along(x) - 1L, ncol = num_class, byrow = TRUE)
     }
   )
 

--- a/R-package/demo/multiclass_custom_objective.R
+++ b/R-package/demo/multiclass_custom_objective.R
@@ -56,7 +56,7 @@ custom_multiclass_obj <- function(preds, dtrain) {
     grad <- prob
     subset_index <- as.matrix(
         data.frame(
-            seq_len(length(labels))
+            seq_along(labels)
             , labels + 1L
             , fix.empty.names = FALSE
         )
@@ -80,7 +80,7 @@ custom_multiclass_metric <- function(preds, dtrain) {
 
     subset_index <- as.matrix(
         data.frame(
-            seq_len(length(labels))
+            seq_along(labels)
             , labels + 1L
             , fix.empty.names = FALSE
         )

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -2571,7 +2571,7 @@ test_that("lgb.train() works with linear learners even if Dataset has missing va
   set.seed(708L)
   .new_dataset <- function() {
     values <- rnorm(100L)
-    values[sample(seq_len(length(values)), size = 10L)] <- NA_real_
+    values[sample(seq_along(values), size = 10L)] <- NA_real_
     X <- matrix(
       data = sample(values, size = 100L)
       , ncol = 1L
@@ -2619,7 +2619,7 @@ test_that("lgb.train() works with linear learners, bagging, and a Dataset that h
   set.seed(708L)
   .new_dataset <- function() {
     values <- rnorm(100L)
-    values[sample(seq_len(length(values)), size = 10L)] <- NA_real_
+    values[sample(seq_along(values), size = 10L)] <- NA_real_
     X <- matrix(
       data = sample(values, size = 100L)
       , ncol = 1L

--- a/build_r.R
+++ b/build_r.R
@@ -97,7 +97,7 @@ install_libs_content <- .replace_flag("use_msys2", USING_MSYS2, install_libs_con
 keyword_args <- parsed_args[["keyword_args"]]
 if (length(keyword_args) > 0L) {
   cmake_args_to_add <- NULL
-  for (i in seq_len(length(keyword_args))) {
+  for (i in seq_along(keyword_args)) {
     arg_name <- names(keyword_args)[[i]]
     define_name <- ARGS_TO_DEFINES[[arg_name]]
     arg_value <- shQuote(normalizePath(keyword_args[[arg_name]], winslash = "/"))


### PR DESCRIPTION
A new version of `{lintr}`, v3.3.0-1, was released on CRAN yesterday (https://cran.r-project.org/web/packages/lintr/index.html).

This fixes the new things it is finding.

```text
[any_is_na] anyNA(x) is better than any(is.na(x))
[boolean_arithmetic] Use any() to express logical aggregations. For example, replace length(which(x == y)) == 0 with !any(x == y).
[seq] Use seq_along(x) instead of seq_len(length(x)).
```

Happy to say those are all efficiency improvements 😁 

## Notes for Reviewers

CI will be blocked until this is resolved.