### PR TITLE
R-package] [ci] work around {yaml} R-devel issues

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -311,9 +311,7 @@ jobs:
       - name: Install development versions of some libraries
         run: |
           git clone https://github.com/r-lib/yaml.git /tmp/yaml
-          pushd /tmp/yaml
-          R CMD INSTALL .
-          popd
+          R CMD INSTALL /tmp/yaml
       - name: Install packages and run tests
         shell: bash
         run: |


### PR DESCRIPTION
See #7099

The latest CRAN release of `{yaml}` has compilation errors against the latest R-devel (https://github.com/microsoft/LightGBM/issues/7099#issuecomment-3621277033). This attempts to work around those by installing a development version of that package in CI.

