### PR TITLE
[python-package] fix mypy errors about __sklearn_tags__()

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1003,7 +1003,7 @@ def _predict(
             pred_contrib=pred_contrib,
             **kwargs,
         )
-        pred_row = predict_fn(data_row)
+        pred_row = predict_fn(data_row)  # type: ignore[misc]
         chunks: Tuple[int, ...] = (data.chunks[0],)
         map_blocks_kwargs = {}
         if len(pred_row.shape) > 1:

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1487,8 +1487,9 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
 
     def __sklearn_tags__(self) -> "_sklearn_Tags":
         tags = super().__sklearn_tags__()
-        tags.classifier_tags.multi_class = True
-        tags.classifier_tags.multi_label = False
+        if tags is not None:
+            tags.classifier_tags.multi_class = True
+            tags.classifier_tags.multi_label = False
         return tags
 
     def fit(  # type: ignore[override]


### PR DESCRIPTION
Contributes to #3867

Fixes these errors from `mypy`:

```text
sklearn.py:1490: error: Item "None" of "Any | None" has no attribute "classifier_tags"  [union-attr]
sklearn.py:1491: error: Item "None" of "Any | None" has no attribute "classifier_tags"  [union-attr]
dask.py:1006: error: Too many positional arguments for "_predict_part"  [misc]
```

After this, only 15 errors remain.