### PR TITLE
[python-package] add Literal type annotation for order variable in _np2d_to_np1d

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -191,7 +191,7 @@ def _np2d_to_np1d(mat: np.ndarray) -> Tuple[np.ndarray, int]:
         dtype = mat.dtype
     else:
         dtype = np.float32
-    order: Literal["C", "F"]
+    order: "Literal['C', 'F']"
     if mat.flags["F_CONTIGUOUS"]:
         order = "F"
         layout = _C_API_IS_COL_MAJOR


### PR DESCRIPTION
## Summary
Add `Literal` type annotation for `order` variable in `_np2d_to_np1d` function to fix mypy `call-overload` error with `np.asarray`.

## Mypy Error (before fix)
```text
python-package/lightgbm/basic.py:201: error: No overload variant of "asarray" matches argument types "ndarray[tuple[Any, ...], dtype[Any]]", "dtype[Any]", "str"  [call-overload]
```

## Related Issue
Fixes: https://github.com/microsoft/LightGBM/issues/3867

## Test Plan
- [x] Ran `pre-commit run mypy --files python-package/lightgbm/basic.py`
- [x] Verified mypy no longer reports call-overload error for line 201
