### PR TITLE
[c++] fix: fail fast if distributed connection retries exhausted

### DIFF
--- a/src/network/linkers_socket.cpp
+++ b/src/network/linkers_socket.cpp
@@ -212,6 +212,9 @@ void Linkers::Construct() {
           connect_fail_delay_time = static_cast<int>(connect_fail_delay_time * connect_fail_retry_delay_factor);
         }
       }
+      if (linkers_[out_rank] == nullptr) {
+        Log::Fatal("Failed to connect to rank %d after %d retries", out_rank, connect_fail_retry_cnt);
+      }
     }
   }
   // wait for listener


### PR DESCRIPTION
## Summary

Adds explicit null check after connection retry loop to fail fast with clear error message instead of crashing later with SIGSEGV.

## Problem

In `linkers_socket.cpp:196-216`, if all connection retries fail:
1. `linkers_[out_rank]` remains `nullptr` (initialized at line 56)
2. No error is raised - code continues silently
3. Later, `Send()`/`Recv()` in `linkers.h:245,257` dereference without null check
4. Result: **SIGSEGV** (null pointer dereference)

## Evidence

Tested by reducing retry count and connecting to unreachable address (`192.0.2.1`):

**Before fix:**
```
[Warning] Connecting to rank 1 failed, waiting for 200 milliseconds
[Warning] Connecting to rank 1 failed, waiting for 260 milliseconds
[Info] Finished initializing network
Segmentation fault (exit code 139)
```

**After fix:**
```
[Warning] Connecting to rank 1 failed, waiting for 200 milliseconds
[Warning] Connecting to rank 1 failed, waiting for 260 milliseconds
[Fatal] Failed to connect to rank 1 after 2 retries
(exit code 127 - normal error exit)
```

## Changes

- `src/network/linkers_socket.cpp`: Add null check after retry loop (3 lines)

## Test Plan

- [x] Pre-commit passes
- [x] Windows build compiles (MSVC)
- [x] Linux build compiles (GCC in WSL)
- [x] C++ unit tests pass (31/31)
- [x] Verified crash before fix (SIGSEGV)
- [x] Verified clean error after fix

## Related

- Contributes to investigation of #4074 (Dask tests randomly fail)