### PR TITLE
[python-package] Added test for plotting.ylim

### DIFF
--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -99,6 +99,17 @@ def test_plot_importance(params, breast_cancer_split, train_data):
     with pytest.raises(TypeError, match="xlim must be a tuple of 2 elements."):
         lgb.plot_importance(gbm0, title=None, xlabel=None, ylabel=None, xlim="not a tuple")
 
+    ax5 = lgb.plot_importance(gbm0, title=None, xlabel=None, ylabel=None, ylim=(0, 30))
+    assert isinstance(ax5, matplotlib.axes.Axes)
+    assert ax5.get_title() == ""
+    assert ax5.get_xlabel() == ""
+    assert ax5.get_ylabel() == ""
+    assert ax5.get_ylim() == (0, 30)
+    assert len(ax5.patches) <= 30
+
+    with pytest.raises(TypeError, match="ylim must be a tuple of 2 elements."):
+        lgb.plot_importance(gbm0, title=None, xlabel=None, ylabel=None, ylim="not a tuple")
+
     gbm2 = lgb.LGBMClassifier(n_estimators=10, num_leaves=3, verbose=-1, importance_type="gain")
     gbm2.fit(X_train, y_train)
 


### PR DESCRIPTION
Contributes to: #7031

[tested lines](https://github.com/microsoft/LightGBM/blob/f981fba730d1eaf26cfd6662155487e9b3d1109d/python-package/lightgbm/plotting.py#L269-L270)


## coverage before
<img width="777" height="280" alt="Screenshot 2026-01-29 at 8 42 40 PM" src="https://github.com/user-attachments/assets/de2ef8a6-7ab2-4120-a3f8-a4301b6d3b8d" />


## coverage after
<img width="763" height="304" alt="Screenshot 2026-01-29 at 7 28 23 PM" src="https://github.com/user-attachments/assets/8447646f-25a9-4d29-aeeb-971b519605ad" />

1 line difference in coverage for `/lightgbm/plotting.py`


