### PR TITLE
Allow creating bitsets larger than 2^32 elements for CEGB

### DIFF
--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -816,21 +816,21 @@ inline static std::vector<uint32_t> EmptyBitset(size_t n) {
 template<typename T>
 inline static void InsertBitset(std::vector<uint32_t>* vec, const T val) {
   auto& ref_v = *vec;
-  int i1 = val / 32;
-  int i2 = val % 32;
-  if (static_cast<int>(vec->size()) < i1 + 1) {
+  size_t i1 = val / 32;
+  size_t i2 = val % 32;
+  if (vec->size() < i1 + 1) {
     vec->resize(i1 + 1, 0);
   }
   ref_v[i1] |= (1 << i2);
 }
 
 template<typename T>
-inline static std::vector<uint32_t> ConstructBitset(const T* vals, int n) {
+inline static std::vector<uint32_t> ConstructBitset(const T* vals, size_t n) {
   std::vector<uint32_t> ret;
   for (int i = 0; i < n; ++i) {
-    int i1 = vals[i] / 32;
-    int i2 = vals[i] % 32;
-    if (static_cast<int>(ret.size()) < i1 + 1) {
+    size_t i1 = vals[i] / 32;
+    size_t i2 = vals[i] % 32;
+    if (ret.size() < i1 + 1) {
       ret.resize(i1 + 1, 0);
     }
     ret[i1] |= (1 << i2);
@@ -839,12 +839,12 @@ inline static std::vector<uint32_t> ConstructBitset(const T* vals, int n) {
 }
 
 template<typename T>
-inline static bool FindInBitset(const uint32_t* bits, int n, T pos) {
-  int i1 = pos / 32;
+inline static bool FindInBitset(const uint32_t* bits, size_t n, T pos) {
+  size_t i1 = pos / 32;
   if (i1 >= n) {
     return false;
   }
-  int i2 = pos % 32;
+  size_t i2 = pos % 32;
   return (bits[i1] >> i2) & 1;
 }
 

--- a/src/treelearner/cost_effective_gradient_boosting.hpp
+++ b/src/treelearner/cost_effective_gradient_boosting.hpp
@@ -130,7 +130,7 @@ class CostEfficientGradientBoosting {
         int real_idx = tmp_idx[i_input];
         Common::InsertBitset(
             &feature_used_in_data_,
-            train_data->num_data() * inner_feature_index + real_idx);
+            static_cast<size_t>(train_data->num_data()) * inner_feature_index + real_idx);
       }
     }
   }
@@ -154,8 +154,8 @@ class CostEfficientGradientBoosting {
       int real_idx = tmp_idx[i_input];
       if (Common::FindInBitset(
               feature_used_in_data_.data(),
-              train_data->num_data() * train_data->num_features(),
-              train_data->num_data() * feature_index + real_idx)) {
+              static_cast<size_t>(train_data->num_data()) * train_data->num_features(),
+              static_cast<size_t>(train_data->num_data()) * feature_index + real_idx)) {
         continue;
       }
       total += penalty;

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -814,14 +814,14 @@ void SerialTreeLearner::SplitInner(Tree* tree, int best_leaf, int* left_leaf,
   } else {
     std::vector<uint32_t> cat_bitset_inner =
         Common::ConstructBitset(best_split_info.cat_threshold.data(),
-                                best_split_info.num_cat_threshold);
+                                static_cast<size_t>(best_split_info.num_cat_threshold));
     std::vector<int> threshold_int(best_split_info.num_cat_threshold);
     for (int i = 0; i < best_split_info.num_cat_threshold; ++i) {
       threshold_int[i] = static_cast<int>(train_data_->RealThreshold(
           inner_feature_index, best_split_info.cat_threshold[i]));
     }
     std::vector<uint32_t> cat_bitset = Common::ConstructBitset(
-        threshold_int.data(), best_split_info.num_cat_threshold);
+        threshold_int.data(), static_cast<size_t>(best_split_info.num_cat_threshold));
 
     data_partition_->Split(best_leaf, train_data_, inner_feature_index,
                            cat_bitset_inner.data(),


### PR DESCRIPTION
I ran into an issue where I get
```
LightGBM/src/treelearner/cost_effective_gradient_boosting.hpp:62:52: runtime error: signed integer overflow: 3331 * 749988 cannot be represented in type 'int'
```
because my num_features * num_data > 2^32

Switching to size_t (goes up to 2^64 on 64 bit platforms) to alleviate this.


I tested it by re-running on my data after this feature, and was able to run without encountering the error.
