### PR TITLE
[python-package] Added test for pickling _InnerPredictor

### DIFF
--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -4867,3 +4867,14 @@ def test_equal_predict_from_row_major_and_col_major_data():
     preds_col = bst.predict(X_col)
 
     np.testing.assert_allclose(preds_row, preds_col)
+
+
+def test_inner_predictor_pickling() -> None:
+    X = np.random.default_rng(42).standard_normal((100, 4))
+    y = (X[:, 0] > 0).astype(float)
+    ds = lgb.Dataset(X, label=y, free_raw_data=False)
+    params = {"num_leaves": 4, "verbose": -1}
+
+    booster = lgb.train(params, ds, num_boost_round=3)
+    booster2 = lgb.train(params, ds, num_boost_round=3, init_model=booster)
+    pickle.dumps(booster2)


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/7031
**BEFORE**
<img width="486" height="175" alt="Screenshot 2026-02-22 at 1 27 24 PM" src="https://github.com/user-attachments/assets/0ba61197-fc90-44da-bd2d-fe592033c5b0" />

**AFTER**
<img width="501" height="175" alt="Screenshot 2026-02-22 at 1 30 44 PM" src="https://github.com/user-attachments/assets/cca4952b-5301-443c-8d33-3cb74c350f5d" />

4 line difference in coverage for `/lightgbm/basic.py`


**NOTE**
This only tests pickling. Unpickling requires a `__set_state__` that restores the `_handle` . Without it, the unpickled `_InnerPredictor` is not possible. Would you like me to open a separate issue for that fix?