### PR TITLE
[python-package] Added test for plot_metric ylim

### DIFF
--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -595,11 +595,11 @@ def test_plot_metrics(params, breast_cancer_split, train_data):
         lgb.plot_metric(evals_result0, metric="binary_logloss", xlim="not a tuple")
 
     ax6 = lgb.plot_metric(evals_result0, metric="binary_logloss", ylim=(0, 15), title=None, xlabel=None, ylabel=None)
-    assert isinstance(ax5, matplotlib.axes.Axes)
+    assert isinstance(ax6, matplotlib.axes.Axes)
     assert ax6.get_title() == ""
     assert ax6.get_xlabel() == ""
     assert ax6.get_ylabel() == ""
     assert ax6.get_ylim() == (0, 15)
 
     with pytest.raises(TypeError, match="ylim must be a tuple of 2 elements."):
-        lgb.plot_metric(evals_result0, metric="binary_logloss", xlim="not a tuple")
+        lgb.plot_metric(evals_result0, metric="binary_logloss", ylim="not a tuple")


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/7031
**BEFORE**
<img width="480" height="171" alt="Screenshot 2026-02-23 at 11 28 37 AM" src="https://github.com/user-attachments/assets/06a7c37c-d9d3-4268-b9cf-68b2641373b8" />


**AFTER**
<img width="503" height="197" alt="Screenshot 2026-02-23 at 11 22 57 AM" src="https://github.com/user-attachments/assets/90f7ef73-4bee-4831-99be-17ace4df7e75" />

1 line difference in coverage for `/lightgbm/plotting.py`


**NOTE**
xlim is already tested for here https://github.com/microsoft/LightGBM/blob/8d4443b74ceb315593a099da254f032359870cbc/tests/python_package_test/test_plotting.py#L587-L595