### PR TITLE
[python-package] Added test for plot_split_value_histogram ylim

### DIFF
--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -212,6 +212,16 @@ def test_plot_split_value_histogram(params, breast_cancer_split, train_data):
     with pytest.raises(TypeError, match="xlim must be a tuple of 2 elements."):
         lgb.plot_split_value_histogram(gbm0, 27, xlim="not a tuple")
 
+    ax4 = lgb.plot_split_value_histogram(gbm0, 27, ylim=(0, 100), title=None, xlabel=None, ylabel=None)
+    assert isinstance(ax4, matplotlib.axes.Axes)
+    assert ax4.get_title() == ""
+    assert ax4.get_xlabel() == ""
+    assert ax4.get_ylabel() == ""
+    assert ax4.get_ylim() == (0, 100)
+
+    with pytest.raises(TypeError, match="ylim must be a tuple of 2 elements."):
+        lgb.plot_split_value_histogram(gbm0, 27, ylim="not a tuple")
+
     with pytest.raises(
         ValueError, match="Cannot plot split value histogram, because feature 0 was not used in splitting"
     ):


### PR DESCRIPTION
Contributes to #7031

**BEFORE**
<img width="480" height="171" alt="Screenshot 2026-02-23 at 11 28 37 AM" src="https://github.com/user-attachments/assets/06a7c37c-d9d3-4268-b9cf-68b2641373b8" />


**AFTER**
<img width="503" height="197" alt="Screenshot 2026-02-23 at 11 22 57 AM" src="https://github.com/user-attachments/assets/90f7ef73-4bee-4831-99be-17ace4df7e75" />

1 line difference in coverage for `/lightgbm/plotting.py`