### PR TITLE
[python-package] Add tests for more create_tree_digraph() inputs

### DIFF
--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -247,7 +247,7 @@ def test_plot_tree(breast_cancer_split):
 
 
 @pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
-def test_create_tree_digraph(tmp_path):
+def test_create_tree_digraph(tmp_path, breast_cancer_split):
     X_train, _, y_train, _ = breast_cancer_split
     constraints = [-1, 1] * int(X_train.shape[1] / 2)
     gbm = lgb.LGBMClassifier(

--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -246,17 +246,8 @@ def test_plot_tree(breast_cancer_split):
     assert int(h) == 8
 
 
-@pytest.fixture
-def fitted_gbm(breast_cancer_split):
-    X_train, _, y_train, _ = breast_cancer_split
-    constraints = [-1, 1] * int(X_train.shape[1] / 2)
-    gbm = lgb.LGBMClassifier(n_estimators=10, num_leaves=3, verbose=-1, monotone_constraints=constraints)
-    gbm.fit(X_train, y_train)
-    return gbm
-
-
 @pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
-def test_create_tree_digraph(tmp_path, breast_cancer_split):
+def test_create_tree_digraph(tmp_path):
     X_train, _, y_train, _ = breast_cancer_split
     constraints = [-1, 1] * int(X_train.shape[1] / 2)
     gbm = lgb.LGBMClassifier(

--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -293,7 +293,7 @@ def test_create_tree_digraph(tmp_path, breast_cancer_split):
     # test internal_count
     graph = lgb.create_tree_digraph(gbm, tree_index=0, show_info=["internal_count"])
     graph_body = "".join(graph.body)
-    assert "count: 200" in graph_body
+    assert "count: 200" in graph_body, graph_body
     assert "count: 512" in graph_body
 
     # test data_percentage for internal and leaf nodes


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/7031
**BEFORE**
<img width="477" height="184" alt="Screenshot 2026-02-23 at 2 32 15 PM" src="https://github.com/user-attachments/assets/a96fab97-55e2-468a-87f0-4b6f1db2f83d" />



**AFTER**
<img width="475" height="176" alt="Screenshot 2026-02-23 at 2 52 55 PM" src="https://github.com/user-attachments/assets/51cb7d3f-6226-4b1c-993b-4b84d527ecaf" />

7 line difference in coverage for `/lightgbm/plotting.py`

*NOTE*

I know these are very specific tests, however, the random state is fixed making the model fixture deterministic. Given other tests depend on the model fixture I expect it to be in a stable state and not change anytime (at least soon)