### PR TITLE
[python-package] Added tests on Booster.shuffle_model()

### DIFF
--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -1098,3 +1098,23 @@ def test_set_field_none_removes_field(rng, field_name):
 
     d.set_field(field_name, None)
     assert d.get_field(field_name) is None
+
+
+def test_booster_shuffle_models() -> None:
+    X_train, _, y_train, _ = train_test_split(
+        *load_breast_cancer(return_X_y=True),
+        test_size=0.1,
+        random_state=42,
+    )
+    train_set = lgb.Dataset(X_train, label=y_train)
+    booster = lgb.Booster(
+        params={"objective": "binary", "verbose": -1},
+        train_set=train_set,
+    )
+    for _ in range(2):
+        booster.update()
+
+    model_str_before = booster.model_to_string()
+    booster.shuffle_models(start_iteration=0, end_iteration=-1)
+    model_str_after = booster.model_to_string()
+    assert model_str_before != model_str_after


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/7031
**BEFORE**
<img width="496" height="181" alt="Screenshot 2026-02-24 at 1 31 13 PM" src="https://github.com/user-attachments/assets/0d321740-3d9c-4228-b9f9-20395ce4de71" />




**AFTER**
<img width="471" height="168" alt="Screenshot 2026-02-24 at 1 23 14 PM" src="https://github.com/user-attachments/assets/813b6c5f-7364-41bf-908a-5a8c685550ac" />


2 line difference in coverage for `/lightgbm/basic.py`


From my understanding `shuffle_models` literally just reorders the trees by calling the C API `LGBM_BoosterShuffleModels`.  The predictions will be the same but the actual model itself will be different, hence, why `model_to_string()` is different before and after (Tree=0 and Tree=1 switch positions). Please let me know if I am understanding this correctly.