### PR TITLE
[python-package][dask] avoid warning for default n_jobs values

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -570,8 +570,13 @@ def _train(
     # Some passed-in parameters can be removed:
     #   * 'num_machines': set automatically from Dask worker list
     #   * 'num_threads': overridden to match nthreads on each Dask process
+    num_threads_aliases = _ConfigAliases.get("num_threads")
     for param_alias in _ConfigAliases.get("num_machines", "num_threads"):
         if param_alias in params:
+            # ``None`` and ``-1`` are defaults in sklearn-compatible constructors.
+            if param_alias in num_threads_aliases and params[param_alias] in {None, -1}:
+                params.pop(param_alias)
+                continue
             _log_warning(f"Parameter {param_alias} will be ignored.")
             params.pop(param_alias)
 

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1208,6 +1208,17 @@ def test_warns_and_continues_on_unrecognized_tree_learner(cluster):
         assert dask_regressor.fitted_
 
 
+@pytest.mark.parametrize("n_jobs", [-1, None])
+def test_does_not_warn_on_default_n_jobs_alias_values(cluster, n_jobs):
+    with Client(cluster) as client:
+        X = da.random.random((100, 10))
+        y = da.random.random((100, 1))
+        dask_regressor = lgb.DaskLGBMRegressor(client=client, n_estimators=1, num_leaves=2, n_jobs=n_jobs)
+        dask_regressor.fit(X, y)
+
+        assert dask_regressor.fitted_
+
+
 @pytest.mark.parametrize("tree_learner", ["data_parallel", "voting_parallel"])
 def test_training_respects_tree_learner_aliases(tree_learner, cluster):
     with Client(cluster) as client:


### PR DESCRIPTION
## Summary
- avoid warning in `lightgbm.dask._train()` when a `num_threads` alias is present with default sklearn-constructor values (`None` or `-1`)
- keep warning behavior unchanged for other explicit `num_threads` / `num_machines` values that are ignored
- add a Dask test covering both default `n_jobs` alias values (`-1`, `None`)

## Testing
- `python -m compileall -q python-package/lightgbm/dask.py tests/python_package_test/test_dask.py`
- targeted `test_dask.py` run could not be executed here because the available LightGBM test environment lacks `dask` / `distributed` and package install is blocked by network proxy

Fixes #6797
