### PR TITLE
[c++] fail when forcedsplits_filename points to missing file

### DIFF
--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -90,6 +90,9 @@ void GBDT::Init(const Config* config, const Dataset* train_data, const Objective
   // load forced_splits file
   if (!config->forcedsplits_filename.empty()) {
     std::ifstream forced_splits_file(config->forcedsplits_filename.c_str());
+    if (forced_splits_file.fail()) {
+      Log::Fatal("Could not open %s", config->forcedsplits_filename.c_str());
+    }
     std::stringstream buffer;
     buffer << forced_splits_file.rdbuf();
     std::string err;
@@ -840,6 +843,9 @@ void GBDT::ResetConfig(const Config* config) {
     if (!new_config->forcedsplits_filename.empty()) {
       std::ifstream forced_splits_file(
           new_config->forcedsplits_filename.c_str());
+      if (forced_splits_file.fail()) {
+        Log::Fatal("Could not open %s", new_config->forcedsplits_filename.c_str());
+      }
       std::stringstream buffer;
       buffer << forced_splits_file.rdbuf();
       std::string err;

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -3429,6 +3429,14 @@ def test_forced_split_feature_indices(tmp_path):
         lgb.train(params, lgb_train)
 
 
+def test_forced_split_missing_file(tmp_path):
+    X, y = make_synthetic_regression()
+    lgb_train = lgb.Dataset(X, y)
+    params = {"objective": "regression", "forcedsplits_filename": tmp_path / "does_not_exist.json"}
+    with pytest.raises(lgb.basic.LightGBMError, match="Could not open"):
+        lgb.train(params, lgb_train)
+
+
 def test_forced_bins():
     x = np.empty((100, 2))
     x[:, 0] = np.arange(0, 1, 0.01)


### PR DESCRIPTION
## Summary
- make GBDT fail fast when `forcedsplits_filename` is set but the file cannot be opened
- add a Python test that verifies this missing-file case raises `LightGBMError`

## Testing
- `./lightgbm config=examples/binary_classification/train.conf data=examples/binary_classification/binary.train valid_data=examples/binary_classification/binary.test num_iterations=1 forced_splits=examples/binary_classification/does_not_exist.json`
- `./lightgbm config=examples/binary_classification/train.conf data=examples/binary_classification/binary.train valid_data=examples/binary_classification/binary.test num_iterations=1 forced_splits=examples/binary_classification/forced_splits.json`
- `conda run -n lightgbm python -m pytest tests/python_package_test/test_engine.py -k "forced_split_feature_indices or forced_split_missing_file" -q`

Fixes #6830
