### PR TITLE
[c++] fix multithreading pragma in LeafSplits::Init()

### DIFF
--- a/src/treelearner/leaf_splits.hpp
+++ b/src/treelearner/leaf_splits.hpp
@@ -179,7 +179,7 @@ class LeafSplits {
     double tmp_sum_hessians = 0.0f;
     const int16_t* packed_int_gradients_and_hessians = reinterpret_cast<const int16_t*>(int_gradients_and_hessians);
     int64_t tmp_sum_gradients_and_hessians = 0;
-#pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static, 512) reduction(+:tmp_sum_gradients, tmp_sum_hessians, tmp_sum_gradients_and_hessians) if (num_data_in_leaf_ >= 1024 && deterministic_)
+#pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static, 512) reduction(+:tmp_sum_gradients, tmp_sum_hessians, tmp_sum_gradients_and_hessians) if (num_data_in_leaf_ >= 1024 && !deterministic_)
     for (data_size_t i = 0; i < num_data_in_leaf_; ++i) {
       const data_size_t idx = data_indices_[i];
       tmp_sum_gradients += int_gradients_and_hessians[2 * idx + 1] * grad_scale;


### PR DESCRIPTION
Throughout the library, operations using OpenMP are guarded with conditions like this:

```cpp
if (num_data_in_leaf_ >= 1024 && !deterministic_)
```

The `deterministic` parameter is used to turn off parallelism (see #3494  and #6731 for more).

This PR fixes one case in `LeafSplits::Init()` where a condition like that accidentally missed a `!`, meaning multithreading was (accidentally) off by default.

## Notes for Reviewers

This condition is used for quantized training (the `git` blame points to #5800). Maybe it will help with #6703 !
