### PR TITLE
Fix refit() for single-tree boosters (fixes #7156)

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -4892,6 +4892,9 @@ class Booster:
             pred_leaf=True,
             validate_features=validate_features,
         )
+        # Handle 1D array case when there's only one tree (issue #7156)
+        if leaf_preds.ndim == 1:
+            leaf_preds = leaf_preds.reshape(-1, 1)
         nrow, ncol = leaf_preds.shape
         out_is_linear = ctypes.c_int(0)
         _safe_call(


### PR DESCRIPTION
Description:
  ## Description
  Fixes #7156

  ## Bug
  When calling `Booster.refit()` on a model trained with `num_boost_round=1`, the method raised
  `ValueError: not enough values to unpack (expected 2, got 1)` because `predict()` with
  `pred_leaf=True` returns a 1D array for single-tree models.

  ## Fix
  Added a dimensionality check in the `refit()` method to ensure `leaf_preds` is always 2D before
   unpacking its shape.

  ```python
  # Handle 1D array case when there's only one tree (issue #7156)
  if leaf_preds.ndim == 1:
      leaf_preds = leaf_preds.reshape(-1, 1)

  Changes

  - Modified python-package/lightgbm/basic.py in the refit() method (lines 4895-4897)

  Testing

  This fix allows existing tests to pass:
  - test_refit_with_one_tree_regression
  - test_refit_with_one_tree_binary_classification
  - test_refit_with_one_tree_multiclass_classification

  All existing functionality remains unchanged for multi-tree boosters.