### PR TITLE
[ci] install 'CMake' in R-package jobs for {fs}

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -288,6 +288,7 @@ jobs:
           if type -f apt 2>&1 > /dev/null; then
             apt-get update
             apt-get install --no-install-recommends -y \
+                cmake \
                 devscripts \
                 texinfo \
                 texlive-latex-extra \
@@ -299,6 +300,7 @@ jobs:
           else
             yum update -y
             yum install -y \
+                cmake \
                 devscripts \
                 qpdf \
                 texinfo \


### PR DESCRIPTION
Fixes #7208

The new release of `{fs}` has this note in its SystemRequirements:

> SystemRequirements: libuv: libuv-devel (rpm) or libuv1-dev (deb). Alternatively
    to build the vendored libuv 'cmake' is required. GNU make.

([code link](https://github.com/r-lib/fs/blob/f5b4da1cf759df1eb86450433ff1a91791f84a9a/DESCRIPTION#L38))

See https://github.com/r-lib/fs/pull/506

This installs CMake in the jobs using the r-hub images, so `{fs}` can be built successfully.