### PR TITLE
[ci] [R-package] drop 'icc' test job, update clang and GCC r-hub container jobs

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -273,14 +273,16 @@ jobs:
         # references:
         #   * CRAN "additional checks": https://cran.r-project.org/web/checks/check_issue_kinds.html
         #   * images: https://r-hub.github.io/containers/containers.html
+        #
+        # Generally, only images that are still supported, listed at
+        # https://r-hub.github.io/containers/#available-containers, should be used.
         image:
-          # unless a specific reason to do otherwise, just test
-          # oldest and newest supported versions of compilers here
-          - clang16
+          - clang21
           - clang22
-          - gcc14
           - gcc16
           - rchk
+          - r-devel-linux-x86_64-debian-clang
+          - r-devel-linux-x86_64-debian-gcc
     runs-on: ubuntu-latest
     container: ghcr.io/r-hub/containers/${{ matrix.image }}:latest
     steps:

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -281,8 +281,8 @@ jobs:
           - clang22
           - gcc16
           - rchk
-          - r-devel-linux-x86_64-debian-clang
-          - r-devel-linux-x86_64-debian-gcc
+          - ubuntu-clang
+          - ubuntu-gcc12
     runs-on: ubuntu-latest
     container: ghcr.io/r-hub/containers/${{ matrix.image }}:latest
     steps:
@@ -320,6 +320,7 @@ jobs:
                 qpdf \
                 texinfo \
                 texinfo-tex \
+                texlive-collection-fontsrecommended \
                 texlive-latex \
                 tidy
           fi

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -274,13 +274,12 @@ jobs:
         #   * CRAN "additional checks": https://cran.r-project.org/web/checks/check_issue_kinds.html
         #   * images: https://r-hub.github.io/containers/containers.html
         image:
+          # unless a specific reason to do otherwise, just test
+          # oldest and newest supported versions of compilers here
           - clang16
-          - clang17
-          - clang18
-          - clang19
-          - clang20
+          - clang22
           - gcc14
-          - intel
+          - gcc16
           - rchk
     runs-on: ubuntu-latest
     container: ghcr.io/r-hub/containers/${{ matrix.image }}:latest

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -303,6 +303,7 @@ jobs:
             apt-get install --no-install-recommends -y \
                 cmake \
                 devscripts \
+                libcurl4-openssl-dev \
                 libuv1-dev \
                 texinfo \
                 texlive-latex-extra \
@@ -316,6 +317,7 @@ jobs:
             yum install -y \
                 cmake \
                 devscripts \
+                libcurl-devel \
                 libuv-devel \
                 qpdf \
                 texinfo \
@@ -358,7 +360,11 @@ jobs:
           #   - 'curl' is not a dependency of {lightgbm}, but it's needed for 'R CMD check' URL checks
           #   - 'testthat' is not needed by 'rchk', so avoid installing it until here
           #
-          Rscript -e "install.packages(c('curl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+          Rscript -e "
+            install.packages(c('curl', 'testthat'),
+            repos = 'https://cran.rstudio.com',
+            Ncpus = parallel::detectCores())
+          "
 
           if [[ "${{ matrix.image }}" =~ "clang" ]]; then
             # allowing the following NOTEs (produced by default in the clang images):

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -302,6 +302,7 @@ jobs:
             apt-get update
             apt-get install --no-install-recommends -y \
                 cmake \
+                curl \
                 devscripts \
                 libuv1-dev \
                 texinfo \
@@ -315,12 +316,16 @@ jobs:
             yum update -y
             yum install -y \
                 cmake \
+                curl \
                 devscripts \
                 libuv-devel \
                 qpdf \
                 texinfo \
                 texinfo-tex \
+                texlive-amsmath \
+                texlive-amsfonts \
                 texlive-collection-fontsrecommended \
+                texlive-collection-latexrecommended \
                 texlive-latex \
                 tidy
           fi

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -302,7 +302,6 @@ jobs:
             apt-get update
             apt-get install --no-install-recommends -y \
                 cmake \
-                curl \
                 devscripts \
                 libuv1-dev \
                 texinfo \
@@ -316,7 +315,6 @@ jobs:
             yum update -y
             yum install -y \
                 cmake \
-                curl \
                 devscripts \
                 libuv-devel \
                 qpdf \
@@ -355,8 +353,12 @@ jobs:
             fi
           fi
 
-          # 'testthat' is not needed by 'rchk', so avoid installing it until here
-          Rscript -e "install.packages('testthat', repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+          # why these packages?
+          #
+          #   - 'curl' is not a dependency of {lightgbm}, but it's needed for 'R CMD check' URL checks
+          #   - 'testthat' is not needed by 'rchk', so avoid installing it until here
+          #
+          Rscript -e "install.packages(c('curl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
 
           if [[ "${{ matrix.image }}" =~ "clang" ]]; then
             # allowing the following NOTEs (produced by default in the clang images):


### PR DESCRIPTION
Fixes #7221

Intel stopped shipping `icc` in 2024. From https://www.intel.com/content/www/us/en/developer/articles/release-notes/oneapi-c-compiler-release-notes.html

> _Intel® C++ Compiler Classic (icc) is deprecated and was discontinued in the oneAPI 2024.0 release._

And R Hub removed their `intel` container image last month: https://github.com/r-hub/containers/commit/a44746408991588ded6d92f722a8c5b6b136d96e#diff-1645e8921051d59c6ea1f1f10e1926a1891fce8f0351bc427bff02ef3650d4eb

I think that's why R CI jobs using that `intel` container image are failing here... packages have made it to CRAN which rely on features in R-devel that are too new for the version in those no-longer-published images.

This proposes the following for R CI:

* drop `intel` job
* add `clang22` job (previous max `clang` tested: `clang20`)
* add `gcc16` job (previous max `gcc` tested: `gcc 14`)
* remove interemediate `clang` and `gcc` R CI jobs

## Notes for Reviewers

### Why not add a job using `icx`?

Intel does have a new compiler replacing `icc`:

> _Intel recommends that customers transition now to using the LLVM-based Intel® oneAPI DPC++/C++ Compiler (icx)_

But I'm not aware of an easy-to-use container image with it + R installed, and it isn't required for CRAN submissions: https://cran.r-project.org/web/checks/check_flavors.html#r-devel-linux-x86_64-debian-clang

Even outside of R, I personally don't want to spend time trying to add a `icx` support + a CI job for it here until someone asks for it.

### Why cut out those other `clang` and `gcc` jobs?

Since the project moved out of the `microsoft/` org (#7187), we face lower maximum number of concurrent CI jobs. Proposing only testing endpoints of the support matrix to reduce the total number of jobs. That should be enough to catch most compatibility problems, and keep in mind that we do probably end up testing intermediate versions in other jobs via Linux distributions choosing versions somewhere in the middle of the range.