### PR TITLE
[ci] cut some macOS jobs

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -94,21 +94,8 @@ jobs:
       matrix:
         include:
           - os: macos-15-intel
-            task: regular
-            compiler: gcc
-            python_version: '3.11'
-          - os: macos-15-intel
             task: sdist
             compiler: clang
-            python_version: '3.10'
-          - os: macos-15-intel
-            task: sdist
-            compiler: gcc
-            python_version: '3.12'
-          - os: macos-15-intel
-            task: bdist
-            method: wheel
-            compiler: gcc
             python_version: '3.9'
           - os: windows-2022
             task: sdist
@@ -166,21 +153,11 @@ jobs:
           ############
           # MPI jobs #
           ############
-          - os: macos-15-intel
+          - os: macos-14
             task: mpi
             compiler: gcc
             method: source
             python_version: '3.12'
-          - os: macos-15-intel
-            task: mpi
-            compiler: gcc
-            method: pip
-            python_version: '3.13'
-          - os: macos-15-intel
-            task: mpi
-            compiler: gcc
-            method: wheel
-            python_version: '3.10'
           - os: ubuntu-latest
             container: *manylinux_amd64_image
             os-display-name: *manylinux_amd64_display_name

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -153,7 +153,7 @@ jobs:
           ############
           # MPI jobs #
           ############
-          - os: macos-14
+          - os: macos-15-intel
             task: mpi
             compiler: gcc
             method: source

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -85,12 +85,6 @@ jobs:
             os-display-name: 'ubuntu22.04'
           - os: macos-15-intel
             task: r-package
-            compiler: gcc
-            r_version: 4.3
-            build_type: cmake
-            container: null
-          - os: macos-15-intel
-            task: r-package
             compiler: clang
             r_version: 4.3
             build_type: cmake


### PR DESCRIPTION
Moving to our own org (#7187), we moved the project from a GItHub `Enterprise` account to a `Team` account, so we now get only 5 concurrent macOS CI jobs instead of 50 😬 

<img width="746" height="560" alt="Screenshot 2026-04-09 at 9 25 08 PM" src="https://github.com/user-attachments/assets/8e78c01a-6246-4d77-823f-54c5ddac67a7" />

https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners

We currently run **17 macOS jobs on every commit**, so we're really feeling that lower concurrency... I've seen it not be uncommon for CI to take over an hour to finish if even 2 PRs are active at the same time.

This proposes dropping 7 of those jobs:

* 3 python-package jobs
* 3 Python + MPI jobs
* 1 R job

For all of these, I targeted `macos-15-intel`... Apple isn't making new hardware with x86_64 chips (as far as I know), so I think it's more important to preserve CI coverage of macOS + arm64.

Those MPI jobs were especially unnecessary... these days, I think it's very unlikely that there are many folks running LightGBM distributed training using MPI on multiple x86_64 macOS boxes 😅

## Notes for Reviewers

### Example

These new limits often means it's macOS jobs we're stuck waiting for. Happened to catch a perfect screenshot of that recently, on #7145 

<img width="853" height="584" alt="image" src="https://github.com/user-attachments/assets/0ee402df-fdff-46e1-807c-3da9cccd0040" />
