### PR TITLE
fix(c_api): include start_iteration in SingleRowPredictor cache key

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -83,6 +83,7 @@ class SingleRowPredictorInner {
     early_stop_ = config.pred_early_stop;
     early_stop_freq_ = config.pred_early_stop_freq;
     early_stop_margin_ = config.pred_early_stop_margin;
+    start_iter_ = start_iter;
     iter_ = num_iter;
     predictor_.reset(new Predictor(boosting, start_iter, iter_, is_raw_score, is_predict_leaf, predict_contrib,
                                    early_stop_, early_stop_freq_, early_stop_margin_));
@@ -93,10 +94,11 @@ class SingleRowPredictorInner {
 
   ~SingleRowPredictorInner() {}
 
-  bool IsPredictorEqual(const Config& config, int iter, Boosting* boosting) {
+  bool IsPredictorEqual(const Config& config, int start_iter, int iter, Boosting* boosting) {
     return early_stop_ == config.pred_early_stop &&
       early_stop_freq_ == config.pred_early_stop_freq &&
       early_stop_margin_ == config.pred_early_stop_margin &&
+      start_iter_ == start_iter &&
       iter_ == iter &&
       num_total_model_ == boosting->NumberOfTotalModel();
   }
@@ -106,6 +108,7 @@ class SingleRowPredictorInner {
   bool early_stop_;
   int early_stop_freq_;
   double early_stop_margin_;
+  int start_iter_;
   int iter_;
   int num_total_model_;
 };
@@ -434,7 +437,7 @@ class Booster {
   void SetSingleRowPredictorInner(int start_iteration, int num_iteration, int predict_type, const Config& config) {
       UNIQUE_LOCK(mutex_)
       if (single_row_predictor_[predict_type].get() == nullptr ||
-          !single_row_predictor_[predict_type]->IsPredictorEqual(config, num_iteration, boosting_.get())) {
+          !single_row_predictor_[predict_type]->IsPredictorEqual(config, start_iteration, num_iteration, boosting_.get())) {
         single_row_predictor_[predict_type].reset(new SingleRowPredictorInner(predict_type, boosting_.get(),
                                                                          config, start_iteration, num_iteration));
       }

--- a/tests/cpp_tests/test_single_row.cpp
+++ b/tests/cpp_tests/test_single_row.cpp
@@ -188,3 +188,144 @@ TEST(SingleRow, Normal) {
 TEST(SingleRow, Contrib) {
     test_predict_type(C_API_PREDICT_CONTRIB, 29);
 }
+
+// Regression test for issue #7220: LGBM_BoosterPredictForMatSingleRow
+// reused a cached single-row predictor without taking `start_iteration`
+// into account, so consecutive calls with different start_iteration values
+// but the same num_iteration returned stale (identical) predictions.
+TEST(SingleRow, StartIterationChangesPrediction) {
+    int result;
+
+    DatasetHandle train_dataset;
+    result = TestUtils::LoadDatasetFromExamples("binary_classification/binary.train", "max_bin=15", &train_dataset);
+    EXPECT_EQ(0, result) << "LoadDatasetFromExamples train result code: " << result;
+
+    BoosterHandle booster_handle;
+    result = LGBM_BoosterCreate(train_dataset, "app=binary metric=auc num_leaves=31 verbose=0", &booster_handle);
+    EXPECT_EQ(0, result) << "LGBM_BoosterCreate result code: " << result;
+
+    const int kNumIterTrained = 30;
+    for (int i = 0; i < kNumIterTrained; i++) {
+        int produced_empty_tree;
+        result = LGBM_BoosterUpdateOneIter(booster_handle, &produced_empty_tree);
+        EXPECT_EQ(0, result) << "LGBM_BoosterUpdateOneIter result code: " << result;
+    }
+
+    int n_features;
+    result = LGBM_BoosterGetNumFeature(booster_handle, &n_features);
+    EXPECT_EQ(0, result) << "LGBM_BoosterGetNumFeature result code: " << result;
+
+    // Load a single test row.
+    std::ifstream test_file("examples/binary_classification/binary.test");
+    std::vector<double> single_row;
+    double x;
+    int field = 0;
+    while (test_file >> x) {
+        if (field == 0) {
+            // Drop the label column.
+            field++;
+            continue;
+        }
+        single_row.push_back(x);
+        field++;
+        if (static_cast<int>(single_row.size()) == n_features) {
+            break;
+        }
+    }
+    EXPECT_EQ(static_cast<int>(single_row.size()), n_features) << "Failed to parse a single row from the test file";
+
+    int64_t output_size;
+    result = LGBM_BoosterCalcNumPredict(
+        booster_handle,
+        1,
+        C_API_PREDICT_NORMAL,
+        0,
+        10,
+        &output_size);
+    EXPECT_EQ(0, result) << "LGBM_BoosterCalcNumPredict result code: " << result;
+
+    // Call LGBM_BoosterPredictForMatSingleRow twice with the same num_iteration
+    // but different start_iteration. The two boosting iteration windows are
+    // disjoint, so the resulting scores must differ.
+    std::vector<double> pred_early(output_size, -1);
+    std::vector<double> pred_late(output_size, -1);
+    int64_t written;
+
+    result = LGBM_BoosterPredictForMatSingleRow(
+        booster_handle,
+        &single_row[0],
+        C_API_DTYPE_FLOAT64,
+        n_features,
+        1,                     // is_row_major
+        C_API_PREDICT_NORMAL,
+        0,                     // start_iteration
+        10,                    // num_iteration
+        "",
+        &written,
+        &pred_early[0]);
+    EXPECT_EQ(0, result) << "LGBM_BoosterPredictForMatSingleRow (start=0) result code: " << result;
+
+    result = LGBM_BoosterPredictForMatSingleRow(
+        booster_handle,
+        &single_row[0],
+        C_API_DTYPE_FLOAT64,
+        n_features,
+        1,                     // is_row_major
+        C_API_PREDICT_NORMAL,
+        20,                    // start_iteration — window [20, 30) disjoint from [0, 10)
+        10,                    // num_iteration
+        "",
+        &written,
+        &pred_late[0]);
+    EXPECT_EQ(0, result) << "LGBM_BoosterPredictForMatSingleRow (start=20) result code: " << result;
+
+    EXPECT_NE(pred_early[0], pred_late[0])
+        << "LGBM_BoosterPredictForMatSingleRow returned identical predictions for "
+           "disjoint iteration windows [0,10) and [20,30); start_iteration is being "
+           "ignored by the predictor cache key.";
+
+    // Cross-check against LGBM_BoosterPredictForMat (the non-single-row path),
+    // which does not use the buggy cache and is known to respect start_iteration.
+    std::vector<double> ref_early(output_size, -1);
+    std::vector<double> ref_late(output_size, -1);
+    result = LGBM_BoosterPredictForMat(
+        booster_handle,
+        &single_row[0],
+        C_API_DTYPE_FLOAT64,
+        1,                     // nrow
+        n_features,
+        1,                     // is_row_major
+        C_API_PREDICT_NORMAL,
+        0,                     // start_iteration
+        10,                    // num_iteration
+        "",
+        &written,
+        &ref_early[0]);
+    EXPECT_EQ(0, result) << "LGBM_BoosterPredictForMat (start=0) result code: " << result;
+
+    result = LGBM_BoosterPredictForMat(
+        booster_handle,
+        &single_row[0],
+        C_API_DTYPE_FLOAT64,
+        1,
+        n_features,
+        1,
+        C_API_PREDICT_NORMAL,
+        20,
+        10,
+        "",
+        &written,
+        &ref_late[0]);
+    EXPECT_EQ(0, result) << "LGBM_BoosterPredictForMat (start=20) result code: " << result;
+
+    EXPECT_DOUBLE_EQ(pred_early[0], ref_early[0])
+        << "LGBM_BoosterPredictForMatSingleRow (start=0) disagrees with LGBM_BoosterPredictForMat";
+    EXPECT_DOUBLE_EQ(pred_late[0], ref_late[0])
+        << "LGBM_BoosterPredictForMatSingleRow (start=20) disagrees with LGBM_BoosterPredictForMat";
+
+    result = LGBM_BoosterFree(booster_handle);
+    EXPECT_EQ(0, result) << "LGBM_BoosterFree result code: " << result;
+
+    result = LGBM_DatasetFree(train_dataset);
+    EXPECT_EQ(0, result) << "LGBM_DatasetFree result code: " << result;
+}


### PR DESCRIPTION
## Summary

Fixes #7220. `LGBM_BoosterPredictForMatSingleRow` (and its Fast/CSR/CSC siblings that share the same cached predictor) returned stale predictions when called repeatedly on the same booster with different `start_iteration` values but the same `num_iteration` and `predict_type`.

Root cause: `SingleRowPredictorInner::IsPredictorEqual` at `src/c_api.cpp:96` omitted `start_iteration` from the cache key, so `SetSingleRowPredictorInner` (line 434) never rebuilt the cached predictor when only `start_iteration` changed.

## The fix

```diff
   SingleRowPredictorInner(int predict_type, Boosting* boosting, const Config& config, int start_iter, int num_iter) {
     ...
+    start_iter_ = start_iter;
     iter_ = num_iter;
     ...
   }

-  bool IsPredictorEqual(const Config& config, int iter, Boosting* boosting) {
+  bool IsPredictorEqual(const Config& config, int start_iter, int iter, Boosting* boosting) {
     return early_stop_ == config.pred_early_stop &&
       early_stop_freq_ == config.pred_early_stop_freq &&
       early_stop_margin_ == config.pred_early_stop_margin &&
+      start_iter_ == start_iter &&
       iter_ == iter &&
       num_total_model_ == boosting->NumberOfTotalModel();
   }

  private:
   ...
+  int start_iter_;
   int iter_;
   int num_total_model_;
 };
```

Caller update in `SetSingleRowPredictorInner` (the only caller of `IsPredictorEqual`):

```diff
-          !single_row_predictor_[predict_type]->IsPredictorEqual(config, num_iteration, boosting_.get())) {
+          !single_row_predictor_[predict_type]->IsPredictorEqual(config, start_iteration, num_iteration, boosting_.get())) {
```

## Test

Adds `SingleRow.StartIterationChangesPrediction` to `tests/cpp_tests/test_single_row.cpp`. The test:

1. Trains 30 iterations on `binary.train`.
2. Calls `LGBM_BoosterPredictForMatSingleRow` twice on the same booster with `num_iteration=10`, `start_iteration=0` then `start_iteration=20` (disjoint iteration windows).
3. Asserts the two predictions differ.
4. Cross-checks both against `LGBM_BoosterPredictForMat` (which does not use the buggy cache) to confirm the single-row path agrees with the non-single-row path for both iteration windows.

### TDD verification

I stashed the `c_api.cpp` fix, rebuilt `testlightgbm`, and re-ran just the new test. It failed exactly as the issue describes:

```
[ RUN      ] SingleRow.StartIterationChangesPrediction
test_single_row.cpp:282: Failure
Expected: (pred_early[0]) != (pred_late[0]),
   actual: 0.65339054153163234 vs 0.65339054153163234
LGBM_BoosterPredictForMatSingleRow returned identical predictions for
disjoint iteration windows [0,10) and [20,30); start_iteration is being
ignored by the predictor cache key.

test_single_row.cpp:323: Failure
Expected equality of these values:
  pred_late[0]   Which is: 0.65339054153163234
  ref_late[0]    Which is: 0.56966613224435347
LGBM_BoosterPredictForMatSingleRow (start=20) disagrees with LGBM_BoosterPredictForMat
[  FAILED  ] SingleRow.StartIterationChangesPrediction
```

I then reapplied the fix, rebuilt, and ran the full `SingleRow.*` suite:

```
[ RUN      ] SingleRow.Normal
[       OK ] SingleRow.Normal (708 ms)
[ RUN      ] SingleRow.Contrib
[       OK ] SingleRow.Contrib (954 ms)
[ RUN      ] SingleRow.StartIterationChangesPrediction
[       OK ] SingleRow.StartIterationChangesPrediction (416 ms)
[  PASSED  ] 3 tests.
```

Build: `cmake -S . -B build-test -DBUILD_CPP_TEST=ON -DUSE_OPENMP=ON -G "MinGW Makefiles" && cmake --build build-test --target testlightgbm` on Windows + MinGW gcc 13.2.0.

## Impact

Any consumer that re-uses a Booster handle and calls any of the single-row predict entry points with varying `start_iteration` hit this bug. This affects online-serving / low-latency inference patterns where a single booster is loaded once and reused across many per-request prediction calls with different slicing. Every language binding that calls through the C API (including SWIG-based ones) is affected.

No API or ABI surface change — `IsPredictorEqual` is a private class method; its only caller is updated in the same patch.