### PR TITLE
[c++] mark a few more read-only methods const

### DIFF
--- a/include/LightGBM/feature_group.h
+++ b/include/LightGBM/feature_group.h
@@ -566,7 +566,7 @@ class FeatureGroup {
     }
   }
 
-  uint32_t feature_max_bin(const int sub_feature_index) {
+  uint32_t feature_max_bin(const int sub_feature_index) const {
     if (!is_multi_val_) {
       return bin_offsets_[sub_feature_index + 1] - 1;
     } else {
@@ -575,7 +575,7 @@ class FeatureGroup {
     }
   }
 
-  uint32_t feature_min_bin(const int sub_feature_index) {
+  uint32_t feature_min_bin(const int sub_feature_index) const {
     if (!is_multi_val_) {
       return bin_offsets_[sub_feature_index];
     } else {

--- a/include/LightGBM/train_share_states.h
+++ b/include/LightGBM/train_share_states.h
@@ -23,7 +23,7 @@ class MultiValBinWrapper {
   MultiValBinWrapper(MultiValBin* bin, data_size_t num_data,
     const std::vector<int>& feature_groups_contained, const int num_grad_quant_bins);
 
-  bool const IsSparse() {
+  bool IsSparse() const {
     if (multi_val_bin_ != nullptr) {
       return multi_val_bin_->IsSparse();
     }

--- a/include/LightGBM/train_share_states.h
+++ b/include/LightGBM/train_share_states.h
@@ -23,7 +23,7 @@ class MultiValBinWrapper {
   MultiValBinWrapper(MultiValBin* bin, data_size_t num_data,
     const std::vector<int>& feature_groups_contained, const int num_grad_quant_bins);
 
-  bool IsSparse() {
+  bool const IsSparse() {
     if (multi_val_bin_ != nullptr) {
       return multi_val_bin_->IsSparse();
     }
@@ -277,7 +277,7 @@ struct TrainingShareStates {
     multi_val_bin_wrapper_.reset(nullptr);
   }
 
-  int num_hist_total_bin() { return num_hist_total_bin_; }
+  int num_hist_total_bin() const { return num_hist_total_bin_; }
 
   const std::vector<uint32_t>& feature_hist_offsets() const { return feature_hist_offsets_; }
 
@@ -285,7 +285,7 @@ struct TrainingShareStates {
   const std::vector<uint32_t>& column_hist_offsets() const { return column_hist_offsets_; }
   #endif  // USE_CUDA
 
-  bool IsSparseRowwise() {
+  bool IsSparseRowwise() const {
     return (multi_val_bin_wrapper_ != nullptr && multi_val_bin_wrapper_->IsSparse());
   }
 

--- a/include/LightGBM/utils/byte_buffer.h
+++ b/include/LightGBM/utils/byte_buffer.h
@@ -50,7 +50,7 @@ struct ByteBuffer final : public BinaryWriter {
     return buffer_.at(index);
   }
 
-  LIGHTGBM_EXPORT char* Data() const {
+  LIGHTGBM_EXPORT char* Data() {
     return buffer_.data();
   }
 

--- a/include/LightGBM/utils/byte_buffer.h
+++ b/include/LightGBM/utils/byte_buffer.h
@@ -42,15 +42,15 @@ struct ByteBuffer final : public BinaryWriter {
     buffer_.reserve(capacity);
   }
 
-  LIGHTGBM_EXPORT size_t GetSize() {
+  LIGHTGBM_EXPORT size_t GetSize() const {
     return buffer_.size();
   }
 
-  LIGHTGBM_EXPORT char GetAt(size_t index) {
+  LIGHTGBM_EXPORT char GetAt(size_t index) const {
     return buffer_.at(index);
   }
 
-  LIGHTGBM_EXPORT char* Data() {
+  LIGHTGBM_EXPORT char* Data() const {
     return buffer_.data();
   }
 

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -702,7 +702,7 @@ class FeatureHistogram {
   /*!
    * \brief True if this histogram can be splitted
    */
-  bool is_splittable() { return is_splittable_; }
+  bool is_splittable() const { return is_splittable_; }
 
   /*!
    * \brief Set splittable to this histogram

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -306,11 +306,11 @@ struct AdvancedFeatureConstraints : FeatureConstraint {
     max_constraints.UpdateMax(new_max);
   }
 
-  bool FeatureMaxConstraintsToBeUpdated() {
+  bool FeatureMaxConstraintsToBeUpdated() const {
     return max_constraints_to_be_recomputed;
   }
 
-  bool FeatureMinConstraintsToBeUpdated() {
+  bool FeatureMinConstraintsToBeUpdated() const {
     return min_constraints_to_be_recomputed;
   }
 


### PR DESCRIPTION
I've been trying to learn more C++ so I can help with more things here 😊 

This proposes marking some read-only methods as `const`, to make it clearer to the compiler that they don't modify any state.

## Notes for Reviewers

The failing R CI jobs should be fixed by #7222 