### PR TITLE
[docs] add Michael Mayer to CODEOWNERS and docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # offer a reasonable automatic best-guess
 
 # catch-all rule (this only gets matched if no rules below match)
-*    @guolinke @jameslamb @shiyu1994 @jmoralez @borchero @StrikerRUS
+*    @guolinke @jameslamb @shiyu1994 @jmoralez @borchero @StrikerRUS @mayer79

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -20,6 +20,8 @@ If your request is time-sensitive or more than a month goes by without a respons
 -  `@shiyu1994 <https://github.com/shiyu1994>`__ **Yu Shi**
 -  `@jameslamb <https://github.com/jameslamb>`__ **James Lamb**
 -  `@jmoralez <https://github.com/jmoralez>`__ **José Morales**
+-  `@borchero <https://github.com/borchero>`__ **Oliver Borchert**
+-  `@mayer79 <https://github.com/mayer79>`__ **Michael Mayer**
 
 --------------
 


### PR DESCRIPTION
I'm very pleased to announce that @mayer79 has agreed to join the project as a maintainer.

This adds him to the `CODEOWNERS` (used for automatic PR review requests) and the FAQ docs listing active maintainers (see https://github.com/lightgbm-org/LightGBM/pull/6247/changes#r1434761641 for reasoning about this list).

It also adds @borchero to that list in the FAQ docs, he should have been added there a long time ago.