### PR TITLE
[c++] add path_smooth_hessian parameter for hessian-based path smoothing

### DIFF
--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -1052,6 +1052,7 @@ test_that("all parameters are stored correctly with save_model_to_string()", {
         , "[cegb_penalty_feature_lazy: ]"
         , "[cegb_penalty_feature_coupled: ]"
         , "[path_smooth: 0]"
+        , "[path_smooth_hessian: 0]"
         , "[interaction_constraints: ]"
         , sprintf("[verbosity: %i]", .LGB_VERBOSITY)
         , "[saved_feature_importance_type: 0]"

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -675,6 +675,20 @@ Learning Control Parameters
 
       -  note that the parent output ``w_p`` itself has smoothing applied, unless it is the root node, so that the smoothing effect accumulates with the tree depth
 
+-  ``path_smooth_hessian`` :raw-html:`<a id="path_smooth_hessian" title="Permalink to this parameter" href="#path_smooth_hessian">&#x1F517;&#xFE0E;</a>`, default = ``0``, type = double, constraints: ``path_smooth_hessian >=  0.0``
+
+   -  controls smoothing applied to tree nodes using the sum of hessians instead of the number of samples
+
+   -  works the same way as ``path_smooth`` but uses the sum of hessians as the weight, making it more appropriate when samples have different weights
+
+   -  has the same dimension as ``min_sum_hessian_in_leaf``
+
+   -  cannot be used simultaneously with ``path_smooth``; set one to ``0`` when using the other
+
+      -  the weight of each node is ``w * (h / path_smooth_hessian) / (h / path_smooth_hessian + 1) + w_p / (h / path_smooth_hessian + 1)``, where ``h`` is the sum of hessians in the node, ``w`` is the optimal node weight to minimise the loss (approximately ``-sum_gradients / sum_hessians``), and ``w_p`` is the weight of the parent node
+
+      -  note that the parent output ``w_p`` itself has smoothing applied, unless it is the root node, so that the smoothing effect accumulates with the tree depth
+
 -  ``interaction_constraints`` :raw-html:`<a id="interaction_constraints" title="Permalink to this parameter" href="#interaction_constraints">&#x1F517;&#xFE0E;</a>`, default = ``""``, type = string
 
    -  controls which features can appear in the same branch

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -584,6 +584,15 @@ struct Config {
   // descl2 = note that the parent output ``w_p`` itself has smoothing applied, unless it is the root node, so that the smoothing effect accumulates with the tree depth
   double path_smooth = 0;
 
+  // check = >= 0.0
+  // desc = controls smoothing applied to tree nodes using the sum of hessians instead of the number of samples
+  // desc = works the same way as ``path_smooth`` but uses the sum of hessians as the weight, making it more appropriate when samples have different weights
+  // desc = has the same dimension as ``min_sum_hessian_in_leaf``
+  // desc = cannot be used simultaneously with ``path_smooth``; set one to ``0`` when using the other
+  // descl2 = the weight of each node is ``w * (h / path_smooth_hessian) / (h / path_smooth_hessian + 1) + w_p / (h / path_smooth_hessian + 1)``, where ``h`` is the sum of hessians in the node, ``w`` is the optimal node weight to minimise the loss (approximately ``-sum_gradients / sum_hessians``), and ``w_p`` is the weight of the parent node
+  // descl2 = note that the parent output ``w_p`` itself has smoothing applied, unless it is the root node, so that the smoothing effect accumulates with the tree depth
+  double path_smooth_hessian = 0;
+
   // desc = controls which features can appear in the same branch
   // desc = by default interaction constraints are disabled, to enable them you can specify
   // descl2 = for CLI, lists separated by commas, e.g. ``[0,1,2],[2,3]``
@@ -1154,6 +1163,13 @@ struct Config {
   #endif  // __NVCC__
 
   size_t file_load_progress_interval_bytes = size_t(10) * 1024 * 1024 * 1024;
+
+  double effective_path_smooth() const {
+    return path_smooth_hessian > kEpsilon ? path_smooth_hessian : path_smooth;
+  }
+  bool use_hessian_smoothing() const {
+    return path_smooth_hessian > kEpsilon;
+  }
 
   bool is_parallel = false;
   bool is_data_based_parallel = false;

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -439,10 +439,14 @@ void Config::CheckParamConflict(const std::unordered_map<std::string, std::strin
       Log::Fatal("Cannot use regression_l1 objective when fitting linear trees.");
     }
   }
-  // min_data_in_leaf must be at least 2 if path smoothing is active. This is because when the split is calculated
-  // the count is calculated using the proportion of hessian in the leaf which is rounded up to nearest int, so it can
-  // be 1 when there is actually no data in the leaf. In rare cases this can cause a bug because with path smoothing the
-  // calculated split gain can be positive even with zero gradient and hessian.
+  if (path_smooth > kEpsilon && path_smooth_hessian > kEpsilon) {
+    Log::Warning("Cannot use both path_smooth and path_smooth_hessian simultaneously. path_smooth will be ignored.");
+    path_smooth = 0;
+  }
+  // min_data_in_leaf must be at least 2 if count-based path smoothing is active. This is because when the split is
+  // calculated the count is calculated using the proportion of hessian in the leaf which is rounded up to nearest int,
+  // so it can be 1 when there is actually no data in the leaf. In rare cases this can cause a bug because with path
+  // smoothing the calculated split gain can be positive even with zero gradient and hessian.
   if (path_smooth > kEpsilon && min_data_in_leaf < 2) {
     min_data_in_leaf = 2;
     Log::Warning("min_data_in_leaf has been increased to 2 because this is required when path smoothing is active.");

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -254,6 +254,7 @@ const std::unordered_set<std::string>& Config::parameter_set() {
   "cegb_penalty_feature_lazy",
   "cegb_penalty_feature_coupled",
   "path_smooth",
+  "path_smooth_hessian",
   "interaction_constraints",
   "verbosity",
   "input_model",
@@ -501,6 +502,9 @@ void Config::GetMembersFromString(const std::unordered_map<std::string, std::str
   GetDouble(params, "path_smooth", &path_smooth);
   CHECK_GE(path_smooth,  0.0);
 
+  GetDouble(params, "path_smooth_hessian", &path_smooth_hessian);
+  CHECK_GE(path_smooth_hessian,  0.0);
+
   GetString(params, "interaction_constraints", &interaction_constraints);
 
   GetInt(params, "verbosity", &verbosity);
@@ -740,6 +744,7 @@ std::string Config::SaveMembersToString() const {
   str_buf << "[cegb_penalty_feature_lazy: " << Common::Join(cegb_penalty_feature_lazy, ",") << "]\n";
   str_buf << "[cegb_penalty_feature_coupled: " << Common::Join(cegb_penalty_feature_coupled, ",") << "]\n";
   str_buf << "[path_smooth: " << path_smooth << "]\n";
+  str_buf << "[path_smooth_hessian: " << path_smooth_hessian << "]\n";
   str_buf << "[interaction_constraints: " << interaction_constraints << "]\n";
   str_buf << "[verbosity: " << verbosity << "]\n";
   str_buf << "[saved_feature_importance_type: " << saved_feature_importance_type << "]\n";
@@ -867,6 +872,7 @@ const std::unordered_map<std::string, std::vector<std::string>>& Config::paramet
     {"cegb_penalty_feature_lazy", {}},
     {"cegb_penalty_feature_coupled", {}},
     {"path_smooth", {}},
+    {"path_smooth_hessian", {}},
     {"interaction_constraints", {}},
     {"verbosity", {"verbose"}},
     {"input_model", {"model_input", "model_in"}},
@@ -1013,6 +1019,7 @@ const std::unordered_map<std::string, std::string>& Config::ParameterTypes() {
     {"cegb_penalty_feature_lazy", "vector<double>"},
     {"cegb_penalty_feature_coupled", "vector<double>"},
     {"path_smooth", "double"},
+    {"path_smooth_hessian", "double"},
     {"interaction_constraints", "vector<vector<int>>"},
     {"verbosity", "int"},
     {"input_model", "string"},

--- a/src/treelearner/cuda/cuda_best_split_finder.cpp
+++ b/src/treelearner/cuda/cuda_best_split_finder.cpp
@@ -35,8 +35,9 @@ CUDABestSplitFinder::CUDABestSplitFinder(
   max_cat_to_onehot_(config->max_cat_to_onehot),
   extra_trees_(config->extra_trees),
   extra_seed_(config->extra_seed),
-  use_smoothing_(config->path_smooth > 0),
-  path_smooth_(config->path_smooth),
+  use_smoothing_(config->effective_path_smooth() > 0),
+  path_smooth_(config->effective_path_smooth()),
+  path_smooth_use_hessian_(config->use_hessian_smoothing()),
   num_total_bin_(feature_hist_offsets.empty() ? 0 : static_cast<int>(feature_hist_offsets.back())),
   select_features_by_node_(select_features_by_node),
   cuda_hist_(cuda_hist) {
@@ -276,8 +277,9 @@ void CUDABestSplitFinder::ResetConfig(const Config* config, const hist_t* cuda_h
   max_cat_to_onehot_ = config->max_cat_to_onehot;
   extra_trees_ = config->extra_trees;
   extra_seed_ = config->extra_seed;
-  use_smoothing_ = (config->path_smooth > 0.0f);
-  path_smooth_ = config->path_smooth;
+  use_smoothing_ = (config->effective_path_smooth() > 0.0f);
+  path_smooth_ = config->effective_path_smooth();
+  path_smooth_use_hessian_ = config->use_hessian_smoothing();
   cuda_hist_ = cuda_hist;
 
   const int num_task_blocks = (num_tasks_ + NUM_TASKS_PER_SYNC_BLOCK - 1) / NUM_TASKS_PER_SYNC_BLOCK;

--- a/src/treelearner/cuda/cuda_best_split_finder.cu
+++ b/src/treelearner/cuda/cuda_best_split_finder.cu
@@ -137,6 +137,7 @@ __device__ void FindBestSplitsForLeafKernelInner(
   const double lambda_l1,
   const double lambda_l2,
   const double path_smooth,
+  const bool path_smooth_use_hessian,
   const data_size_t min_data_in_leaf,
   const double min_sum_hessian_in_leaf,
   const double min_gain_to_split,
@@ -227,7 +228,9 @@ __device__ void FindBestSplitsForLeafKernelInner(
         double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
           sum_left_gradient, sum_left_hessian, sum_right_gradient,
           sum_right_hessian, lambda_l1,
-          lambda_l2, path_smooth, left_count, right_count, parent_output);
+          lambda_l2, path_smooth,
+          path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count),
+          path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain > min_gain_shift) {
           local_gain = current_gain - min_gain_shift;
@@ -251,7 +254,9 @@ __device__ void FindBestSplitsForLeafKernelInner(
         double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
           sum_left_gradient, sum_left_hessian, sum_right_gradient,
           sum_right_hessian, lambda_l1,
-          lambda_l2, path_smooth, left_count, right_count, parent_output);
+          lambda_l2, path_smooth,
+          path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count),
+          path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain > min_gain_shift) {
           local_gain = current_gain - min_gain_shift;
@@ -282,9 +287,11 @@ __device__ void FindBestSplitsForLeafKernelInner(
       const double sum_left_hessian = sum_hessians - sum_right_hessian - kEpsilon;
       const data_size_t left_count = num_data - right_count;
       const double left_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_left_gradient,
-        sum_left_hessian, lambda_l1, lambda_l2, path_smooth, left_count, parent_output);
+        sum_left_hessian, lambda_l1, lambda_l2, path_smooth,
+        path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count), parent_output);
       const double right_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_right_gradient,
-        sum_right_hessian, lambda_l1, lambda_l2, path_smooth, right_count, parent_output);
+        sum_right_hessian, lambda_l1, lambda_l2, path_smooth,
+        path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
       cuda_best_split_info->left_sum_gradients = sum_left_gradient;
       cuda_best_split_info->left_sum_hessians = sum_left_hessian;
       cuda_best_split_info->left_count = left_count;
@@ -305,9 +312,11 @@ __device__ void FindBestSplitsForLeafKernelInner(
       const double sum_right_hessian = sum_hessians - sum_left_hessian - kEpsilon;
       const data_size_t right_count = num_data - left_count;
       const double left_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_left_gradient,
-        sum_left_hessian, lambda_l1, lambda_l2, path_smooth, left_count, parent_output);
+        sum_left_hessian, lambda_l1, lambda_l2, path_smooth,
+        path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count), parent_output);
       const double right_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_right_gradient,
-        sum_right_hessian, lambda_l1, lambda_l2, path_smooth, right_count, parent_output);
+        sum_right_hessian, lambda_l1, lambda_l2, path_smooth,
+        path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
       cuda_best_split_info->left_sum_gradients = sum_left_gradient;
       cuda_best_split_info->left_sum_hessians = sum_left_hessian;
       cuda_best_split_info->left_count = left_count;
@@ -335,6 +344,7 @@ __device__ void FindBestSplitsDiscretizedForLeafKernelInner(
   const double lambda_l1,
   const double lambda_l2,
   const double path_smooth,
+  const bool path_smooth_use_hessian,
   const data_size_t min_data_in_leaf,
   const double min_sum_hessian_in_leaf,
   const double min_gain_to_split,
@@ -424,7 +434,9 @@ __device__ void FindBestSplitsDiscretizedForLeafKernelInner(
         double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
           sum_left_gradient, sum_left_hessian + kEpsilon, sum_right_gradient,
           sum_right_hessian + kEpsilon, lambda_l1,
-          lambda_l2, path_smooth, left_count, right_count, parent_output);
+          lambda_l2, path_smooth,
+          path_smooth_use_hessian ? sum_left_hessian + kEpsilon : static_cast<double>(left_count),
+          path_smooth_use_hessian ? sum_right_hessian + kEpsilon : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain > min_gain_shift) {
           local_gain = current_gain - min_gain_shift;
@@ -451,7 +463,9 @@ __device__ void FindBestSplitsDiscretizedForLeafKernelInner(
         double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
           sum_left_gradient, sum_left_hessian + kEpsilon, sum_right_gradient,
           sum_right_hessian + kEpsilon, lambda_l1,
-          lambda_l2, path_smooth, left_count, right_count, parent_output);
+          lambda_l2, path_smooth,
+          path_smooth_use_hessian ? sum_left_hessian + kEpsilon : static_cast<double>(left_count),
+          path_smooth_use_hessian ? sum_right_hessian + kEpsilon : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain > min_gain_shift) {
           local_gain = current_gain - min_gain_shift;
@@ -473,9 +487,11 @@ __device__ void FindBestSplitsDiscretizedForLeafKernelInner(
     cuda_best_split_info->gain = local_gain;
     cuda_best_split_info->default_left = task->assume_out_default_left;
     const double left_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_left_gradient,
-      sum_left_hessian, lambda_l1, lambda_l2, path_smooth, left_count, parent_output);
+      sum_left_hessian, lambda_l1, lambda_l2, path_smooth,
+      path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count), parent_output);
     const double right_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_right_gradient,
-      sum_right_hessian, lambda_l1, lambda_l2, path_smooth, right_count, parent_output);
+      sum_right_hessian, lambda_l1, lambda_l2, path_smooth,
+      path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
     cuda_best_split_info->left_sum_gradients = sum_left_gradient;
     cuda_best_split_info->left_sum_hessians = sum_left_hessian;
     cuda_best_split_info->left_sum_of_gradients_hessians = sum_left_gradient_hessian;
@@ -504,6 +520,7 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner(
   const double lambda_l1,
   const double lambda_l2,
   const double path_smooth,
+  const bool path_smooth_use_hessian,
   const data_size_t min_data_in_leaf,
   const double min_sum_hessian_in_leaf,
   const double min_gain_to_split,
@@ -561,7 +578,9 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner(
             double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
               sum_other_gradient, sum_other_hessian, grad,
               hess + kEpsilon, lambda_l1,
-              l2, path_smooth, other_count, cnt, parent_output);
+              l2, path_smooth,
+              path_smooth_use_hessian ? sum_other_hessian : static_cast<double>(other_count),
+              path_smooth_use_hessian ? hess + kEpsilon : static_cast<double>(cnt), parent_output);
             if (current_gain > min_gain_shift) {
               local_gain = current_gain;
               threshold_found = true;
@@ -590,9 +609,11 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner(
       const double sum_right_hessian = sum_hessians - sum_left_hessian;
       const data_size_t right_count = static_cast<data_size_t>(__double2int_rn(sum_right_hessian * cnt_factor));
       const double left_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_left_gradient,
-        sum_left_hessian, lambda_l1, l2, path_smooth, left_count, parent_output);
+        sum_left_hessian, lambda_l1, l2, path_smooth,
+        path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count), parent_output);
       const double right_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_right_gradient,
-        sum_right_hessian, lambda_l1, l2, path_smooth, right_count, parent_output);
+        sum_right_hessian, lambda_l1, l2, path_smooth,
+        path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
       cuda_best_split_info->left_sum_gradients = sum_left_gradient;
       cuda_best_split_info->left_sum_hessians = sum_left_hessian;
       cuda_best_split_info->left_count = left_count;
@@ -675,7 +696,9 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner(
         double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
           sum_left_gradient, sum_left_hessian, sum_right_gradient,
           sum_right_hessian, lambda_l1,
-          l2, path_smooth, left_count, right_count, parent_output);
+          l2, path_smooth,
+          path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count),
+          path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain > local_gain) {
           local_gain = current_gain;
@@ -714,7 +737,9 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner(
         double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
           sum_left_gradient, sum_left_hessian, sum_right_gradient,
           sum_right_hessian, lambda_l1,
-          l2, path_smooth, left_count, right_count, parent_output);
+          l2, path_smooth,
+          path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count),
+          path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain > local_gain) {
           local_gain = current_gain;
@@ -753,9 +778,11 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner(
       const double sum_right_hessian = sum_hessians - sum_left_hessian;
       const data_size_t right_count = static_cast<data_size_t>(__double2int_rn(sum_right_hessian * cnt_factor));
       const double left_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_left_gradient,
-        sum_left_hessian, lambda_l1, l2, path_smooth, left_count, parent_output);
+        sum_left_hessian, lambda_l1, l2, path_smooth,
+        path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count), parent_output);
       const double right_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_right_gradient,
-        sum_right_hessian, lambda_l1, l2, path_smooth, right_count, parent_output);
+        sum_right_hessian, lambda_l1, l2, path_smooth,
+        path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
       cuda_best_split_info->left_sum_gradients = sum_left_gradient;
       cuda_best_split_info->left_sum_hessians = sum_left_hessian;
       cuda_best_split_info->left_count = left_count;
@@ -790,6 +817,7 @@ __global__ void FindBestSplitsForLeafKernel(
   const double lambda_l1,
   const double lambda_l2,
   const double path_smooth,
+  const bool path_smooth_use_hessian,
   const double cat_smooth,
   const double cat_l2,
   const int max_cat_threshold,
@@ -824,6 +852,7 @@ __global__ void FindBestSplitsForLeafKernel(
         lambda_l1,
         lambda_l2,
         path_smooth,
+        path_smooth_use_hessian,
         min_data_in_leaf,
         min_sum_hessian_in_leaf,
         min_gain_to_split,
@@ -851,6 +880,7 @@ __global__ void FindBestSplitsForLeafKernel(
           lambda_l1,
           lambda_l2,
           path_smooth,
+          path_smooth_use_hessian,
           min_data_in_leaf,
           min_sum_hessian_in_leaf,
           min_gain_to_split,
@@ -873,6 +903,7 @@ __global__ void FindBestSplitsForLeafKernel(
           lambda_l1,
           lambda_l2,
           path_smooth,
+          path_smooth_use_hessian,
           min_data_in_leaf,
           min_sum_hessian_in_leaf,
           min_gain_to_split,
@@ -912,6 +943,7 @@ __global__ void FindBestSplitsDiscretizedForLeafKernel(
   const double lambda_l1,
   const double lambda_l2,
   const double path_smooth,
+  const bool path_smooth_use_hessian,
   const double cat_smooth,
   const double cat_l2,
   const int max_cat_threshold,
@@ -960,6 +992,7 @@ __global__ void FindBestSplitsDiscretizedForLeafKernel(
             lambda_l1,
             lambda_l2,
             path_smooth,
+            path_smooth_use_hessian,
             min_data_in_leaf,
             min_sum_hessian_in_leaf,
             min_gain_to_split,
@@ -986,6 +1019,7 @@ __global__ void FindBestSplitsDiscretizedForLeafKernel(
             lambda_l1,
             lambda_l2,
             path_smooth,
+            path_smooth_use_hessian,
             min_data_in_leaf,
             min_sum_hessian_in_leaf,
             min_gain_to_split,
@@ -1014,6 +1048,7 @@ __global__ void FindBestSplitsDiscretizedForLeafKernel(
             lambda_l1,
             lambda_l2,
             path_smooth,
+            path_smooth_use_hessian,
             min_data_in_leaf,
             min_sum_hessian_in_leaf,
             min_gain_to_split,
@@ -1040,6 +1075,7 @@ __global__ void FindBestSplitsDiscretizedForLeafKernel(
             lambda_l1,
             lambda_l2,
             path_smooth,
+            path_smooth_use_hessian,
             min_data_in_leaf,
             min_sum_hessian_in_leaf,
             min_gain_to_split,
@@ -1072,6 +1108,7 @@ __device__ void FindBestSplitsForLeafKernelInner_GlobalMemory(
   const double lambda_l1,
   const double lambda_l2,
   const double path_smooth,
+  const bool path_smooth_use_hessian,
   const data_size_t min_data_in_leaf,
   const double min_sum_hessian_in_leaf,
   const double min_gain_to_split,
@@ -1180,7 +1217,9 @@ __device__ void FindBestSplitsForLeafKernelInner_GlobalMemory(
           double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
             sum_left_gradient, sum_left_hessian, sum_right_gradient,
             sum_right_hessian, lambda_l1,
-            lambda_l2, path_smooth, left_count, right_count, parent_output);
+            lambda_l2, path_smooth,
+            path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count),
+            path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
           // gain with split is worse than without split
           if (current_gain > min_gain_shift) {
             local_gain = current_gain - min_gain_shift;
@@ -1208,7 +1247,9 @@ __device__ void FindBestSplitsForLeafKernelInner_GlobalMemory(
           double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
             sum_left_gradient, sum_left_hessian, sum_right_gradient,
             sum_right_hessian, lambda_l1,
-            lambda_l2, path_smooth, left_count, right_count, parent_output);
+            lambda_l2, path_smooth,
+            path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count),
+            path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
           // gain with split is worse than without split
           if (current_gain > min_gain_shift) {
             local_gain = current_gain - min_gain_shift;
@@ -1240,9 +1281,11 @@ __device__ void FindBestSplitsForLeafKernelInner_GlobalMemory(
       const double sum_left_hessian = sum_hessians - sum_right_hessian - kEpsilon;
       const data_size_t left_count = num_data - right_count;
       const double left_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_left_gradient,
-        sum_left_hessian, lambda_l1, lambda_l2, path_smooth, left_count, parent_output);
+        sum_left_hessian, lambda_l1, lambda_l2, path_smooth,
+        path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count), parent_output);
       const double right_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_right_gradient,
-        sum_right_hessian, lambda_l1, lambda_l2, path_smooth, right_count, parent_output);
+        sum_right_hessian, lambda_l1, lambda_l2, path_smooth,
+        path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
       cuda_best_split_info->left_sum_gradients = sum_left_gradient;
       cuda_best_split_info->left_sum_hessians = sum_left_hessian;
       cuda_best_split_info->left_count = left_count;
@@ -1265,9 +1308,11 @@ __device__ void FindBestSplitsForLeafKernelInner_GlobalMemory(
       const double sum_right_hessian = sum_hessians - sum_left_hessian - kEpsilon;
       const data_size_t right_count = num_data - left_count;
       const double left_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_left_gradient,
-        sum_left_hessian, lambda_l1, lambda_l2, path_smooth, left_count, parent_output);
+        sum_left_hessian, lambda_l1, lambda_l2, path_smooth,
+        path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count), parent_output);
       const double right_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_right_gradient,
-        sum_right_hessian, lambda_l1, lambda_l2, path_smooth, right_count, parent_output);
+        sum_right_hessian, lambda_l1, lambda_l2, path_smooth,
+        path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
       cuda_best_split_info->left_sum_gradients = sum_left_gradient;
       cuda_best_split_info->left_sum_hessians = sum_left_hessian;
       cuda_best_split_info->left_count = left_count;
@@ -1295,6 +1340,7 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner_GlobalMemory(
   const double lambda_l1,
   const double lambda_l2,
   const double path_smooth,
+  const bool path_smooth_use_hessian,
   const data_size_t min_data_in_leaf,
   const double min_sum_hessian_in_leaf,
   const double min_gain_to_split,
@@ -1357,7 +1403,9 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner_GlobalMemory(
             double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
               sum_other_gradient, sum_other_hessian, grad,
               hess + kEpsilon, lambda_l1,
-              l2, path_smooth, other_count, cnt, parent_output);
+              l2, path_smooth,
+              path_smooth_use_hessian ? sum_other_hessian : static_cast<double>(other_count),
+              path_smooth_use_hessian ? hess + kEpsilon : static_cast<double>(cnt), parent_output);
             if (current_gain > min_gain_shift) {
               best_threshold = bin;
               local_gain = current_gain - min_gain_shift;
@@ -1387,9 +1435,11 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner_GlobalMemory(
       const double sum_right_hessian = sum_hessians - sum_left_hessian;
       const data_size_t right_count = static_cast<data_size_t>(__double2int_rn(sum_right_hessian * cnt_factor));
       const double left_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_left_gradient,
-        sum_left_hessian, lambda_l1, l2, path_smooth, left_count, parent_output);
+        sum_left_hessian, lambda_l1, l2, path_smooth,
+        path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count), parent_output);
       const double right_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_right_gradient,
-        sum_right_hessian, lambda_l1, l2, path_smooth, right_count, parent_output);
+        sum_right_hessian, lambda_l1, l2, path_smooth,
+        path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
       cuda_best_split_info->left_sum_gradients = sum_left_gradient;
       cuda_best_split_info->left_sum_hessians = sum_left_hessian;
       cuda_best_split_info->left_count = left_count;
@@ -1469,7 +1519,9 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner_GlobalMemory(
         double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
           sum_left_gradient, sum_left_hessian, sum_right_gradient,
           sum_right_hessian, lambda_l1,
-          l2, path_smooth, left_count, right_count, parent_output);
+          l2, path_smooth,
+          path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count),
+          path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain > min_gain_shift) {
           local_gain = current_gain - min_gain_shift;
@@ -1508,7 +1560,9 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner_GlobalMemory(
         double current_gain = CUDALeafSplits::GetSplitGains<USE_L1, USE_SMOOTHING>(
           sum_left_gradient, sum_left_hessian, sum_right_gradient,
           sum_right_hessian, lambda_l1,
-          l2, path_smooth, left_count, right_count, parent_output);
+          l2, path_smooth,
+          path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count),
+          path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain > min_gain_shift) {
           local_gain = current_gain - min_gain_shift;
@@ -1549,9 +1603,11 @@ __device__ void FindBestSplitsForLeafKernelCategoricalInner_GlobalMemory(
       const double sum_right_hessian = sum_hessians - sum_left_hessian;
       const data_size_t right_count = static_cast<data_size_t>(__double2int_rn(sum_right_hessian * cnt_factor));
       const double left_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_left_gradient,
-        sum_left_hessian, lambda_l1, l2, path_smooth, left_count, parent_output);
+        sum_left_hessian, lambda_l1, l2, path_smooth,
+        path_smooth_use_hessian ? sum_left_hessian : static_cast<double>(left_count), parent_output);
       const double right_output = CUDALeafSplits::CalculateSplittedLeafOutput<USE_L1, USE_SMOOTHING>(sum_right_gradient,
-        sum_right_hessian, lambda_l1, l2, path_smooth, right_count, parent_output);
+        sum_right_hessian, lambda_l1, l2, path_smooth,
+        path_smooth_use_hessian ? sum_right_hessian : static_cast<double>(right_count), parent_output);
       cuda_best_split_info->left_sum_gradients = sum_left_gradient;
       cuda_best_split_info->left_sum_hessians = sum_left_hessian;
       cuda_best_split_info->left_count = left_count;
@@ -1586,6 +1642,7 @@ __global__ void FindBestSplitsForLeafKernel_GlobalMemory(
   const double lambda_l1,
   const double lambda_l2,
   const double path_smooth,
+  const bool path_smooth_use_hessian,
   const double cat_smooth,
   const double cat_l2,
   const int max_cat_threshold,
@@ -1629,6 +1686,7 @@ __global__ void FindBestSplitsForLeafKernel_GlobalMemory(
         lambda_l1,
         lambda_l2,
         path_smooth,
+        path_smooth_use_hessian,
         min_data_in_leaf,
         min_sum_hessian_in_leaf,
         min_gain_to_split,
@@ -1661,6 +1719,7 @@ __global__ void FindBestSplitsForLeafKernel_GlobalMemory(
           lambda_l1,
           lambda_l2,
           path_smooth,
+          path_smooth_use_hessian,
           min_data_in_leaf,
           min_sum_hessian_in_leaf,
           min_gain_to_split,
@@ -1686,6 +1745,7 @@ __global__ void FindBestSplitsForLeafKernel_GlobalMemory(
           lambda_l1,
           lambda_l2,
           path_smooth,
+          path_smooth_use_hessian,
           min_data_in_leaf,
           min_sum_hessian_in_leaf,
           min_gain_to_split,
@@ -1739,6 +1799,7 @@ __global__ void FindBestSplitsForLeafKernel_GlobalMemory(
     lambda_l1_, \
     lambda_l2_, \
     path_smooth_, \
+    path_smooth_use_hessian_, \
     cat_smooth_, \
     cat_l2_, \
     max_cat_threshold_, \
@@ -1865,6 +1926,7 @@ void CUDABestSplitFinder::LaunchFindBestSplitsForLeafKernelInner2(LaunchFindBest
     lambda_l1_, \
     lambda_l2_, \
     path_smooth_, \
+    path_smooth_use_hessian_, \
     cat_smooth_, \
     cat_l2_, \
     max_cat_threshold_, \

--- a/src/treelearner/cuda/cuda_best_split_finder.hpp
+++ b/src/treelearner/cuda/cuda_best_split_finder.hpp
@@ -196,6 +196,7 @@ class CUDABestSplitFinder {
   int extra_seed_;
   bool use_smoothing_;
   double path_smooth_;
+  bool path_smooth_use_hessian_;
   std::vector<cudaStream_t> cuda_streams_;
   // for best split find tasks
   std::vector<SplitFindTask> split_find_tasks_;

--- a/src/treelearner/cuda/cuda_leaf_splits.hpp
+++ b/src/treelearner/cuda/cuda_leaf_splits.hpp
@@ -75,7 +75,7 @@ class CUDALeafSplits: public NCCLInfo {
   template <bool USE_L1, bool USE_SMOOTHING>
   __device__ static double CalculateSplittedLeafOutput(double sum_gradients,
                                           double sum_hessians, double l1, double l2,
-                                          double path_smooth, data_size_t num_data,
+                                          double path_smooth, double num_data,
                                           double parent_output) {
     double ret;
     if (USE_L1) {
@@ -106,7 +106,7 @@ class CUDALeafSplits: public NCCLInfo {
   template <bool USE_L1, bool USE_SMOOTHING>
   __device__ static double GetLeafGain(double sum_gradients, double sum_hessians,
                           double l1, double l2,
-                          double path_smooth, data_size_t num_data,
+                          double path_smooth, double num_data,
                           double parent_output) {
     if (!USE_SMOOTHING) {
       if (USE_L1) {
@@ -129,8 +129,8 @@ class CUDALeafSplits: public NCCLInfo {
                             double sum_right_hessians,
                             double l1, double l2,
                             double path_smooth,
-                            data_size_t left_count,
-                            data_size_t right_count,
+                            double left_count,
+                            double right_count,
                             double parent_output) {
     return GetLeafGain<USE_L1, USE_SMOOTHING>(sum_left_gradients,
                       sum_left_hessians,

--- a/src/treelearner/cuda/cuda_single_gpu_tree_learner.cpp
+++ b/src/treelearner/cuda/cuda_single_gpu_tree_learner.cpp
@@ -178,10 +178,12 @@ Tree* CUDASingleGPUTreeLearner::Train(const score_t* gradients,
   std::unique_ptr<CUDATree> tree(new CUDATree(config_->num_leaves, track_branch_features,
     config_->linear_tree, gpu_device_id_, has_categorical_feature_));
   // set the root value by hand, as it is not handled by splits
+  const double cuda_root_smoothing = config_->use_hessian_smoothing() ?
+    leaf_sum_hessians_[smaller_leaf_index_] : static_cast<double>(num_data_);
   tree->SetLeafOutput(0, CUDALeafSplits::CalculateSplittedLeafOutput<true, false>(
     leaf_sum_gradients_[smaller_leaf_index_], leaf_sum_hessians_[smaller_leaf_index_],
-    config_->lambda_l1, config_->lambda_l2,  config_->path_smooth,
-    static_cast<data_size_t>(num_data_), 0));
+    config_->lambda_l1, config_->lambda_l2, config_->effective_path_smooth(),
+    cuda_root_smoothing, 0));
   tree->SyncLeafOutputFromHostToCUDA();
   for (int i = 0; i < config_->num_leaves - 1; ++i) {
     global_timer.Start("CUDASingleGPUTreeLearner::ConstructHistogramForLeaf");

--- a/src/treelearner/cuda/cuda_single_gpu_tree_learner.cu
+++ b/src/treelearner/cuda/cuda_single_gpu_tree_learner.cu
@@ -87,6 +87,7 @@ __global__ void CalcRefitLeafOutputKernel(
   const double lambda_l1,
   const double lambda_l2,
   const double path_smooth,
+  const bool path_smooth_use_hessian,
   const double shrinkage_rate,
   const double refit_decay_rate,
   double* leaf_value) {
@@ -109,8 +110,10 @@ __global__ void CalcRefitLeafOutputKernel(
         const double parent_output =
           CUDALeafSplits::CalculateSplittedLeafOutput<false, true>(
             sum_gradients_of_parent, sum_hessians_of_parent, lambda_l1, lambda_l2, 0.0f, 0, 0.0f);
+        const double smoothing_count = path_smooth_use_hessian ?
+          sum_hessians : static_cast<double>(num_data);
           new_leaf_value = CUDALeafSplits::CalculateSplittedLeafOutput<false, true>(
-          sum_gradients, sum_hessians, lambda_l1, lambda_l2, path_smooth, num_data_in_parent, parent_output);
+          sum_gradients, sum_hessians, lambda_l1, lambda_l2, path_smooth, smoothing_count, parent_output);
       } else {
         new_leaf_value = CUDALeafSplits::CalculateSplittedLeafOutput<false, false>(sum_gradients, sum_hessians, lambda_l1, lambda_l2, 0.0f, 0, 0.0f);
       }
@@ -139,14 +142,14 @@ void CUDASingleGPUTreeLearner::LaunchReduceLeafStatKernel(
       cuda_leaf_gradient_stat_buffer_.RawData(), cuda_leaf_hessian_stat_buffer_.RawData());
   }
   const bool use_l1 = config_->lambda_l1 > 0.0f;
-  const bool use_smoothing = config_->path_smooth > 0.0f;
+  const bool use_smoothing = config_->effective_path_smooth() > 0.0f;
   num_block = (num_leaves + CUDA_SINGLE_GPU_TREE_LEARNER_BLOCK_SIZE - 1) / CUDA_SINGLE_GPU_TREE_LEARNER_BLOCK_SIZE;
 
   #define CalcRefitLeafOutputKernel_ARGS \
     num_leaves, cuda_leaf_gradient_stat_buffer_.RawData(), cuda_leaf_hessian_stat_buffer_.RawData(), num_data_in_leaf, \
     leaf_parent, left_child, right_child, \
-    config_->lambda_l1, config_->lambda_l2, config_->path_smooth, \
-    shrinkage_rate, config_->refit_decay_rate, cuda_leaf_value
+    config_->lambda_l1, config_->lambda_l2, config_->effective_path_smooth(), \
+    config_->use_hessian_smoothing(), shrinkage_rate, config_->refit_decay_rate, cuda_leaf_value
 
   if (!use_l1) {
     if (!use_smoothing) {
@@ -265,10 +268,10 @@ void CUDASingleGPUTreeLearner::LaunchCalcLeafValuesGivenGradStat(
   #define CalcRefitLeafOutputKernel_ARGS \
     cuda_tree->num_leaves(), cuda_leaf_gradient_stat_buffer_.RawData(), cuda_leaf_hessian_stat_buffer_.RawData(), num_data_in_leaf, \
     cuda_tree->cuda_leaf_parent(), cuda_tree->cuda_left_child(), cuda_tree->cuda_right_child(), \
-    config_->lambda_l1, config_->lambda_l2, config_->path_smooth, \
-    1.0f, config_->refit_decay_rate, cuda_tree->cuda_leaf_value_ref()
+    config_->lambda_l1, config_->lambda_l2, config_->effective_path_smooth(), \
+    config_->use_hessian_smoothing(), 1.0f, config_->refit_decay_rate, cuda_tree->cuda_leaf_value_ref()
   const bool use_l1 = config_->lambda_l1 > 0.0f;
-  const bool use_smoothing = config_->path_smooth > 0.0f;
+  const bool use_smoothing = config_->effective_path_smooth() > 0.0f;
   const int num_block = (cuda_tree->num_leaves() + CUDA_SINGLE_GPU_TREE_LEARNER_BLOCK_SIZE - 1) / CUDA_SINGLE_GPU_TREE_LEARNER_BLOCK_SIZE;
   if (!use_l1) {
     if (!use_smoothing) {

--- a/src/treelearner/feature_histogram.cpp
+++ b/src/treelearner/feature_histogram.cpp
@@ -30,7 +30,7 @@ void FeatureHistogram::FuncForCategorical() {
 
 template <bool USE_RAND, bool USE_MC>
 void FeatureHistogram::FuncForCategoricalL1() {
-  if (meta_->config->path_smooth > kEpsilon) {
+  if (meta_->config->effective_path_smooth() > kEpsilon) {
     FuncForCategoricalL2<USE_RAND, USE_MC, true>();
   } else {
     FuncForCategoricalL2<USE_RAND, USE_MC, false>();
@@ -223,7 +223,9 @@ void FeatureHistogram::FindBestThresholdCategoricalInner(double sum_gradient,
       double current_gain = GetSplitGains<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
           sum_other_gradient, sum_other_hessian, grad, hess + kEpsilon,
           meta_->config->lambda_l1, l2, meta_->config->max_delta_step,
-          constraints, 0, meta_->config->path_smooth, other_count, cnt, parent_output);
+          constraints, 0, meta_->config->effective_path_smooth(),
+          meta_->config->use_hessian_smoothing() ? sum_other_hessian : static_cast<double>(other_count),
+          meta_->config->use_hessian_smoothing() ? (hess + kEpsilon) : static_cast<double>(cnt), parent_output);
       // gain with split is worse than without split
       if (current_gain <= min_gain_shift) {
         continue;
@@ -325,8 +327,9 @@ void FeatureHistogram::FindBestThresholdCategoricalInner(double sum_gradient,
         double current_gain = GetSplitGains<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
             sum_left_gradient, sum_left_hessian, sum_right_gradient,
             sum_right_hessian, meta_->config->lambda_l1, l2,
-            meta_->config->max_delta_step, constraints, 0, meta_->config->path_smooth,
-            left_count, right_count, parent_output);
+            meta_->config->max_delta_step, constraints, 0, meta_->config->effective_path_smooth(),
+            meta_->config->use_hessian_smoothing() ? sum_left_hessian : static_cast<double>(left_count),
+            meta_->config->use_hessian_smoothing() ? sum_right_hessian : static_cast<double>(right_count), parent_output);
         if (current_gain <= min_gain_shift) {
           continue;
         }
@@ -344,18 +347,20 @@ void FeatureHistogram::FindBestThresholdCategoricalInner(double sum_gradient,
   }
 
   if (is_splittable_) {
+    const double best_left_smoothing = meta_->config->use_hessian_smoothing() ? best_sum_left_hessian : static_cast<double>(best_left_count);
+    const double best_right_smoothing = meta_->config->use_hessian_smoothing() ? (sum_hessian - best_sum_left_hessian) : static_cast<double>(num_data - best_left_count);
     output->left_output = CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
         best_sum_left_gradient, best_sum_left_hessian,
         meta_->config->lambda_l1, l2, meta_->config->max_delta_step,
-        constraints->LeftToBasicConstraint(), meta_->config->path_smooth, best_left_count, parent_output);
+        constraints->LeftToBasicConstraint(), meta_->config->effective_path_smooth(), best_left_smoothing, parent_output);
     output->left_count = best_left_count;
     output->left_sum_gradient = best_sum_left_gradient;
     output->left_sum_hessian = best_sum_left_hessian - kEpsilon;
     output->right_output = CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
         sum_gradient - best_sum_left_gradient,
         sum_hessian - best_sum_left_hessian, meta_->config->lambda_l1, l2,
-        meta_->config->max_delta_step, constraints->RightToBasicConstraint(), meta_->config->path_smooth,
-        num_data - best_left_count, parent_output);
+        meta_->config->max_delta_step, constraints->RightToBasicConstraint(), meta_->config->effective_path_smooth(),
+        best_right_smoothing, parent_output);
     output->right_count = num_data - best_left_count;
     output->right_sum_gradient = sum_gradient - best_sum_left_gradient;
     output->right_sum_hessian =
@@ -504,7 +509,9 @@ void FeatureHistogram::FindBestThresholdCategoricalIntInner(int64_t int_sum_grad
       double current_gain = GetSplitGains<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
           sum_other_gradient, sum_other_hessian, grad, hess,
           meta_->config->lambda_l1, l2, meta_->config->max_delta_step,
-          constraints, 0, meta_->config->path_smooth, other_count, cnt, parent_output);
+          constraints, 0, meta_->config->effective_path_smooth(),
+          meta_->config->use_hessian_smoothing() ? sum_other_hessian : static_cast<double>(other_count),
+          meta_->config->use_hessian_smoothing() ? hess : static_cast<double>(cnt), parent_output);
       // gain with split is worse than without split
       if (current_gain <= min_gain_shift) {
         continue;
@@ -655,8 +662,9 @@ void FeatureHistogram::FindBestThresholdCategoricalIntInner(int64_t int_sum_grad
         double current_gain = GetSplitGains<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
             sum_left_gradient, sum_left_hessian, sum_right_gradient,
             sum_right_hessian, meta_->config->lambda_l1, l2,
-            meta_->config->max_delta_step, constraints, 0, meta_->config->path_smooth,
-            left_count, right_count, parent_output);
+            meta_->config->max_delta_step, constraints, 0, meta_->config->effective_path_smooth(),
+            meta_->config->use_hessian_smoothing() ? sum_left_hessian : static_cast<double>(left_count),
+            meta_->config->use_hessian_smoothing() ? sum_right_hessian : static_cast<double>(right_count), parent_output);
         if (current_gain <= min_gain_shift) {
           continue;
         }
@@ -700,18 +708,20 @@ void FeatureHistogram::FindBestThresholdCategoricalIntInner(int64_t int_sum_grad
         best_sum_left_gradient_and_hessian;
     const int64_t best_sum_right_gradient_and_hessian_int64 = int_sum_gradient_and_hessian - best_sum_left_gradient_and_hessian_int64;
 
+    const double best_left_smoothing2 = meta_->config->use_hessian_smoothing() ? best_sum_left_hessian : static_cast<double>(best_left_count);
+    const double best_right_smoothing2 = meta_->config->use_hessian_smoothing() ? best_sum_right_hessian : static_cast<double>(best_right_count);
     output->left_output = CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
         best_sum_left_gradient, best_sum_left_hessian,
         meta_->config->lambda_l1, l2, meta_->config->max_delta_step,
-        constraints->LeftToBasicConstraint(), meta_->config->path_smooth, best_left_count, parent_output);
+        constraints->LeftToBasicConstraint(), meta_->config->effective_path_smooth(), best_left_smoothing2, parent_output);
     output->left_count = best_left_count;
     output->left_sum_gradient = best_sum_left_gradient;
     output->left_sum_hessian = best_sum_left_hessian;
     output->right_output = CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
         best_sum_right_gradient,
         best_sum_right_hessian, meta_->config->lambda_l1, l2,
-        meta_->config->max_delta_step, constraints->RightToBasicConstraint(), meta_->config->path_smooth,
-        best_right_count, parent_output);
+        meta_->config->max_delta_step, constraints->RightToBasicConstraint(), meta_->config->effective_path_smooth(),
+        best_right_smoothing2, parent_output);
     output->right_count = best_right_count;
     output->right_sum_gradient = best_sum_right_gradient;
     output->right_sum_hessian = best_sum_right_hessian;

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -196,9 +196,10 @@ class FeatureHistogram {
     is_splittable_ = false;
     output->monotone_type = meta_->monotone_type;
 
+    const double smoothing_weight = meta_->config->use_hessian_smoothing() ? sum_hessian : static_cast<double>(num_data);
     double gain_shift = GetLeafGain<USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
         sum_gradient, sum_hessian, meta_->config->lambda_l1, meta_->config->lambda_l2,
-        meta_->config->max_delta_step, meta_->config->path_smooth, num_data, parent_output);
+        meta_->config->max_delta_step, meta_->config->effective_path_smooth(), smoothing_weight, parent_output);
     *rand_threshold = 0;
     if (USE_RAND) {
       if (meta_->num_bin - 2 > 0) {
@@ -217,9 +218,10 @@ class FeatureHistogram {
     const uint32_t int_sum_hessian = static_cast<uint32_t>(sum_gradient_and_hessian & 0x00000000ffffffff);
     const double sum_gradient = static_cast<double>(int_sum_gradient) * grad_scale;
     const double sum_hessian = static_cast<double>(int_sum_hessian) * hess_scale;
+    const double smoothing_weight = meta_->config->use_hessian_smoothing() ? sum_hessian : static_cast<double>(num_data);
     double gain_shift = GetLeafGain<USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
         sum_gradient, sum_hessian, meta_->config->lambda_l1, meta_->config->lambda_l2,
-        meta_->config->max_delta_step, meta_->config->path_smooth, num_data, parent_output);
+        meta_->config->max_delta_step, meta_->config->effective_path_smooth(), smoothing_weight, parent_output);
     *rand_threshold = 0;
     if (USE_RAND) {
       if (meta_->num_bin - 2 > 0) {
@@ -263,7 +265,7 @@ class FeatureHistogram {
 
   template <bool USE_RAND, bool USE_MC, bool USE_L1, bool USE_MAX_OUTPUT>
   void FuncForNumricalL2() {
-    if (meta_->config->path_smooth > kEpsilon) {
+    if (meta_->config->effective_path_smooth() > kEpsilon) {
       FuncForNumricalL3<USE_RAND, USE_MC, USE_L1, USE_MAX_OUTPUT, true>();
     } else {
       FuncForNumricalL3<USE_RAND, USE_MC, USE_L1, USE_MAX_OUTPUT, false>();
@@ -487,7 +489,7 @@ class FeatureHistogram {
   void GatherInfoForThresholdNumerical(double sum_gradient, double sum_hessian,
                                        uint32_t threshold, data_size_t num_data,
                                        double parent_output, SplitInfo* output) {
-    bool use_smoothing = meta_->config->path_smooth > kEpsilon;
+    bool use_smoothing = meta_->config->effective_path_smooth() > kEpsilon;
     if (use_smoothing) {
       GatherInfoForThresholdNumericalInner<true>(sum_gradient, sum_hessian,
                                                  threshold, num_data,
@@ -549,15 +551,18 @@ class FeatureHistogram {
     double sum_left_gradient = sum_gradient - sum_right_gradient;
     double sum_left_hessian = sum_hessian - sum_right_hessian;
     data_size_t left_count = num_data - right_count;
+
+    const double left_smoothing = meta_->config->use_hessian_smoothing() ? sum_left_hessian : static_cast<double>(left_count);
+    const double right_smoothing = meta_->config->use_hessian_smoothing() ? sum_right_hessian : static_cast<double>(right_count);
     double current_gain =
         GetLeafGain<true, true, USE_SMOOTHING>(
             sum_left_gradient, sum_left_hessian, meta_->config->lambda_l1,
             meta_->config->lambda_l2, meta_->config->max_delta_step,
-            meta_->config->path_smooth, left_count, parent_output) +
+            meta_->config->effective_path_smooth(), left_smoothing, parent_output) +
         GetLeafGain<true, true, USE_SMOOTHING>(
             sum_right_gradient, sum_right_hessian, meta_->config->lambda_l1,
             meta_->config->lambda_l2, meta_->config->max_delta_step,
-            meta_->config->path_smooth, right_count, parent_output);
+            meta_->config->effective_path_smooth(), right_smoothing, parent_output);
 
     // gain with split is worse than without split
     if (std::isnan(current_gain) || current_gain <= min_gain_shift) {
@@ -572,15 +577,15 @@ class FeatureHistogram {
     output->left_output = CalculateSplittedLeafOutput<true, true, USE_SMOOTHING>(
         sum_left_gradient, sum_left_hessian, meta_->config->lambda_l1,
         meta_->config->lambda_l2, meta_->config->max_delta_step,
-        meta_->config->path_smooth, left_count, parent_output);
+        meta_->config->effective_path_smooth(), left_smoothing, parent_output);
     output->left_count = left_count;
     output->left_sum_gradient = sum_left_gradient;
     output->left_sum_hessian = sum_left_hessian - kEpsilon;
     output->right_output = CalculateSplittedLeafOutput<true, true, USE_SMOOTHING>(
         sum_gradient - sum_left_gradient, sum_hessian - sum_left_hessian,
         meta_->config->lambda_l1, meta_->config->lambda_l2,
-        meta_->config->max_delta_step, meta_->config->path_smooth,
-        right_count, parent_output);
+        meta_->config->max_delta_step, meta_->config->effective_path_smooth(),
+        right_smoothing, parent_output);
     output->right_count = num_data - left_count;
     output->right_sum_gradient = sum_gradient - sum_left_gradient;
     output->right_sum_hessian = sum_hessian - sum_left_hessian - kEpsilon;
@@ -591,7 +596,7 @@ class FeatureHistogram {
   void GatherInfoForThresholdCategorical(double sum_gradient,  double sum_hessian,
                                          uint32_t threshold, data_size_t num_data,
                                          double parent_output, SplitInfo* output) {
-    bool use_smoothing = meta_->config->path_smooth > kEpsilon;
+    bool use_smoothing = meta_->config->effective_path_smooth() > kEpsilon;
     if (use_smoothing) {
       GatherInfoForThresholdCategoricalInner<true>(sum_gradient, sum_hessian, threshold,
                                                    num_data, parent_output, output);
@@ -629,17 +634,20 @@ class FeatureHistogram {
     double sum_right_hessian = sum_hessian - sum_left_hessian;
     double sum_left_gradient = grad;
     double sum_right_gradient = sum_gradient - sum_left_gradient;
+
+    const double left_smoothing = meta_->config->use_hessian_smoothing() ? sum_left_hessian : static_cast<double>(left_count);
+    const double right_smoothing = meta_->config->use_hessian_smoothing() ? sum_right_hessian : static_cast<double>(right_count);
     // current split gain
     double current_gain =
         GetLeafGain<true, true, USE_SMOOTHING>(sum_right_gradient, sum_right_hessian,
                                       meta_->config->lambda_l1, l2,
                                       meta_->config->max_delta_step,
-                                      meta_->config->path_smooth, right_count,
+                                      meta_->config->effective_path_smooth(), right_smoothing,
                                       parent_output) +
         GetLeafGain<true, true, USE_SMOOTHING>(sum_left_gradient, sum_left_hessian,
                                       meta_->config->lambda_l1, l2,
                                       meta_->config->max_delta_step,
-                                      meta_->config->path_smooth, left_count,
+                                      meta_->config->effective_path_smooth(), left_smoothing,
                                       parent_output);
     if (std::isnan(current_gain) || current_gain <= min_gain_shift) {
       output->gain = kMinScore;
@@ -649,14 +657,14 @@ class FeatureHistogram {
     }
     output->left_output = CalculateSplittedLeafOutput<true, true, USE_SMOOTHING>(
         sum_left_gradient, sum_left_hessian, meta_->config->lambda_l1, l2,
-        meta_->config->max_delta_step, meta_->config->path_smooth, left_count,
+        meta_->config->max_delta_step, meta_->config->effective_path_smooth(), left_smoothing,
         parent_output);
     output->left_count = left_count;
     output->left_sum_gradient = sum_left_gradient;
     output->left_sum_hessian = sum_left_hessian - kEpsilon;
     output->right_output = CalculateSplittedLeafOutput<true, true, USE_SMOOTHING>(
         sum_right_gradient, sum_right_hessian, meta_->config->lambda_l1, l2,
-        meta_->config->max_delta_step, meta_->config->path_smooth, right_count,
+        meta_->config->max_delta_step, meta_->config->effective_path_smooth(), right_smoothing,
         parent_output);
     output->right_count = right_count;
     output->right_sum_gradient = sum_gradient - sum_left_gradient;
@@ -718,7 +726,7 @@ class FeatureHistogram {
   static double CalculateSplittedLeafOutput(double sum_gradients,
                                             double sum_hessians, double l1,
                                             double l2, double max_delta_step,
-                                            double smoothing, data_size_t num_data,
+                                            double smoothing, double smoothing_weight,
                                             double parent_output) {
     double ret;
     if (USE_L1) {
@@ -732,8 +740,8 @@ class FeatureHistogram {
       }
     }
     if (USE_SMOOTHING) {
-      ret = ret * (num_data / smoothing) / (num_data / smoothing + 1) \
-          + parent_output / (num_data / smoothing + 1);
+      ret = ret * (smoothing_weight / smoothing) / (smoothing_weight / smoothing + 1) \
+          + parent_output / (smoothing_weight / smoothing + 1);
     }
     return ret;
   }
@@ -742,9 +750,9 @@ class FeatureHistogram {
   static double CalculateSplittedLeafOutput(
       double sum_gradients, double sum_hessians, double l1, double l2,
       double max_delta_step, const BasicConstraint& constraints,
-      double smoothing, data_size_t num_data, double parent_output) {
+      double smoothing, double smoothing_weight, double parent_output) {
     double ret = CalculateSplittedLeafOutput<USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
-        sum_gradients, sum_hessians, l1, l2, max_delta_step, smoothing, num_data, parent_output);
+        sum_gradients, sum_hessians, l1, l2, max_delta_step, smoothing, smoothing_weight, parent_output);
     if (USE_MC) {
       if (ret < constraints.min) {
         ret = constraints.min;
@@ -765,27 +773,27 @@ class FeatureHistogram {
                               const FeatureConstraint* constraints,
                               int8_t monotone_constraint,
                               double smoothing,
-                              data_size_t left_count,
-                              data_size_t right_count,
+                              double left_smoothing_weight,
+                              double right_smoothing_weight,
                               double parent_output) {
     if (!USE_MC) {
       return GetLeafGain<USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(sum_left_gradients,
                                                                 sum_left_hessians, l1, l2,
                                                                 max_delta_step, smoothing,
-                                                                left_count, parent_output) +
+                                                                left_smoothing_weight, parent_output) +
              GetLeafGain<USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(sum_right_gradients,
                                                                 sum_right_hessians, l1, l2,
                                                                 max_delta_step, smoothing,
-                                                                right_count, parent_output);
+                                                                right_smoothing_weight, parent_output);
     } else {
       double left_output =
           CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
               sum_left_gradients, sum_left_hessians, l1, l2, max_delta_step,
-              constraints->LeftToBasicConstraint(), smoothing, left_count, parent_output);
+              constraints->LeftToBasicConstraint(), smoothing, left_smoothing_weight, parent_output);
       double right_output =
           CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
               sum_right_gradients, sum_right_hessians, l1, l2, max_delta_step,
-              constraints->RightToBasicConstraint(), smoothing, right_count, parent_output);
+              constraints->RightToBasicConstraint(), smoothing, right_smoothing_weight, parent_output);
       if (((monotone_constraint > 0) && (left_output > right_output)) ||
           ((monotone_constraint < 0) && (left_output < right_output))) {
         return 0;
@@ -800,7 +808,7 @@ class FeatureHistogram {
   template <bool USE_L1, bool USE_MAX_OUTPUT, bool USE_SMOOTHING>
   static double GetLeafGain(double sum_gradients, double sum_hessians,
                             double l1, double l2, double max_delta_step,
-                            double smoothing, data_size_t num_data, double parent_output) {
+                            double smoothing, double smoothing_weight, double parent_output) {
     if (!USE_MAX_OUTPUT && !USE_SMOOTHING) {
       if (USE_L1) {
         const double sg_l1 = ThresholdL1(sum_gradients, l1);
@@ -810,7 +818,7 @@ class FeatureHistogram {
       }
     } else {
       double output = CalculateSplittedLeafOutput<USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
-          sum_gradients, sum_hessians, l1, l2, max_delta_step, smoothing, num_data, parent_output);
+          sum_gradients, sum_hessians, l1, l2, max_delta_step, smoothing, smoothing_weight, parent_output);
       return GetLeafGainGivenOutput<USE_L1>(sum_gradients, sum_hessians, l1, l2, output);
     }
   }
@@ -842,6 +850,7 @@ class FeatureHistogram {
     data_size_t best_left_count = 0;
     uint32_t best_threshold = static_cast<uint32_t>(meta_->num_bin);
     const double cnt_factor = num_data / sum_hessian;
+
 
     BasicConstraint best_right_constraints;
     BasicConstraint best_left_constraints;
@@ -908,8 +917,9 @@ class FeatureHistogram {
             sum_left_gradient, sum_left_hessian, sum_right_gradient,
             sum_right_hessian, meta_->config->lambda_l1,
             meta_->config->lambda_l2, meta_->config->max_delta_step,
-            constraints, meta_->monotone_type, meta_->config->path_smooth,
-            left_count, right_count, parent_output);
+            constraints, meta_->monotone_type, meta_->config->effective_path_smooth(),
+            meta_->config->use_hessian_smoothing() ? sum_left_hessian : static_cast<double>(left_count),
+            meta_->config->use_hessian_smoothing() ? sum_right_hessian : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain <= min_gain_shift) {
           continue;
@@ -1001,8 +1011,9 @@ class FeatureHistogram {
             sum_left_gradient, sum_left_hessian, sum_right_gradient,
             sum_right_hessian, meta_->config->lambda_l1,
             meta_->config->lambda_l2, meta_->config->max_delta_step,
-            constraints, meta_->monotone_type, meta_->config->path_smooth, left_count,
-            right_count, parent_output);
+            constraints, meta_->monotone_type, meta_->config->effective_path_smooth(),
+            meta_->config->use_hessian_smoothing() ? sum_left_hessian : static_cast<double>(left_count),
+            meta_->config->use_hessian_smoothing() ? sum_right_hessian : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain <= min_gain_shift) {
           continue;
@@ -1030,14 +1041,16 @@ class FeatureHistogram {
     }
 
     if (is_splittable_ && best_gain > output->gain + min_gain_shift) {
+      const double best_left_smoothing = meta_->config->use_hessian_smoothing() ? best_sum_left_hessian : static_cast<double>(best_left_count);
+      const double best_right_smoothing = meta_->config->use_hessian_smoothing() ? (sum_hessian - best_sum_left_hessian) : static_cast<double>(num_data - best_left_count);
       // update split information
       output->threshold = best_threshold;
       output->left_output =
           CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
               best_sum_left_gradient, best_sum_left_hessian,
               meta_->config->lambda_l1, meta_->config->lambda_l2,
-              meta_->config->max_delta_step, best_left_constraints, meta_->config->path_smooth,
-              best_left_count, parent_output);
+              meta_->config->max_delta_step, best_left_constraints, meta_->config->effective_path_smooth(),
+              best_left_smoothing, parent_output);
       output->left_count = best_left_count;
       output->left_sum_gradient = best_sum_left_gradient;
       output->left_sum_hessian = best_sum_left_hessian - kEpsilon;
@@ -1046,7 +1059,7 @@ class FeatureHistogram {
               sum_gradient - best_sum_left_gradient,
               sum_hessian - best_sum_left_hessian, meta_->config->lambda_l1,
               meta_->config->lambda_l2, meta_->config->max_delta_step,
-              best_right_constraints, meta_->config->path_smooth, num_data - best_left_count,
+              best_right_constraints, meta_->config->effective_path_smooth(), best_right_smoothing,
               parent_output);
       output->right_count = num_data - best_left_count;
       output->right_sum_gradient = sum_gradient - best_sum_left_gradient;
@@ -1076,6 +1089,7 @@ class FeatureHistogram {
     uint32_t best_threshold = static_cast<uint32_t>(meta_->num_bin);
     const double cnt_factor = static_cast<double>(num_data) /
       static_cast<double>(static_cast<uint32_t>(int_sum_gradient_and_hessian & 0x00000000ffffffff));
+
 
     BasicConstraint best_right_constraints;
     BasicConstraint best_left_constraints;
@@ -1164,8 +1178,9 @@ class FeatureHistogram {
             sum_left_gradient, sum_left_hessian + kEpsilon, sum_right_gradient,
             sum_right_hessian + kEpsilon, meta_->config->lambda_l1,
             meta_->config->lambda_l2, meta_->config->max_delta_step,
-            constraints, meta_->monotone_type, meta_->config->path_smooth,
-            left_count, right_count, parent_output);
+            constraints, meta_->monotone_type, meta_->config->effective_path_smooth(),
+            meta_->config->use_hessian_smoothing() ? (sum_left_hessian + kEpsilon) : static_cast<double>(left_count),
+            meta_->config->use_hessian_smoothing() ? (sum_right_hessian + kEpsilon) : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain <= min_gain_shift) {
           continue;
@@ -1276,8 +1291,9 @@ class FeatureHistogram {
             sum_left_gradient, sum_left_hessian + kEpsilon, sum_right_gradient,
             sum_right_hessian + kEpsilon, meta_->config->lambda_l1,
             meta_->config->lambda_l2, meta_->config->max_delta_step,
-            constraints, meta_->monotone_type, meta_->config->path_smooth, left_count,
-            right_count, parent_output);
+            constraints, meta_->monotone_type, meta_->config->effective_path_smooth(),
+            meta_->config->use_hessian_smoothing() ? (sum_left_hessian + kEpsilon) : static_cast<double>(left_count),
+            meta_->config->use_hessian_smoothing() ? (sum_right_hessian + kEpsilon) : static_cast<double>(right_count), parent_output);
         // gain with split is worse than without split
         if (current_gain <= min_gain_shift) {
           continue;
@@ -1322,14 +1338,16 @@ class FeatureHistogram {
       const double best_sum_right_hessian = static_cast<double>(int_best_sum_right_hessian) * hess_scale;
       const data_size_t best_left_count = Common::RoundInt(static_cast<double>(int_best_sum_left_hessian) * cnt_factor);
       const data_size_t best_right_count = Common::RoundInt(static_cast<double>(int_best_sum_right_hessian) * cnt_factor);
+      const double best_left_smoothing = meta_->config->use_hessian_smoothing() ? best_sum_left_hessian : static_cast<double>(best_left_count);
+      const double best_right_smoothing = meta_->config->use_hessian_smoothing() ? best_sum_right_hessian : static_cast<double>(best_right_count);
       // update split information
       output->threshold = best_threshold;
       output->left_output =
           CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
               best_sum_left_gradient, best_sum_left_hessian,
               meta_->config->lambda_l1, meta_->config->lambda_l2,
-              meta_->config->max_delta_step, best_left_constraints, meta_->config->path_smooth,
-              best_left_count, parent_output);
+              meta_->config->max_delta_step, best_left_constraints, meta_->config->effective_path_smooth(),
+              best_left_smoothing, parent_output);
       output->left_count = best_left_count;
       output->left_sum_gradient = best_sum_left_gradient;
       output->left_sum_hessian = best_sum_left_hessian;
@@ -1339,7 +1357,7 @@ class FeatureHistogram {
               best_sum_right_gradient,
               best_sum_right_hessian, meta_->config->lambda_l1,
               meta_->config->lambda_l2, meta_->config->max_delta_step,
-              best_right_constraints, meta_->config->path_smooth, best_right_count,
+              best_right_constraints, meta_->config->effective_path_smooth(), best_right_smoothing,
               parent_output);
       output->right_count = best_right_count;
       output->right_sum_gradient = best_sum_right_gradient;
@@ -1513,7 +1531,8 @@ class HistogramPool {
         old_config->monotone_constraints != config->monotone_constraints ||
         old_config->extra_trees != config->extra_trees ||
         old_config->max_delta_step != config->max_delta_step ||
-        old_config->path_smooth != config->path_smooth) {
+        old_config->path_smooth != config->path_smooth ||
+        old_config->path_smooth_hessian != config->path_smooth_hessian) {
 #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
       for (int i = 0; i < cache_size_; ++i) {
         for (int j = 0; j < train_data->num_features(); ++j) {

--- a/src/treelearner/gradient_discretizer.cpp
+++ b/src/treelearner/gradient_discretizer.cpp
@@ -232,10 +232,12 @@ void GradientDiscretizer::RenewIntGradTreeOutput(
     for (int leaf_id = 0; leaf_id < tree->num_leaves(); ++leaf_id) {
       const double sum_gradient = global_leaf_grad_hess_stats[2 * leaf_id];
       const double sum_hessian = global_leaf_grad_hess_stats[2 * leaf_id + 1];
+      const double smoothing_count_global = config->use_hessian_smoothing() ?
+        sum_hessian : static_cast<double>(leaf_index_to_global_num_data(leaf_id));
       const double leaf_output = FeatureHistogram::CalculateSplittedLeafOutput<true, true, false>(
         sum_gradient, sum_hessian,
-        config->lambda_l1, config->lambda_l2, config->max_delta_step, config->path_smooth,
-        leaf_index_to_global_num_data(leaf_id), 0.0f);
+        config->lambda_l1, config->lambda_l2, config->max_delta_step, config->effective_path_smooth(),
+        smoothing_count_global, 0.0f);
       tree->SetLeafOutput(leaf_id, leaf_output);
     }
   } else {
@@ -251,9 +253,11 @@ void GradientDiscretizer::RenewIntGradTreeOutput(
         sum_gradient += grad;
         sum_hessian += hess;
       }
+      const double smoothing_count_local = config->use_hessian_smoothing() ?
+        sum_hessian : static_cast<double>(leaf_cnt);
       const double leaf_output = FeatureHistogram::CalculateSplittedLeafOutput<true, true, false>(sum_gradient, sum_hessian,
-        config->lambda_l1, config->lambda_l2, config->max_delta_step, config->path_smooth,
-        leaf_cnt, 0.0f);
+        config->lambda_l1, config->lambda_l2, config->max_delta_step, config->effective_path_smooth(),
+        smoothing_count_local, 0.0f);
       tree->SetLeafOutput(leaf_id, leaf_output);
     }
   }

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -206,10 +206,12 @@ Tree* SerialTreeLearner::Train(const score_t* gradients, const score_t *hessians
   constraints_->ShareTreePointer(tree_ptr);
 
   // set the root value by hand, as it is not handled by splits
+  const double root_smoothing_weight = config_->use_hessian_smoothing() ?
+    smaller_leaf_splits_->sum_hessians() : static_cast<double>(num_data_);
   tree->SetLeafOutput(0, FeatureHistogram::CalculateSplittedLeafOutput<true, true, true, false>(
     smaller_leaf_splits_->sum_gradients(), smaller_leaf_splits_->sum_hessians(),
     config_->lambda_l1, config_->lambda_l2, config_->max_delta_step,
-    BasicConstraint(), config_->path_smooth, static_cast<data_size_t>(num_data_), 0));
+    BasicConstraint(), config_->effective_path_smooth(), root_smoothing_weight, 0));
 
   // root leaf
   int left_leaf = 0;
@@ -265,14 +267,16 @@ Tree* SerialTreeLearner::FitByExistingTree(const Tree* old_tree, const score_t* 
       sum_hess += hessians[idx];
     }
     double output;
-    if ((config_->path_smooth > kEpsilon) & (i > 0)) {
+    const double refit_smoothing_weight = config_->use_hessian_smoothing() ?
+      sum_hess : static_cast<double>(cnt_leaf_data);
+    if ((config_->effective_path_smooth() > kEpsilon) & (i > 0)) {
       output = FeatureHistogram::CalculateSplittedLeafOutput<true, true, true>(
           sum_grad, sum_hess, config_->lambda_l1, config_->lambda_l2,
-          config_->max_delta_step, config_->path_smooth, cnt_leaf_data, tree->leaf_parent(i));
+          config_->max_delta_step, config_->effective_path_smooth(), refit_smoothing_weight, tree->leaf_parent(i));
     } else {
       output = FeatureHistogram::CalculateSplittedLeafOutput<true, true, false>(
           sum_grad, sum_hess, config_->lambda_l1, config_->lambda_l2,
-          config_->max_delta_step, config_->path_smooth, cnt_leaf_data, 0);
+          config_->max_delta_step, config_->effective_path_smooth(), refit_smoothing_weight, 0);
     }
     auto old_leaf_output = tree->LeafOutput(i);
     auto new_leaf_output = output * tree->shrinkage();
@@ -1014,10 +1018,12 @@ double SerialTreeLearner::GetParentOutput(const Tree* tree, const LeafSplits* le
   double parent_output;
   if (tree->num_leaves() == 1) {
     // for root leaf the "parent" output is its own output because we don't apply any smoothing to the root
+    const double smoothing_weight = config_->use_hessian_smoothing() ?
+      leaf_splits->sum_hessians() : static_cast<double>(leaf_splits->num_data_in_leaf());
     parent_output = FeatureHistogram::CalculateSplittedLeafOutput<true, true, true, false>(
       leaf_splits->sum_gradients(), leaf_splits->sum_hessians(), config_->lambda_l1,
       config_->lambda_l2, config_->max_delta_step, BasicConstraint(),
-      config_->path_smooth, static_cast<data_size_t>(leaf_splits->num_data_in_leaf()), 0);
+      config_->effective_path_smooth(), smoothing_weight, 0);
   } else {
     parent_output = leaf_splits->weight();
   }
@@ -1043,10 +1049,12 @@ void SerialTreeLearner::RecomputeBestSplitForLeaf(Tree* tree, int leaf, SplitInf
 
   // can't use GetParentOutput because leaf_splits doesn't have weight property set
   double parent_output = 0;
-  if (config_->path_smooth > kEpsilon) {
+  if (config_->effective_path_smooth() > kEpsilon) {
+    const double smoothing_weight = config_->use_hessian_smoothing() ?
+      sum_hessians : static_cast<double>(num_data);
     parent_output = FeatureHistogram::CalculateSplittedLeafOutput<true, true, true, false>(
       sum_gradients, sum_hessians, config_->lambda_l1, config_->lambda_l2, config_->max_delta_step,
-      BasicConstraint(), config_->path_smooth, static_cast<data_size_t>(num_data), 0);
+      BasicConstraint(), config_->effective_path_smooth(), smoothing_weight, 0);
   }
 
   OMP_INIT_EX();

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -3633,6 +3633,22 @@ def test_path_smoothing():
     assert err < err_new
 
 
+def test_path_smoothing_hessian():
+    # check that path_smooth_hessian produces different results than path_smooth when samples have different weights
+    X, y = make_synthetic_regression()
+    rng = np.random.RandomState(42)
+    weight = rng.exponential(scale=2.0, size=len(y))
+    lgb_x = lgb.Dataset(X, label=y, weight=weight)
+    params = {"objective": "regression", "num_leaves": 32, "verbose": -1, "seed": 0, "path_smooth": 1}
+    est_default = lgb.train(params, lgb_x, num_boost_round=10)
+    pred_default = est_default.predict(X)
+    params_hessian = {"objective": "regression", "num_leaves": 32, "verbose": -1, "seed": 0, "path_smooth_hessian": 1}
+    est_hessian = lgb.train(params_hessian, lgb_x, num_boost_round=10)
+    pred_hessian = est_hessian.predict(X)
+    # predictions should differ when using hessian-based smoothing with non-uniform weights
+    assert not np.allclose(pred_default, pred_hessian)
+
+
 def test_trees_to_dataframe(rng):
     pytest.importorskip("pandas")
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -3674,6 +3674,22 @@ def test_path_smoothing():
     assert err < err_new
 
 
+def test_path_smoothing_hessian():
+    # check that path_smooth_hessian produces different results than path_smooth when samples have different weights
+    X, y = make_synthetic_regression()
+    rng = np.random.RandomState(42)
+    weight = rng.exponential(scale=2.0, size=len(y))
+    lgb_x = lgb.Dataset(X, label=y, weight=weight)
+    params = {"objective": "regression", "num_leaves": 32, "verbose": -1, "seed": 0, "path_smooth": 1}
+    est_default = lgb.train(params, lgb_x, num_boost_round=10)
+    pred_default = est_default.predict(X)
+    params_hessian = {"objective": "regression", "num_leaves": 32, "verbose": -1, "seed": 0, "path_smooth_hessian": 1}
+    est_hessian = lgb.train(params_hessian, lgb_x, num_boost_round=10)
+    pred_hessian = est_hessian.predict(X)
+    # predictions should differ when using hessian-based smoothing with non-uniform weights
+    assert not np.allclose(pred_default, pred_hessian)
+
+
 def test_trees_to_dataframe(rng):
     pytest.importorskip("pandas")
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
                                                            
  Adds a new `path_smooth_hessian` parameter — a hessian-based variant of `path_smooth` (implemented in https://github.com/lightgbm-org/LightGBM/pull/2950) that is more appropriate when samples have different weights.                                                              
   
  ### Motivation                                                                                                                                                                                                   
                                                            
  The existing `path_smooth` uses sample counts as the smoothing weight. This works well for unweighted data, but when samples have different weights (e.g. via the `weight` column), sample count does not reflect the actual importance of the data in each leaf. A leaf with 10 high-weight samples and a leaf with 10 low-weight samples get the same smoothing, even though they carry very different amounts of information.
                                                                                                                                                                                                                   
  `path_smooth_hessian` uses the sum of Hessians instead, which naturally incorporates sample weights (since `h_i = w_i * h_i_unweighted`). This makes the smoothing weight-aware: leaves with more weighted evidence are trusted more, leaves with less are pulled harder toward the parent.

  ### Theory
The current path_smooth looks like an implementation of [Bülmann's credibility](https://openacttexts.github.io/Loss-Data-Analytics/ChapCredibility.html#S:Cred:Buhlmann), which assumes all rows have the same exposure/weight. 

An extension of it is the [Bühlmann-Straub](https://openacttexts.github.io/Loss-Data-Analytics/ChapCredibility.html#b%C3%BChlmann-straub-credibility) credibility, which uses weights rather than raw counts when observations have different weights. However, we implement it using the Hessian instead to stay consistent with the existing `min_data_in_leaf` vs `min_sum_hessian_in_leaf`, and because it would require more changes to the code (weights aren't available when smoothing is applied).
                                                                                                                                                                                                                   
  ### Smoothing formula                                     

  Same structure as `path_smooth`, with `h` (sum of hessians) replacing `n` (sample count):                                                                                                                        
   
`w_L = w*_L * (h / α) / (h / α + 1) + w_parent / (h / α + 1)`                                                                                                                                          
                                                            
  where `alpha = path_smooth_hessian`, `h` = sum of hessians in the leaf, `w*_L` = unsmoothed leaf output, `w_parent` = parent's smoothed output.

**Note:** the current implementation of `path_smooth` actually uses a hessian-based approximation of `n_samples` (via `RoundInt(bin_hessian * num_data / leaf_sum_hessian)`), not the true sample count. This  
  means `path_smooth` is already between its stated definition and `path_smooth_hessian`. 
                                                                                                                                                                                                                   
  ### Results
I tested this change on some of my datasets, with Poisson, Gamma, and Logistic Losses, and it seems to either perform better or as good as path_smooth, depending on the dataset.
Here is an example of the performance on a Poisson dataset with heterogeneous weights. The smoothing ranges are centered around the optimal one (found empirically), and results are cross-validated to reduce the noise.

<img width="905" height="495" alt="image" src="https://github.com/user-attachments/assets/0772e4f0-f231-408a-98eb-4f9bf8ee5b55" />

I also compared it with `min_data_in_leaf` and `min_sum_hessian_in_leaf` (which are called `mcs` and `mcw` on the graph). And it seems to improve path_smooth the same way as `min_sum_hessian_in_leaf` improves `min_data_in_leaf`. 

<img width="937" height="435" alt="image" src="https://github.com/user-attachments/assets/40c558b1-75f2-4b1e-bc7e-53bd1bf89c2f" />

Also, out of 8 business cases I tested, soft smoothing methods (`path_smooth` and `path_smooth_hessian`) outperformed hard smoothing methods (`min_data_in_leaf` and `min_sum_hessian_in_leaf`) on 6 of them, while hard methods had a slight edge on 2 of them (the two smallest datasets I had, 4k and 30k rows). It is one of the reasons that made me want to use soft smoothing methods rather than hard smoothing ones.

  ### Summary of changes
                                                                                                                                                                                                                   
  - **Separate parameter** (`path_smooth_hessian`, double, default 0) rather than a boolean flag on `path_smooth`, following the `min_data_in_leaf` / `min_sum_hessian_in_leaf` pattern.                           
  - Same dimension as `min_sum_hessian_in_leaf`.
  - **Mutually exclusive** with `path_smooth`: if both are set, `path_smooth` is ignored with a warning.                                                                                                           
  - **`min_data_in_leaf >= 2` guard** only applies to count-based `path_smooth`. The hessian-based path uses `sum_hessians` directly from the histogram, so the rounding issue that motivated the guard does not   
  apply.                                                                                                                                                                                                           
  - Two helper methods on `Config` (`effective_path_smooth()`, `use_hessian_smoothing()`) to avoid repeated branching logic across call sites.                                                                     
  - Full **CUDA** support, mirroring the CPU implementation. 
  - new `test_path_smoothing_hessian`