### PR TITLE
[docs] add LightGBM-MoE to external repositories list

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Optuna (hyperparameter optimization framework): https://github.com/optuna/optuna
 
 LightGBMLSS (probabilistic modelling with LightGBM): https://github.com/StatMixedML/LightGBMLSS
 
+LightGBM-MoE (Mixture-of-Experts / regime-switching extension): https://github.com/kyo219/LightGBM-MoE
+
 mlforecast (time series forecasting with LightGBM): https://github.com/Nixtla/mlforecast
 
 skforecast (time series forecasting with LightGBM): https://github.com/JoaquinAmatRodrigo/skforecast


### PR DESCRIPTION
Add LightGBM-MoE to the "External (Unofficial) Repositories" section.

LightGBM-MoE is a fork of LightGBM that implements Mixture-of-Experts
(MoE) / regime-switching GBDT natively in C++, where multiple expert
GBDTs are combined via a learned gating function.

https://github.com/kyo219/LightGBM-MoE