### PR TITLE
[ci] update to r-lib/actions v2.12.0, align 'pip' and 'python' to same interpreter in 'build-python.sh'

### DIFF
--- a/.ci/conda-envs/ci-core-py39.txt
+++ b/.ci/conda-envs/ci-core-py39.txt
@@ -40,6 +40,9 @@ pytest=7.4.*
 # https://github.com/lightgbm-org/LightGBM/issues/6990
 graphite2=1.3.14=*_0
 
+# starting some time around 2026, 'pip' is no longer guaranteed to be installed
+pip=25.2.*
+
 # other recursive dependencies, just
 # pinned here to help speed up solves
 bokeh=2.4.*

--- a/.ci/conda-envs/ci-core.txt
+++ b/.ci/conda-envs/ci-core.txt
@@ -28,6 +28,9 @@ python-graphviz>=0.20.3
 scikit-learn>=1.3.2
 scipy>=1.1
 
+# starting some time around 2026, 'pip' is no longer guaranteed to be installed
+pip>=24
+
 # testing-only dependencies
 cloudpickle>=3.0.0
 psutil>=5.9.8

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -178,10 +178,10 @@ jobs:
           persist-credentials: false
           submodules: true
       - name: Install pandoc
-        uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  # v2.11.4
+        uses: r-lib/actions/setup-pandoc@a51a8012b0aab7c32ef9d19bf54da93f3254335e  # v2.12.0
       - name: Install tinytex
         if: startsWith(matrix.os, 'windows')
-        uses: r-lib/actions/setup-tinytex@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  # v2.11.4
+        uses: r-lib/actions/setup-tinytex@a51a8012b0aab7c32ef9d19bf54da93f3254335e  # v2.12.0
         env:
           CTAN_MIRROR: https://ctan.math.illinois.edu/systems/win32/miktex
           TINYTEX_INSTALLER: TinyTeX
@@ -293,7 +293,7 @@ jobs:
           persist-credentials: false
           submodules: true
       - name: Install pandoc
-        uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  # v2.11.4
+        uses: r-lib/actions/setup-pandoc@a51a8012b0aab7c32ef9d19bf54da93f3254335e  # v2.12.0
       - name: Install system dependencies
         shell: bash
         run: |

--- a/build-python.sh
+++ b/build-python.sh
@@ -185,7 +185,7 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-pip install --prefer-binary 'build>=0.10.0'
+python -m pip install --prefer-binary 'build>=0.10.0'
 
 # create a new directory that just contains the files needed
 # to build the Python-package
@@ -388,7 +388,7 @@ if test "${INSTALL}" = true; then
         PACKAGE_FILE="$(echo dist/lightgbm*.tar.gz)"
     fi
     # shellcheck disable=SC2086
-    pip install \
+    python -m pip install \
         ${PIP_INSTALL_ARGS} \
         --force-reinstall \
         --no-cache-dir \


### PR DESCRIPTION
Fixes #7248

See the linked issues there. I think the latest `r-lib/actions/setup-tinytex` needs to be used because something has been changed about `https://tinytex.yihui.org/install-bin-windows.ps1` (it appears to be there, but the action fails to download it).

Fixes #7258

* directly declares `pip` dependency in conda environments
* replaces `pip` w/ `python -m pip` in `build-python.sh`, to ensure all processes use the same Python interpreter

Closes #7257

* this will not be mergeable until the issues with Ubuntu package servers are resolved