### PR TITLE
[docs] [python-package] Update pandas categorical feature encoding details

### DIFF
--- a/docs/Advanced-Topics.rst
+++ b/docs/Advanced-Topics.rst
@@ -23,7 +23,7 @@ Categorical Feature Support
 -  Use ``categorical_feature`` to specify the categorical features.
    Refer to the parameter ``categorical_feature`` in `Parameters <./Parameters.rst#categorical_feature>`__.
 
--  Categorical features will be cast to ``int32`` (integer codes will be extracted from pandas categoricals in the Python-package) so they must be encoded as non-negative integers (negative values will be treated as missing)
+-  Categorical features will be cast to ``int32`` so they must be encoded as non-negative integers (negative values will be treated as missing)
    less than ``Int32.MaxValue`` (2147483647).
    It is best to use a contiguous range of integers started from zero.
    Floating point numbers in categorical features will be rounded towards 0.
@@ -33,6 +33,14 @@ Categorical Feature Support
 -  For a categorical feature with high cardinality (``#category`` is large), it often works best to
    treat the feature as numeric, either by simply ignoring the categorical interpretation of the integers or
    by embedding the categories in a low-dimensional numeric space.
+
+.. note::
+
+   When using the Python package with a pandas ``DataFrame`` and columns of dtype ``category``,
+   LightGBM stores the category labels observed during training and re-aligns categories at
+   prediction time before converting them to integer codes. This ensures consistent encoding
+   even if category order or subsets differ between training and prediction data. Categories
+   not seen during training are treated as missing values.
 
 LambdaRank
 ----------

--- a/docs/Advanced-Topics.rst
+++ b/docs/Advanced-Topics.rst
@@ -23,10 +23,16 @@ Categorical Feature Support
 -  Use ``categorical_feature`` to specify the categorical features.
    Refer to the parameter ``categorical_feature`` in `Parameters <./Parameters.rst#categorical_feature>`__.
 
--  Categorical features will be cast to ``int32`` so they must be encoded as non-negative integers (negative values will be treated as missing)
+-  Categorical features will be cast to ``int32`` (integer codes will be extracted from pandas categoricals in the Python-package) so they must be encoded as non-negative integers (negative values will be treated as missing)
    less than ``Int32.MaxValue`` (2147483647).
    It is best to use a contiguous range of integers started from zero.
    Floating point numbers in categorical features will be rounded towards 0.
+
+-  When using ``pandas.DataFrame`` inputs with columns of dtype ``category``, LightGBM will
+   align categories to those observed during training before converting them to integer values.
+   This ensures consistent encoding between training and prediction without additional preprocessing.
+
+-  At ``predict()`` time, categories not seen during training will be treated as missing values.
 
 -  Use ``min_data_per_group``, ``cat_smooth`` to deal with over-fitting (when ``#data`` is small or ``#category`` is large).
 

--- a/docs/Advanced-Topics.rst
+++ b/docs/Advanced-Topics.rst
@@ -40,14 +40,6 @@ Categorical Feature Support
    treat the feature as numeric, either by simply ignoring the categorical interpretation of the integers or
    by embedding the categories in a low-dimensional numeric space.
 
-.. note::
-
-   When using the Python package with a pandas ``DataFrame`` and columns of dtype ``category``,
-   LightGBM stores the category labels observed during training and re-aligns categories at
-   prediction time before converting them to integer codes. This ensures consistent encoding
-   even if category order or subsets differ between training and prediction data. Categories
-   not seen during training are treated as missing values.
-
 LambdaRank
 ----------
 


### PR DESCRIPTION
The current documentation states

> integer codes will be extracted from pandas categoricals in the Python-package

However, this statement alone leaves out a very important nuance: if the category mapping observed using during prediction differs from the mapping observed during training, the mapping of the training data is applied to the prediction dataset. This is important information, because this means that categorical encodings are **part of the learning process** of LightGBM and no external data processing is required to prevent mixing up categorical codes (e.g. [OrdinalEncoder](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OrdinalEncoder.html)).

Related to this discussion: https://github.com/lightgbm-org/LightGBM/issues/2761

The application of training categories to prediction data is done here: https://github.com/lightgbm-org/LightGBM/blob/9545905b9ade997ee8a06001ff0f4c5e792e3f85/python-package/lightgbm/basic.py#L852-L854