### PR TITLE
[cuda] Fix dense histogram offset issue for global-memory 

### DIFF
--- a/src/treelearner/cuda/cuda_histogram_constructor.cu
+++ b/src/treelearner/cuda/cuda_histogram_constructor.cu
@@ -403,7 +403,7 @@ __global__ void CUDAConstructDiscretizedHistogramDenseKernel_GlobalMemory(
   const uint32_t partition_hist_end = column_hist_offsets_full[blockIdx.x + 1];
   const uint32_t num_items_in_partition = (partition_hist_end - partition_hist_start);
   const int num_total_bin = column_hist_offsets_full[gridDim.x];
-  int32_t* shared_hist_packed = global_hist_buffer + (blockIdx.y * num_total_bin + partition_column_start);
+  int32_t* shared_hist_packed = global_hist_buffer + (blockIdx.y * num_total_bin + partition_hist_start);
   const unsigned int thread_idx = threadIdx.x + threadIdx.y * blockDim.x;
   for (unsigned int i = thread_idx; i < num_items_in_partition; i += num_threads_per_block) {
     shared_hist_packed[i] = 0;


### PR DESCRIPTION
## Summary

There is a one liner error fix (probably a copy paste error) in `CUDAConstructDiscretizedHistogramDenseKernel_GlobalMemory` 
`src/treelearner/cuda/cuda_histogram_constructor.cu`.

The correct version of the pattern appears in CUDAConstructDiscretizedHistogramSparseKernel_GlobalMemory (Sparse).
"blockIdx.y * num_total_bin + partition_hist_start" appears 3 times in the file and one time it appears as "blockIdx.y * num_total_bin + partition_column_start"

`partition_column_start` and `partition_hist_start`  are the same when every column has exactly one bin.

The bug is dispatched only when

- `use_quantized_grad == true`,
- the data is dense, and
- the global-memory buffer path is taken `USE_GLOBAL_MEM_BUFFER == true`, i.e. when the per-partition histogram doesn't fit in shared memory).

Verified locally on CUDA 13.2 / sm_120 (RTX 5090).

Added a test that fails on master and passed with the one line fix
