### PR TITLE
[python-package] Add support for PyArrow-backed Pandas DataFrames

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -35,11 +35,14 @@ from .compat import (
     arrow_is_floating,
     arrow_is_integer,
     concat,
+    pa_array,
     pa_Array,
     pa_chunked_array,
     pa_ChunkedArray,
     pa_compute,
+    pa_DataType,
     pa_Table,
+    pd_ArrowDtype,
     pd_CategoricalDtype,
     pd_DataFrame,
     pd_Series,
@@ -407,6 +410,23 @@ def _is_2d_list(data: Any) -> bool:
 def _is_2d_collection(data: Any) -> bool:
     """Check whether data is a 2-D collection."""
     return _is_numpy_2d_array(data) or _is_2d_list(data) or isinstance(data, pd_DataFrame)
+
+
+def _is_pd_arrow_dtype(dtype: Any) -> bool:
+    """Check whether the dtype is a pandas ArrowDtype."""
+    return pd_ArrowDtype is not None and isinstance(dtype, pd_ArrowDtype)
+
+
+def _is_arrow_backed_pd_series(data: Any) -> bool:
+    """Check whether data is a pandas Series backed by ArrowDtype."""
+    return isinstance(data, pd_Series) and _is_pd_arrow_dtype(data.dtype)
+
+
+def _extract_arrow_array(data: Any) -> Any:
+    """Extract PyArrow array from arrow-backed pandas Series, or return as-is if already an arrow array."""
+    if _is_arrow_backed_pd_series(data):
+        return data.array.__arrow_array__()
+    return data
 
 
 def _is_pyarrow_array(data: Any) -> "TypeGuard[Union[pa_Array, pa_ChunkedArray]]":
@@ -790,6 +810,55 @@ def _c_int_array(data: np.ndarray) -> Tuple[_ctypes_int_ptr, int, np.ndarray]:
     return (ptr_data, type_data, data)  # return `data` to avoid the temporary copy is freed
 
 
+def _is_allowed_arrow_dtype(arrow_type: pa_DataType) -> bool:
+    """Check if the Arrow type is one that C++ can handle (integer, floating point, or boolean)."""
+    return arrow_is_integer(arrow_type) or arrow_is_floating(arrow_type) or arrow_is_boolean(arrow_type)
+
+
+def _check_for_bad_arrow_dtypes(table: pa_Table) -> None:
+    """Raise if the Arrow table contains non-numeric types."""
+    bad_arrow_dtypes = [
+        f"{field.name}: {field.type}"
+        for field in table.schema
+        if not _is_allowed_arrow_dtype(field.type)
+    ]
+    if bad_arrow_dtypes:
+        raise ValueError(
+            "Arrow columns must be int, float or bool.\n"
+            f"Fields with bad Arrow dtypes: {', '.join(bad_arrow_dtypes)}"
+        )
+
+
+def _pandas_to_arrow_table(data: pd_DataFrame) -> pa_Table:
+    """Convert a pandas DataFrame to an Arrow Table."""
+    if not (PYARROW_INSTALLED and CFFI_INSTALLED):
+        raise LightGBMError("Cannot init Dataset from Arrow without 'pyarrow' and 'cffi' installed.")
+    arrays = []
+    names = []
+    for col_name, col in data.items():
+        dtype = col.dtype
+        if _is_pd_arrow_dtype(dtype):
+            # arrow-backed columns can be converted zero-copy by extracting the underlying array
+            arrays.append(col.array.__arrow_array__())
+        elif hasattr(dtype, 'numpy_dtype'):
+            # nullable extension types (e.g. pd.Int64Dtype, pd.Float64Dtype, pd.BooleanDtype)
+            # use separate data+mask arrays; pass the Series directly so pyarrow can interpret the mask
+            arrays.append(pa_array(col, from_pandas=True))
+        elif _is_allowed_numpy_dtype(dtype.type):
+            # numpy-backed columns are a single contiguous buffer; .values is a zero-copy view
+            arrays.append(pa_array(col.values, from_pandas=True))
+        else:
+            raise ValueError(
+                f"Column '{col_name}' has unsupported dtype '{dtype}'. "
+                "Columns must have integer, floating point, or boolean dtypes."
+            )
+        names.append(str(col_name))
+    # column names are coerced to strings as required by Arrow
+    table = pa_Table.from_arrays(arrays, names=names)
+    _check_for_bad_arrow_dtypes(table)
+    return table
+
+
 def _is_allowed_numpy_dtype(dtype: type) -> bool:
     float128 = getattr(np, "float128", type(None))
     return issubclass(dtype, (np.integer, np.floating, np.bool_)) and not issubclass(dtype, (np.timedelta64, float128))
@@ -829,7 +898,7 @@ def _data_from_pandas(
     feature_name: _LGBM_FeatureNameConfiguration,
     categorical_feature: _LGBM_CategoricalFeatureConfiguration,
     pandas_categorical: Optional[List[List]],
-) -> Tuple[np.ndarray, List[str], Union[List[str], List[int]], List[List]]:
+) -> Tuple[Union[np.ndarray, pa_Table], List[str], Union[List[str], List[int]], List[List]]:
     if len(data.shape) != 2 or data.shape[0] < 1:
         raise ValueError("Input data must be 2 dimensional and non empty.")
 
@@ -858,6 +927,14 @@ def _data_from_pandas(
     # use cat cols from DataFrame
     if categorical_feature == "auto":
         categorical_feature = cat_cols_not_ordered
+
+    if any(_is_pd_arrow_dtype(dtype) for dtype in data.dtypes):
+        return (
+            _pandas_to_arrow_table(data),
+            feature_name,
+            categorical_feature,
+            pandas_categorical,
+        )
 
     df_dtypes = [dtype.type for dtype in data.dtypes]
     # so that the target dtype considers floats
@@ -1718,9 +1795,7 @@ class _InnerPredictor:
         if not (PYARROW_INSTALLED and CFFI_INSTALLED):
             raise LightGBMError("Cannot predict from Arrow without 'pyarrow' and 'cffi' installed.")
 
-        # Check that the input is valid: we only handle numbers (for now)
-        if not all(arrow_is_integer(t) or arrow_is_floating(t) or arrow_is_boolean(t) for t in table.schema.types):
-            raise ValueError("Arrow table may only have integer or floating point datatypes")
+        _check_for_bad_arrow_dtypes(table)
 
         # Prepare prediction output array
         n_preds = self.__get_num_preds(
@@ -2473,9 +2548,7 @@ class Dataset:
         if not (PYARROW_INSTALLED and CFFI_INSTALLED):
             raise LightGBMError("Cannot init Dataset from Arrow without 'pyarrow' and 'cffi' installed.")
 
-        # Check that the input is valid: we only handle numbers (for now)
-        if not all(arrow_is_integer(t) or arrow_is_floating(t) or arrow_is_boolean(t) for t in table.schema.types):
-            raise ValueError("Arrow table may only have integer or floating point datatypes")
+        _check_for_bad_arrow_dtypes(table)
 
         # Export Arrow table to C
         c_array = _export_arrow_to_c(table)
@@ -2804,6 +2877,8 @@ class Dataset:
             )
             return self
 
+        data = _extract_arrow_array(data)
+
         # If the data is a arrow data, we can just pass it to C
         if _is_pyarrow_array(data) or _is_pyarrow_table(data):
             # If a table is being passed, we concatenate the columns. This is only valid for
@@ -3076,6 +3151,7 @@ class Dataset:
         ----------
         label : list, numpy 1-D array, pandas Series / one-column DataFrame, pyarrow Array, pyarrow ChunkedArray or None
             The label information to be set into Dataset.
+            Supports arrow-backed pandas Series (ArrowDtype).
 
         Returns
         -------
@@ -3088,7 +3164,7 @@ class Dataset:
                 if len(label.columns) > 1:
                     raise ValueError("DataFrame for label cannot have multiple columns")
                 label_array = np.ravel(_pandas_to_numpy(label, target_dtype=np.float32))
-            elif _is_pyarrow_array(label):
+            elif _is_pyarrow_array(label) or _is_arrow_backed_pd_series(label):
                 label_array = label
             else:
                 label_array = _list_to_1d_numpy(data=label, dtype=np.float32, name="label")
@@ -3106,6 +3182,7 @@ class Dataset:
         ----------
         weight : list, numpy 1-D array, pandas Series, pyarrow Array, pyarrow ChunkedArray or None
             Weight to be set for each data point. Weights should be non-negative.
+            Supports arrow-backed pandas Series (ArrowDtype).
 
         Returns
         -------
@@ -3114,6 +3191,7 @@ class Dataset:
         """
         # Check if the weight contains values other than one
         if weight is not None:
+            weight = _extract_arrow_array(weight)
             if _is_pyarrow_array(weight):
                 # TODO: remove 'type: ignore[attr-defined]' when https://github.com/apache/arrow/issues/49831 is resolved.
                 if pa_compute.all(pa_compute.equal(weight, 1)).as_py():  # type: ignore[attr-defined]
@@ -3124,7 +3202,7 @@ class Dataset:
 
         # Set field
         if self._handle is not None and weight is not None:
-            if not _is_pyarrow_array(weight):
+            if not (_is_pyarrow_array(weight) or _is_arrow_backed_pd_series(weight)):
                 weight = _list_to_1d_numpy(data=weight, dtype=np.float32, name="weight")
             self.set_field("weight", weight)
             self.weight = self.get_field("weight")  # original values can be modified at cpp side
@@ -3140,6 +3218,7 @@ class Dataset:
         ----------
         init_score : list, list of lists (for multi-class task), numpy array, pandas Series, pandas DataFrame (for multi-class task), pyarrow Array, pyarrow ChunkedArray, pyarrow Table (for multi-class task) or None
             Init score for Booster.
+            Supports arrow-backed pandas Series and DataFrame (ArrowDtype).
 
         Returns
         -------
@@ -3166,6 +3245,7 @@ class Dataset:
             sum(group) = n_samples.
             For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
             where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
+            Supports arrow-backed pandas Series (ArrowDtype).
 
         Returns
         -------
@@ -3174,7 +3254,7 @@ class Dataset:
         """
         self.group = group
         if self._handle is not None and group is not None:
-            if not _is_pyarrow_array(group):
+            if not (_is_pyarrow_array(group) or _is_arrow_backed_pd_series(group)):
                 group = _list_to_1d_numpy(data=group, dtype=np.int32, name="group")
             self.set_field("group", group)
             # original values can be modified at cpp side
@@ -3191,8 +3271,9 @@ class Dataset:
 
         Parameters
         ----------
-        position : numpy 1-D array, pandas Series or None, optional (default=None)
+        position : numpy 1-D array, pandas Series, pyarrow Array, pyarrow ChunkedArray or None, optional (default=None)
             Position of items used in unbiased learning-to-rank task.
+            Supports arrow-backed pandas Series (ArrowDtype).
 
         Returns
         -------
@@ -3201,7 +3282,8 @@ class Dataset:
         """
         self.position = position
         if self._handle is not None and position is not None:
-            position = _list_to_1d_numpy(data=position, dtype=np.int32, name="position")
+            if not (_is_pyarrow_array(position) or _is_arrow_backed_pd_series(position)):
+                position = _list_to_1d_numpy(data=position, dtype=np.int32, name="position")
             self.set_field("position", position)
         return self
 

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -176,6 +176,10 @@ try:
         from pandas import CategoricalDtype as pd_CategoricalDtype
     except ImportError:
         from pandas.api.types import CategoricalDtype as pd_CategoricalDtype
+    try:
+        from pandas import ArrowDtype as pd_ArrowDtype
+    except ImportError:
+        pd_ArrowDtype = None
     PANDAS_INSTALLED = True
 except ImportError:
     PANDAS_INSTALLED = False
@@ -194,6 +198,12 @@ except ImportError:
 
     class pd_CategoricalDtype:  # type: ignore
         """Dummy class for pandas.CategoricalDtype."""
+
+        def __init__(self, *args: Any, **kwargs: Any):
+            pass
+
+    class pd_ArrowDtype:  # type: ignore
+        """Dummy class for pandas.ArrowDtype."""
 
         def __init__(self, *args: Any, **kwargs: Any):
             pass
@@ -285,6 +295,7 @@ try:
     from pyarrow import Table as pa_Table
     from pyarrow import array as pa_array
     from pyarrow import chunked_array as pa_chunked_array
+    from pyarrow.lib import DataType as pa_DataType
     from pyarrow.types import is_boolean as arrow_is_boolean
     from pyarrow.types import is_floating as arrow_is_floating
     from pyarrow.types import is_integer as arrow_is_integer
@@ -307,6 +318,12 @@ except ImportError:
 
     class pa_Table:  # type: ignore
         """Dummy class for pa.Table."""
+
+        def __init__(self, *args: Any, **kwargs: Any):
+            pass
+
+    class pa_DataType:  # type: ignore
+        """Dummy class for pa.lib.DataType."""
 
         def __init__(self, *args: Any, **kwargs: Any):
             pass

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -14,7 +14,7 @@ from sklearn.datasets import dump_svmlight_file, load_svmlight_file, make_blobs
 from sklearn.model_selection import train_test_split
 
 import lightgbm as lgb
-from lightgbm.compat import PANDAS_INSTALLED, pd_DataFrame, pd_Series
+from lightgbm.compat import PANDAS_INSTALLED, PYARROW_INSTALLED, pd_DataFrame, pd_Series
 
 from .utils import dummy_obj, load_breast_cancer, mse_obj, np_assert_array_equal
 
@@ -1209,3 +1209,182 @@ def test_refit_correctly_handles_categorical_features_in_params(rng) -> None:
         match=re.escape("Using refit() to change which columns are treated as categorical is not supported"),
     ):
         loaded_bst_new = loaded_bst.refit(X_new, y_new, categorical_feature=[0, 1])
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.parametrize(
+    "dtype_str",
+    [
+        "int8[pyarrow]",
+        "int16[pyarrow]",
+        "int32[pyarrow]",
+        "int64[pyarrow]",
+        "uint8[pyarrow]",
+        "uint32[pyarrow]",
+        "uint64[pyarrow]",
+        "float32[pyarrow]",
+        "float64[pyarrow]",
+        "bool[pyarrow]",
+    ]
+)
+def test_dataset_constructor_with_arrow_backed_dataframe(dtype_str, rng):
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame(rng.integers(0, 10, (100, 5)), dtype=dtype_str)
+    ds = lgb.Dataset(X).construct()
+    assert ds.num_data() == 100
+    assert ds.num_feature() == 5
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+def test_dataset_constructor_with_arrow_backed_dataframe_mixed(rng):
+    """tests for mixes of both numpy series and pyarrow-backed sereis in the same dataframe"""
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame(rng.integers(0, 10, (100, 5)), dtype="int32[pyarrow]")
+    X["int_col"] = pd.Series(rng.integers(0, 10, 100), dtype=np.int32)
+    X["float_col"] = pd.Series(rng.uniform(size=100), dtype=np.float32)
+    X["bool_col"] = pd.Series(rng.choice(a=[False, True], size=100), dtype=np.bool_)
+    X["nullable_int_col"] = pd.Series(rng.choice(a=[0, 1, None], size=100), dtype=pd.Int32Dtype())
+    X["nullable_float_col"] = pd.Series(rng.choice(a=[0.0, 1.0, None], size=100), dtype=pd.Float32Dtype())
+    X["nullable_bool_col"] = pd.Series(rng.choice(a=[False, True, None], size=100), dtype=pd.BooleanDtype())
+    ds = lgb.Dataset(X).construct()
+    assert ds.num_data() == 100
+    assert ds.num_feature() == 11
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+def test_dataset_constructor_with_invalid_arrow_backed_dataframe():
+    pd = pytest.importorskip("pandas")
+    for dtype in ["string[pyarrow]", "large_string[pyarrow]", "binary[pyarrow]", "large_binary[pyarrow]"]:
+        with pytest.raises(ValueError, match="must be int, float or bool."):
+            lgb.Dataset(pd.DataFrame(["hello", "world", None], dtype=dtype)).construct()
+    for dtype in [
+        "timestamp[ns][pyarrow]",
+        "timestamp[us][pyarrow]",
+        "timestamp[ms][pyarrow]",
+        "timestamp[s][pyarrow]",
+        "timestamp[ns, tz=UTC][pyarrow]",
+        "date32[pyarrow]",
+        "date64[pyarrow]",
+    ]:
+        with pytest.raises(ValueError, match="must be int, float or bool."):
+            lgb.Dataset(pd.DataFrame(["2020-01-01", None], dtype=dtype)).construct()
+    for dtype in ["time32[s][pyarrow]", "time32[ms][pyarrow]", "time64[ns][pyarrow]", "time64[us][pyarrow]"]:
+        with pytest.raises(ValueError, match="must be int, float or bool."):
+            lgb.Dataset(pd.DataFrame(["12:00:00", None], dtype=dtype)).construct()
+    for dtype in ["duration[s][pyarrow]", "duration[ms][pyarrow]", "duration[us][pyarrow]", "duration[ns][pyarrow]"]:
+        with pytest.raises(ValueError, match="must be int, float or bool."):
+            lgb.Dataset(pd.DataFrame([1000, None], dtype=dtype)).construct()
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.parametrize(
+    ("field_name", "dtype", "data_fn"),
+    [
+        ("label", "float64[pyarrow]", lambda rng: rng.random(100)),
+        ("weight", "float64[pyarrow]", lambda rng: rng.random(100)),
+        ("group", "int32[pyarrow]", lambda _: [20, 30, 50]),
+        # Position support will be added in https://github.com/lightgbm-org/LightGBM/pull/7260
+        # ("position", "int8[pyarrow]", lambda rng: rng.integers(0, 10, size=100)),
+        ("init_score", "float64[pyarrow]", lambda _: list(range(100))),
+    ],
+)
+def test_dataset_constructor_with_arrow_series_metadata_field(rng, field_name, dtype, data_fn):
+    pd = pytest.importorskip("pandas")
+    X = rng.random((100, 5))
+    data = data_fn(rng)
+    series = pd.Series(data, dtype=dtype)
+    ds = lgb.Dataset(X, **{field_name: series}).construct()
+    retrieved = getattr(ds, f"get_{field_name}")()
+    assert isinstance(retrieved, np.ndarray)
+    expected = np.asarray(data)
+    np.testing.assert_allclose(retrieved, expected)
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+def test_arrow_backed_categorical_features(rng):
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame({
+        'cat_col': pd.Series(rng.choice([1, 2, 3], size=100), dtype="float64[pyarrow]"),
+        'num_col': rng.random(100)
+    })
+    y = rng.integers(0, 2, 100)
+    ds = lgb.Dataset(X, label=y, categorical_feature=['cat_col']).construct()
+    assert ds.num_data() == 100
+    assert ds.num_feature() == 2
+    assert ds.categorical_feature == ['cat_col']
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+def test_pd_categorical_features_with_arrow_backed_dataframe(rng):
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame({
+        'cat_col': pd.Categorical(['a', 'b', 'c'] * 30),
+        'num_col': rng.random(90)
+    })
+    y = rng.integers(0, 2, 90)
+    X['num_col'] = X['num_col'].astype('float64[pyarrow]')
+    ds = lgb.Dataset(X, label=y, categorical_feature=['cat_col']).construct()
+    assert ds.num_data() == 90
+    assert ds.num_feature() == 2
+    assert ds.categorical_feature == ['cat_col']
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+def test_empty_arrow_backed_dataframe_raises():
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame(dtype="float64[pyarrow]")
+    with pytest.raises(ValueError, match="must be 2 dimensional and non empty"):
+        lgb.Dataset(X).construct()
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+def test_numeric_column_names_with_arrow_backend(rng):
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame(rng.random((50, 3)), columns=[0, 1, 2], dtype="float64[pyarrow]")
+    ds = lgb.Dataset(X).construct()
+    assert ds.feature_name == ['0', '1', '2']
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+def test_all_null_arrow_column():
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame({
+        'col1': pd.Series([1.0, 2.0, 3.0], dtype='float64[pyarrow]'),
+        'col2': pd.Series([None, None, None], dtype='float64[pyarrow]')
+    })
+    y = [0, 1, 0]
+    ds = lgb.Dataset(X, label=y).construct()
+    assert ds.num_feature() == 2
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+def test_all_arrow_vs_mixed_dtypes_equivalence(rng):
+    pd = pytest.importorskip("pandas")
+    data = rng.random((100, 5))
+    y = rng.integers(0, 2, 100)
+
+    X_all_arrow = pd.DataFrame(data, dtype="float64[pyarrow]")
+    X_mixed = pd.DataFrame(data)
+    X_mixed[0] = X_mixed[0].astype('float64[pyarrow]')
+
+    ds1 = lgb.Dataset(X_all_arrow, label=y).construct()  # fast path
+    ds2 = lgb.Dataset(X_mixed, label=y).construct()  # mixed path
+
+    params = {'seed': 42, 'verbose': -1}
+    bst1 = lgb.train(params, ds1, num_boost_round=5)
+    bst2 = lgb.train(params, ds2, num_boost_round=5)
+
+    pred1 = bst1.predict(data)
+    pred2 = bst2.predict(data)
+
+    np.testing.assert_allclose(pred1, pred2)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -18,6 +18,18 @@ from lightgbm.compat import PANDAS_INSTALLED, PYARROW_INSTALLED, pd_DataFrame, p
 
 from .utils import dummy_obj, load_breast_cancer, mse_obj, np_assert_array_equal
 
+# The "name[pyarrow]" dtype-string syntax used by some tests below requires
+# pandas >= 1.5 (which introduced ``pd.ArrowDtype``). The "oldest" CI matrix
+# pins pandas to a version that does not understand those strings even when
+# pyarrow itself is installed, so we gate those tests on this capability.
+if PANDAS_INSTALLED and PYARROW_INSTALLED:
+    import pandas as _pd_for_arrow_check
+
+    _PANDAS_ARROW_DTYPE_SUPPORTED = hasattr(_pd_for_arrow_check, "ArrowDtype")
+    del _pd_for_arrow_check
+else:
+    _PANDAS_ARROW_DTYPE_SUPPORTED = False
+
 
 def test_basic(tmp_path):
     X_train, X_test, y_train, y_test = train_test_split(
@@ -1211,8 +1223,10 @@ def test_refit_correctly_handles_categorical_features_in_params(rng) -> None:
         loaded_bst_new = loaded_bst.refit(X_new, y_new, categorical_feature=[0, 1])
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 @pytest.mark.parametrize(
     "dtype_str",
     [
@@ -1236,8 +1250,10 @@ def test_dataset_constructor_with_arrow_backed_dataframe(dtype_str, rng):
     assert ds.num_feature() == 5
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 def test_dataset_constructor_with_arrow_backed_dataframe_mixed(rng):
     """tests for mixes of both numpy series and pyarrow-backed sereis in the same dataframe"""
     pd = pytest.importorskip("pandas")
@@ -1253,8 +1269,10 @@ def test_dataset_constructor_with_arrow_backed_dataframe_mixed(rng):
     assert ds.num_feature() == 11
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 def test_dataset_constructor_with_invalid_arrow_backed_dataframe():
     pd = pytest.importorskip("pandas")
     for dtype in ["string[pyarrow]", "large_string[pyarrow]", "binary[pyarrow]", "large_binary[pyarrow]"]:
@@ -1279,8 +1297,10 @@ def test_dataset_constructor_with_invalid_arrow_backed_dataframe():
             lgb.Dataset(pd.DataFrame([1000, None], dtype=dtype)).construct()
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 @pytest.mark.parametrize(
     ("field_name", "dtype", "data_fn"),
     [
@@ -1304,8 +1324,10 @@ def test_dataset_constructor_with_arrow_series_metadata_field(rng, field_name, d
     np.testing.assert_allclose(retrieved, expected)
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 def test_arrow_backed_categorical_features(rng):
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame({
@@ -1319,8 +1341,10 @@ def test_arrow_backed_categorical_features(rng):
     assert ds.categorical_feature == ['cat_col']
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 def test_pd_categorical_features_with_arrow_backed_dataframe(rng):
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame({
@@ -1335,8 +1359,10 @@ def test_pd_categorical_features_with_arrow_backed_dataframe(rng):
     assert ds.categorical_feature == ['cat_col']
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 def test_empty_arrow_backed_dataframe_raises():
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame(dtype="float64[pyarrow]")
@@ -1344,8 +1370,10 @@ def test_empty_arrow_backed_dataframe_raises():
         lgb.Dataset(X).construct()
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 def test_numeric_column_names_with_arrow_backend(rng):
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame(rng.random((50, 3)), columns=[0, 1, 2], dtype="float64[pyarrow]")
@@ -1353,8 +1381,10 @@ def test_numeric_column_names_with_arrow_backend(rng):
     assert ds.feature_name == ['0', '1', '2']
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 def test_all_null_arrow_column():
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame({
@@ -1366,8 +1396,10 @@ def test_all_null_arrow_column():
     assert ds.num_feature() == 2
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 def test_all_arrow_vs_mixed_dtypes_equivalence(rng):
     pd = pytest.importorskip("pandas")
     data = rng.random((100, 5))

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -17,7 +17,7 @@ from sklearn.calibration import CalibratedClassifierCV
 from sklearn.datasets import load_svmlight_file, make_blobs, make_multilabel_classification
 from sklearn.ensemble import StackingClassifier, StackingRegressor
 from sklearn.metrics import accuracy_score, log_loss, mean_squared_error, r2_score
-from sklearn.model_selection import GridSearchCV, RandomizedSearchCV, train_test_split
+from sklearn.model_selection import GridSearchCV, RandomizedSearchCV, cross_val_score, train_test_split
 from sklearn.multioutput import ClassifierChain, MultiOutputClassifier, MultiOutputRegressor, RegressorChain
 from sklearn.utils.estimator_checks import parametrize_with_checks as sklearn_parametrize_with_checks
 from sklearn.utils.validation import check_is_fitted
@@ -2260,3 +2260,47 @@ def test_eval_X_eval_y_eval_set_equivalence():
     assert gbm2.evals_result_["valid_0"]["l2"] != gbm2.evals_result_["valid_1"]["l2"], (
         "Evaluation results for the 2 validation sets are not different. This might mean they weren't both used."
     )
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+def test_lgbm_classifier_with_arrow_backed_dataframe():
+    pd = pytest.importorskip("pandas")
+    X, y = load_breast_cancer(return_X_y=True)
+    X_arrow = pd.DataFrame(X, dtype="float64[pyarrow]")
+    y_arrow = pd.Series(y, dtype="int32[pyarrow]")
+    X_train, X_test, y_train, y_test = train_test_split(X_arrow, y_arrow, test_size=0.2, random_state=42)
+    clf = lgb.LGBMClassifier(n_estimators=10, verbose=-1, random_state=42)
+    clf.fit(X_train, y_train)
+    y_pred = clf.predict(X_test)
+    y_pred_proba = clf.predict_proba(X_test)
+    assert y_pred.shape == (len(X_test),)
+    assert y_pred_proba.shape == (len(X_test), 2)
+    assert accuracy_score(y_test, y_pred) > 0.9
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+def test_lgbm_regressor_with_arrow_backed_dataframe():
+    pd = pytest.importorskip("pandas")
+    X, y = make_synthetic_regression()
+    X_arrow = pd.DataFrame(X, dtype="float32[pyarrow]")
+    y_arrow = pd.Series(y, dtype="float32[pyarrow]")
+    X_train, X_test, y_train, _ = train_test_split(X_arrow, y_arrow, test_size=0.2, random_state=42)
+    reg = lgb.LGBMRegressor(n_estimators=10, verbose=-1, random_state=42)
+    reg.fit(X_train, y_train)
+    y_pred = reg.predict(X_test)
+    assert y_pred.shape == (len(X_test),)
+    assert np.isfinite(y_pred).all()
+
+
+@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
+@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+def test_cross_validation_with_arrow_backed_dataframe(rng):
+    pd = pytest.importorskip("pandas")
+    X_arrow = pd.DataFrame(rng.random((100, 5)), dtype="float32[pyarrow]")
+    y_arrow = pd.Series(rng.integers(0, 2, 100), dtype="int32[pyarrow]")
+    clf = lgb.LGBMClassifier(n_estimators=5, verbose=-1)
+    scores = cross_val_score(clf, X_arrow, y_arrow, cv=3)
+    assert len(scores) == 3
+    assert all(0 <= s <= 1 for s in scores)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -54,6 +54,18 @@ SKLEARN_MAJOR, SKLEARN_MINOR, *_ = _sklearn_version.split(".")
 SKLEARN_VERSION_GTE_1_6 = (int(SKLEARN_MAJOR), int(SKLEARN_MINOR)) >= (1, 6)
 SKLEARN_VERSION_GTE_1_7 = (int(SKLEARN_MAJOR), int(SKLEARN_MINOR)) >= (1, 7)
 
+# The "name[pyarrow]" dtype-string syntax used by some tests below requires
+# pandas >= 1.5 (which introduced ``pd.ArrowDtype``). The "oldest" CI matrix
+# pins pandas to a version that does not understand those strings even when
+# pyarrow itself is installed, so we gate those tests on this capability.
+if PANDAS_INSTALLED and PYARROW_INSTALLED:
+    import pandas as _pd_for_arrow_check
+
+    _PANDAS_ARROW_DTYPE_SUPPORTED = hasattr(_pd_for_arrow_check, "ArrowDtype")
+    del _pd_for_arrow_check
+else:
+    _PANDAS_ARROW_DTYPE_SUPPORTED = False
+
 decreasing_generator = itertools.count(0, -1)
 estimator_classes = (lgb.LGBMModel, lgb.LGBMClassifier, lgb.LGBMRegressor, lgb.LGBMRanker)
 task_to_model_factory = {
@@ -2262,8 +2274,10 @@ def test_eval_X_eval_y_eval_set_equivalence():
     )
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 def test_lgbm_classifier_with_arrow_backed_dataframe():
     pd = pytest.importorskip("pandas")
     X, y = load_breast_cancer(return_X_y=True)
@@ -2279,8 +2293,10 @@ def test_lgbm_classifier_with_arrow_backed_dataframe():
     assert accuracy_score(y_test, y_pred) > 0.9
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 def test_lgbm_regressor_with_arrow_backed_dataframe():
     pd = pytest.importorskip("pandas")
     X, y = make_synthetic_regression()
@@ -2294,8 +2310,10 @@ def test_lgbm_regressor_with_arrow_backed_dataframe():
     assert np.isfinite(y_pred).all()
 
 
-@pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow not installed")
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas not installed")
+@pytest.mark.skipif(
+    not _PANDAS_ARROW_DTYPE_SUPPORTED,
+    reason="pandas + pyarrow with ArrowDtype string support (pandas >= 1.5) not installed",
+)
 def test_cross_validation_with_arrow_backed_dataframe(rng):
     pd = pytest.importorskip("pandas")
     X_arrow = pd.DataFrame(rng.random((100, 5)), dtype="float32[pyarrow]")


### PR DESCRIPTION
> NOTE: full support for all metadata fields depends on https://github.com/lightgbm-org/LightGBM/pull/7260 (`position`)

## Problem

Fixes https://github.com/lightgbm-org/LightGBM/issues/5739

LightGBM currently converts all pandas DataFrames to NumPy arrays during Dataset construction, even when the DataFrame uses PyArrow-backed columns (`ArrowDtype`). This forces an unnecessary copy of data that's already in Arrow's columnar format, missing an opportunity for zero-copy data transfer to the C++ backend.

With pandas 2.0+ increasingly adopting PyArrow as the default backend for better memory efficiency and interoperability, users working with Arrow-backed DataFrames face a performance penalty. This PR enables LightGBM to detect and leverage PyArrow-backed columns, maintaining data in the Arrow format through the entire pipeline.

## Approach

The key design principle was to keep pandas-specific processing (categorical handling, type validation) in the pandas-specific code path while cleanly passing Arrow tables downstream.

**Integration Point**: Modified `_data_from_pandas()` to detect PyArrow-backed columns and convert the entire DataFrame to an Arrow Table instead of a NumPy array. This keeps all existing categorical feature logic intact while letting the downstream C++ interface naturally handle Arrow tables via the existing `_create_from_arrow_table()` path.

**Zero-Copy Strategy**: The implementation handles DataFrames with mixed dtypes (Arrow + NumPy + nullable extension types) by extracting underlying buffers directly where possible, avoiding intermediate copies. Each column type is handled optimally:
- Arrow-backed columns: Extract the underlying Arrow array with `.__arrow_array__()`
- Nullable extension types: Pass through PyArrow's null-aware conversion
- NumPy-backed columns: Use `.values` for a zero-copy view

Only dtypes already supported by LightGBM's Arrow interface (int, float, bool) are allowed, ensuring consistency with the existing Arrow code path.

**Implementation note**: An alternative approach was considered that would use `pa.Table.from_pandas()` for all-Arrow DataFrames:
```python
if all(_is_pd_arrow_dtype(dtype) for dtype in data.dtypes):
    table = pa_Table.from_pandas(data, preserve_index=False)
```
However, benchmarking showed this provided no meaningful speedup over the unified column-by-column implementation, so the latter approach was chosen.

## Changes

### Core Logic (basic.py)

- **`_pandas_to_arrow_table()`** (new): Converts pandas DataFrames to Arrow Tables with zero-copy optimizations. Uses a unified implementation that handles mixed dtypes efficiently:
  - Arrow-backed columns: Extract underlying array directly (`.__arrow_array__()`)
  - Nullable extension types (Int64Dtype, Float64Dtype): Pass through PyArrow's null-aware conversion
  - NumPy-backed columns: Use `.values` for zero-copy view
  - Builds the Arrow table with `pa.Table.from_arrays()` for consistent performance across all DataFrame types
  
- **`_data_from_pandas()`**: Updated return type from `np.ndarray` to `Union[np.ndarray, pa.Table]`. Early-exits with Arrow table when any PyArrow-backed columns detected, preserving all existing categorical logic.

- **`_check_for_bad_arrow_dtypes()`** (new): Centralized validation for Arrow type compatibility, replacing duplicated checks in Dataset and _InnerPredictor.

- **`_is_pd_arrow_dtype()`, `_is_arrow_backed_pd_series()`, `_extract_arrow_array()`** (new): Helper functions for detecting and extracting Arrow arrays from pandas Series.

- **Metadata field support**: Extended `set_label()`, `set_weight()`, `set_group()`, `set_position()` to accept PyArrow-backed Series, maintaining API consistency.

### Compatibility Layer (compat.py)

- Added imports for `pd.ArrowDtype` and `pa.DataType` with fallbacks

### Tests

**Basic Dataset functionality** (test_basic.py):
- All PyArrow integer types (int8/16/32/64, uint8/32/64)
- All PyArrow float types (float32/64)
- Boolean PyArrow columns
- Mixed DataFrames (Arrow + NumPy + nullable extension types)
- Categorical feature handling with Arrow backend
- Edge cases: empty DataFrames, all-null columns, numeric column names
- Metadata fields (label, weight, group, init_score) as Arrow-backed Series
- Invalid dtypes (string, timestamp, date, time, duration) properly rejected

**Sklearn integration** (test_sklearn.py):
- LGBMClassifier fit/predict with Arrow DataFrames
- LGBMRegressor fit/predict with Arrow DataFrames  
- Cross-validation with Arrow-backed data

## Benchmarks

All benchmarks ran 50 iterations per configuration on datasets ranging from 10K to 1M rows. Four scenarios tested:
- **Numpy baseline**: Standard pandas DataFrame backed by NumPy arrays
- **Full arrow**: All columns as PyArrow-backed
- **Mixed arrow/numpy**: 50% PyArrow + 50% NumPy columns
- **Mixed arrow/nullable**: 50% PyArrow + 50% nullable extension types

### Dataset Construction Time

<img width="3000" height="900" alt="image" src="https://github.com/user-attachments/assets/cfe9b667-eb4a-4bc3-94fa-86fb6943ab16" />

**PyArrow-backed DataFrames provide speedups up to 43% in dataset construction for large datasets** (50K+ rows). Minimal impact for small datasets (10K rows: ~6%).

<details>
<summary>Benchmark code and logs</summary>

The benchmark below was ran on a 16GB MacBook Pro M2 Pro.

```python
import time
import numpy as np
import pandas as pd
import lightgbm as lgb
import matplotlib.pyplot as plt

# Dataset sizes to test
SIZES = [
    (10_000, 10),  # 10K rows, 10 cols
    (50_000, 20),  # 50K rows, 20 cols
    (100_000, 20),  # 100K rows, 20 cols
    (500_000, 50),  # 500K rows, 50 cols
    (1_000_000, 50),  # 1M rows, 50 cols
]

N_ITER = 50  # Iterations per configuration

print("=" * 80)
print("CONSTRUCTION TIME BENCHMARK")
print("=" * 80)

# Collect all results for plotting
results = {"sizes": [], "numpy": [], "arrow": [], "mixed": [], "nullable": []}

for n_rows, n_cols in SIZES:
    data = np.random.RandomState(42).random((n_rows, n_cols))
    y = np.random.RandomState(42).randint(0, 2, n_rows)

    print(f"\nDataset: {n_rows:,} rows x {n_cols} cols ({N_ITER} iterations)")
    print("-" * 80)

    # Baseline: Numpy-backed DataFrame
    numpy_times = []
    for _ in range(N_ITER):
        df = pd.DataFrame(data)
        start = time.perf_counter()
        ds = lgb.Dataset(df, label=y).construct()
        numpy_times.append((time.perf_counter() - start) * 1000)
    numpy_mean = np.mean(numpy_times)

    print(f"  Numpy baseline:     {numpy_mean:>6.2f} ms")

    # Full arrow: All columns arrow-backed (fast path)
    arrow_times = []
    for _ in range(N_ITER):
        df = pd.DataFrame(data, dtype="float64[pyarrow]")
        start = time.perf_counter()
        ds = lgb.Dataset(df, label=y).construct()
        arrow_times.append((time.perf_counter() - start) * 1000)
    arrow_mean = np.mean(arrow_times)
    arrow_pct = ((arrow_mean - numpy_mean) / numpy_mean) * 100

    print(f"  Full arrow:         {arrow_mean:>6.2f} ms ({arrow_pct:+.1f}%)")

    # Mixed arrow/numpy: 50% arrow + 50% numpy
    mixed_times = []
    for _ in range(N_ITER):
        df = pd.DataFrame(data)
        half = n_cols // 2
        for i in range(half):
            df[i] = df[i].astype("float64[pyarrow]")
        start = time.perf_counter()
        ds = lgb.Dataset(df, label=y).construct()
        mixed_times.append((time.perf_counter() - start) * 1000)
    mixed_mean = np.mean(mixed_times)
    mixed_pct = ((mixed_mean - numpy_mean) / numpy_mean) * 100

    print(f"  Mixed arrow/numpy:  {mixed_mean:>6.2f} ms ({mixed_pct:+.1f}%)")

    # Mixed arrow/nullable: 50% arrow + 50% nullable
    nullable_times = []
    for _ in range(N_ITER):
        df = pd.DataFrame(data)
        half = n_cols // 2
        for i in range(half):
            df[i] = df[i].astype("float64[pyarrow]")
        for i in range(half, n_cols):
            df[i] = df[i].astype(pd.Float64Dtype())
        start = time.perf_counter()
        ds = lgb.Dataset(df, label=y).construct()
        nullable_times.append((time.perf_counter() - start) * 1000)
    nullable_mean = np.mean(nullable_times)
    nullable_pct = ((nullable_mean - numpy_mean) / numpy_mean) * 100

    print(f"  Mixed arrow/null:   {nullable_mean:>6.2f} ms ({nullable_pct:+.1f}%)")

    # Store results
    results["sizes"].append(f"{n_rows // 1000}K")
    results["numpy"].append(numpy_times)
    results["arrow"].append(arrow_times)
    results["mixed"].append(mixed_times)
    results["nullable"].append(nullable_times)

# Create subplots - one per dataset size for independent y axes
print("\nGenerating plot...")
n_sizes = len(results["sizes"])
fig, axes = plt.subplots(1, n_sizes, figsize=(4 * n_sizes, 6), sharey=False)

if n_sizes == 1:
    axes = [axes]

for i, (ax, size_label) in enumerate(zip(axes, results["sizes"])):
    data_to_plot = [results["numpy"][i], results["arrow"][i], results["mixed"][i], results["nullable"][i]]
    bp = ax.boxplot(data_to_plot, patch_artist=True, tick_labels=["Numpy", "Arrow", "50% Arrow\n50% Numpy", "50% Arrow\n50% Null"])

    # Color the boxes
    colors = ["lightblue", "lightgreen", "lightyellow", "lightcoral"]
    for patch, color in zip(bp["boxes"], colors):
        patch.set_facecolor(color)

    ax.set_title(f"{size_label} rows")
    ax.set_ylabel("Construction Time (ms)")
    ax.grid(True, alpha=0.3)

fig.suptitle("Dataset Construction Time: Numpy vs Arrow Backends", fontsize=14)
plt.tight_layout()
plt.savefig("construction_time.png", dpi=150)
```

**Logs**:
```
================================================================================
CONSTRUCTION TIME BENCHMARK
================================================================================

Dataset: 10,000 rows x 10 cols (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:       2.11 ms
  Full arrow:           1.98 ms (-6.1%)
  Mixed arrow/numpy:    2.00 ms (-5.0%)
  Mixed arrow/null:     2.05 ms (-2.7%)

Dataset: 50,000 rows x 20 cols (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:      22.64 ms
  Full arrow:          14.29 ms (-36.9%)
  Mixed arrow/numpy:   15.37 ms (-32.1%)
  Mixed arrow/null:    15.87 ms (-29.9%)

Dataset: 100,000 rows x 20 cols (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:      45.23 ms
  Full arrow:          29.17 ms (-35.5%)
  Mixed arrow/numpy:   32.19 ms (-28.8%)
  Mixed arrow/null:    30.94 ms (-31.6%)

Dataset: 500,000 rows x 50 cols (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:     292.34 ms
  Full arrow:         166.31 ms (-43.1%)
  Mixed arrow/numpy:  192.65 ms (-34.1%)
  Mixed arrow/null:   186.97 ms (-36.0%)

Dataset: 1,000,000 rows x 50 cols (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:     365.08 ms
  Full arrow:         225.18 ms (-38.3%)
  Mixed arrow/numpy:  283.62 ms (-22.3%)
  Mixed arrow/null:   265.41 ms (-27.3%)

Generating plot...
```

</details>

### End-to-End Training Time

<img width="3000" height="900" alt="image" src="https://github.com/user-attachments/assets/fd42ebd8-c5f1-4dbf-a570-44d6e830bf13" />

**PyArrow provides speedups up to 10% for end-to-end training on large datasets** (500K-1M rows). Minimal impact for small to medium datasets.

<details>
<summary>Benchmark code and logs</summary>

The benchmark below was ran on a 16GB MacBook Pro M2 Pro.

```python
import time
import numpy as np
import pandas as pd
import lightgbm as lgb
import matplotlib.pyplot as plt

# Dataset sizes to test
SIZES = [
    (10_000, 10, 50),  # 10K rows, 10 cols, 50 rounds
    (50_000, 20, 100),  # 50K rows, 20 cols, 100 rounds
    (100_000, 20, 100),  # 100K rows, 20 cols, 100 rounds
    (500_000, 50, 100),  # 500K rows, 50 cols, 100 rounds
    (1_000_000, 50, 100),  # 1M rows, 50 cols, 100 rounds
]

N_ITER = 50  # Iterations per configuration
params = {"objective": "binary", "verbose": -1, "seed": 42}

print("=" * 80)
print("END-TO-END TRAINING BENCHMARK")
print("=" * 80)

# Collect all results for plotting
results = {"sizes": [], "numpy": [], "arrow": [], "mixed": [], "nullable": []}

for n_rows, n_cols, n_rounds in SIZES:
    data = np.random.RandomState(42).random((n_rows, n_cols))
    y = np.random.RandomState(42).randint(0, 2, n_rows)

    print(f"\nDataset: {n_rows:,} rows x {n_cols} cols, {n_rounds} rounds ({N_ITER} iterations)")
    print("-" * 80)

    # Baseline: Numpy-backed DataFrame
    numpy_times = []
    for _ in range(N_ITER):
        df = pd.DataFrame(data)
        start = time.perf_counter()
        ds = lgb.Dataset(df, label=y).construct()
        bst = lgb.train(params, ds, num_boost_round=n_rounds)
        numpy_times.append((time.perf_counter() - start) * 1000)
    numpy_mean = np.mean(numpy_times)

    print(f"  Numpy baseline:     {numpy_mean:>7.1f} ms")

    # Full arrow: All columns arrow-backed
    arrow_times = []
    for _ in range(N_ITER):
        df = pd.DataFrame(data, dtype="float32[pyarrow]")
        start = time.perf_counter()
        ds = lgb.Dataset(df, label=y).construct()
        bst = lgb.train(params, ds, num_boost_round=n_rounds)
        arrow_times.append((time.perf_counter() - start) * 1000)
    arrow_mean = np.mean(arrow_times)
    arrow_pct = ((arrow_mean - numpy_mean) / numpy_mean) * 100

    print(f"  Full arrow:         {arrow_mean:>7.1f} ms ({arrow_pct:+.1f}%)")

    # Mixed arrow/numpy: 50% arrow + 50% numpy
    mixed_times = []
    for _ in range(N_ITER):
        df = pd.DataFrame(data)
        half = n_cols // 2
        for i in range(half):
            df[i] = df[i].astype("float32[pyarrow]")
        start = time.perf_counter()
        ds = lgb.Dataset(df, label=y).construct()
        bst = lgb.train(params, ds, num_boost_round=n_rounds)
        mixed_times.append((time.perf_counter() - start) * 1000)
    mixed_mean = np.mean(mixed_times)
    mixed_pct = ((mixed_mean - numpy_mean) / numpy_mean) * 100

    print(f"  Mixed arrow/numpy:  {mixed_mean:>7.1f} ms ({mixed_pct:+.1f}%)")

    # Mixed arrow/nullable: 50% arrow + 50% nullable
    nullable_times = []
    for _ in range(N_ITER):
        df = pd.DataFrame(data)
        half = n_cols // 2
        for i in range(half):
            df[i] = df[i].astype("float32[pyarrow]")
        for i in range(half, n_cols):
            df[i] = df[i].astype(pd.Float64Dtype())
        start = time.perf_counter()
        ds = lgb.Dataset(df, label=y).construct()
        bst = lgb.train(params, ds, num_boost_round=n_rounds)
        nullable_times.append((time.perf_counter() - start) * 1000)
    nullable_mean = np.mean(nullable_times)
    nullable_pct = ((nullable_mean - numpy_mean) / numpy_mean) * 100

    print(f"  Mixed arrow/null:   {nullable_mean:>7.1f} ms ({nullable_pct:+.1f}%)")

    # Store results
    results["sizes"].append(f"{n_rows // 1000}K")
    results["numpy"].append(numpy_times)
    results["arrow"].append(arrow_times)
    results["mixed"].append(mixed_times)
    results["nullable"].append(nullable_times)

# Create subplots - one per dataset size for independent y axes
print("\nGenerating plot...")
n_sizes = len(results["sizes"])
fig, axes = plt.subplots(1, n_sizes, figsize=(4 * n_sizes, 6), sharey=False)

if n_sizes == 1:
    axes = [axes]

for i, (ax, size_label) in enumerate(zip(axes, results["sizes"])):
    data_to_plot = [results["numpy"][i], results["arrow"][i], results["mixed"][i], results["nullable"][i]]
    bp = ax.boxplot(data_to_plot, patch_artist=True, tick_labels=["Numpy", "Arrow", "50% Arrow\n50% Numpy", "50% Arrow\n50% Null"])

    # Color the boxes
    colors = ["lightblue", "lightgreen", "lightyellow", "lightcoral"]
    for patch, color in zip(bp["boxes"], colors):
        patch.set_facecolor(color)

    ax.set_title(f"{size_label} rows")
    ax.set_ylabel("Training Time (ms)")
    ax.grid(True, alpha=0.3)

fig.suptitle("End-to-End Training: Numpy vs Arrow Backends", fontsize=14)
plt.tight_layout()
plt.savefig("e2e_training.png", dpi=150)
```

**Logs**:
```
================================================================================
END-TO-END TRAINING BENCHMARK
================================================================================

Dataset: 10,000 rows x 10 cols, 50 rounds (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:       267.2 ms
  Full arrow:           267.4 ms (+0.1%)
  Mixed arrow/numpy:    267.2 ms (-0.0%)
  Mixed arrow/null:     266.9 ms (-0.1%)

Dataset: 50,000 rows x 20 cols, 100 rounds (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:       595.5 ms
  Full arrow:           588.1 ms (-1.3%)
  Mixed arrow/numpy:    591.9 ms (-0.6%)
  Mixed arrow/null:     590.4 ms (-0.8%)

Dataset: 100,000 rows x 20 cols, 100 rounds (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:       655.6 ms
  Full arrow:           678.4 ms (+3.5%)
  Mixed arrow/numpy:    743.3 ms (+13.4%)
  Mixed arrow/null:     781.0 ms (+19.1%)

Dataset: 500,000 rows x 50 cols, 100 rounds (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:      1352.6 ms
  Full arrow:          1241.3 ms (-8.2%)
  Mixed arrow/numpy:   1266.3 ms (-6.4%)
  Mixed arrow/null:    1259.1 ms (-6.9%)

Dataset: 1,000,000 rows x 50 cols, 100 rounds (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:      2077.7 ms
  Full arrow:          1882.1 ms (-9.4%)
  Mixed arrow/numpy:   1879.3 ms (-9.6%)
  Mixed arrow/null:    1890.9 ms (-9.0%)

Generating plot...
```

</details>


### Sklearn Integration

<img width="3000" height="900" alt="image" src="https://github.com/user-attachments/assets/08ad6f22-d2e4-49d4-89a6-b1e862b31b4c" />

**PyArrow has minimal impact on sklearn integration performance,** with speedups up to 11% for large datasets (500K rows). Performance is within ±2% for most dataset sizes.

<details>
<summary>Benchmark code and logs</summary>

The benchmark below was ran on a 16GB MacBook Pro M2 Pro.

```python
import time
import numpy as np
import pandas as pd
import lightgbm as lgb
import matplotlib.pyplot as plt

# Dataset sizes to test
SIZES = [
    (10_000, 10, 50),  # 10K rows, 10 cols, 50 estimators
    (50_000, 20, 50),  # 50K rows, 20 cols, 50 estimators
    (100_000, 20, 100),  # 100K rows, 20 cols, 100 estimators
    (500_000, 50, 100),  # 500K rows, 50 cols, 100 estimators
    (1_000_000, 50, 100),  # 1M rows, 50 cols, 100 estimators
]

N_ITER = 50  # Iterations per configuration

print("=" * 80)
print("SKLEARN INTEGRATION BENCHMARK")
print("=" * 80)

# Collect all results for plotting
results = {"sizes": [], "numpy": [], "arrow": [], "mixed": [], "nullable": []}

for n_rows, n_cols, n_estimators in SIZES:
    data = np.random.RandomState(42).random((n_rows, n_cols))
    y = np.random.RandomState(42).randint(0, 2, n_rows)

    print(f"\nDataset: {n_rows:,} rows x {n_cols} cols, {n_estimators} estimators ({N_ITER} iterations)")
    print("-" * 80)

    # Baseline: Numpy-backed DataFrame
    numpy_times = []
    for _ in range(N_ITER):
        df = pd.DataFrame(data)
        start = time.perf_counter()
        clf = lgb.LGBMClassifier(n_estimators=n_estimators, verbose=-1, random_state=42)
        clf.fit(df, y)
        pred = clf.predict(df)
        numpy_times.append((time.perf_counter() - start) * 1000)
    numpy_mean = np.mean(numpy_times)

    print(f"  Numpy baseline:     {numpy_mean:>7.1f} ms")

    # Full arrow: All columns arrow-backed
    arrow_times = []
    for _ in range(N_ITER):
        df_arrow = pd.DataFrame(data, dtype="float32[pyarrow]")
        y_arrow = pd.Series(y, dtype="int32[pyarrow]")
        start = time.perf_counter()
        clf = lgb.LGBMClassifier(n_estimators=n_estimators, verbose=-1, random_state=42)
        clf.fit(df_arrow, y_arrow)
        pred = clf.predict(df_arrow)
        arrow_times.append((time.perf_counter() - start) * 1000)
    arrow_mean = np.mean(arrow_times)
    arrow_pct = ((arrow_mean - numpy_mean) / numpy_mean) * 100

    print(f"  Full arrow:         {arrow_mean:>7.1f} ms ({arrow_pct:+.1f}%)")

    # Mixed arrow/numpy: 50% arrow + 50% numpy
    mixed_times = []
    for _ in range(N_ITER):
        df_mixed = pd.DataFrame(data)
        half = n_cols // 2
        for i in range(half):
            df_mixed[i] = df_mixed[i].astype("float32[pyarrow]")
        start = time.perf_counter()
        clf = lgb.LGBMClassifier(n_estimators=n_estimators, verbose=-1, random_state=42)
        clf.fit(df_mixed, y)
        pred = clf.predict(df_mixed)
        mixed_times.append((time.perf_counter() - start) * 1000)
    mixed_mean = np.mean(mixed_times)
    mixed_pct = ((mixed_mean - numpy_mean) / numpy_mean) * 100

    print(f"  Mixed arrow/numpy:  {mixed_mean:>7.1f} ms ({mixed_pct:+.1f}%)")

    # Mixed arrow/nullable: 50% arrow + 50% nullable
    nullable_times = []
    for _ in range(N_ITER):
        df_nullable = pd.DataFrame(data)
        half = n_cols // 2
        for i in range(half):
            df_nullable[i] = df_nullable[i].astype("float32[pyarrow]")
        for i in range(half, n_cols):
            df_nullable[i] = df_nullable[i].astype(pd.Float64Dtype())
        start = time.perf_counter()
        clf = lgb.LGBMClassifier(n_estimators=n_estimators, verbose=-1, random_state=42)
        clf.fit(df_nullable, y)
        pred = clf.predict(df_nullable)
        nullable_times.append((time.perf_counter() - start) * 1000)
    nullable_mean = np.mean(nullable_times)
    nullable_pct = ((nullable_mean - numpy_mean) / numpy_mean) * 100

    print(f"  Mixed arrow/null:   {nullable_mean:>7.1f} ms ({nullable_pct:+.1f}%)")

    # Store results
    results["sizes"].append(f"{n_rows // 1000}K")
    results["numpy"].append(numpy_times)
    results["arrow"].append(arrow_times)
    results["mixed"].append(mixed_times)
    results["nullable"].append(nullable_times)

# Create subplots - one per dataset size for independent y axes
print("\nGenerating plot...")
n_sizes = len(results["sizes"])
fig, axes = plt.subplots(1, n_sizes, figsize=(4 * n_sizes, 6), sharey=False)

if n_sizes == 1:
    axes = [axes]

for i, (ax, size_label) in enumerate(zip(axes, results["sizes"])):
    data_to_plot = [results["numpy"][i], results["arrow"][i], results["mixed"][i], results["nullable"][i]]
    bp = ax.boxplot(data_to_plot, patch_artist=True, tick_labels=["Numpy", "Arrow", "50% Arrow\n50% Numpy", "50% Arrow\n50% Null"])

    # Color the boxes
    colors = ["lightblue", "lightgreen", "lightyellow", "lightcoral"]
    for patch, color in zip(bp["boxes"], colors):
        patch.set_facecolor(color)

    ax.set_title(f"{size_label} rows")
    ax.set_ylabel("Fit + Predict Time (ms)")
    ax.grid(True, alpha=0.3)

fig.suptitle("Sklearn Integration: Numpy vs Arrow Backends", fontsize=14)
plt.tight_layout()
plt.savefig("sklearn_integration.png", dpi=150)
```

**Logs**:
```
================================================================================
SKLEARN INTEGRATION BENCHMARK
================================================================================

Dataset: 10,000 rows x 10 cols, 50 estimators (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:       272.2 ms
  Full arrow:           275.9 ms (+1.4%)
  Mixed arrow/numpy:    272.2 ms (-0.0%)
  Mixed arrow/null:     274.5 ms (+0.8%)

Dataset: 50,000 rows x 20 cols, 50 estimators (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:       327.1 ms
  Full arrow:           321.0 ms (-1.9%)
  Mixed arrow/numpy:    322.8 ms (-1.3%)
  Mixed arrow/null:     325.2 ms (-0.6%)

Dataset: 100,000 rows x 20 cols, 100 estimators (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:       692.9 ms
  Full arrow:           680.7 ms (-1.8%)
  Mixed arrow/numpy:    690.1 ms (-0.4%)
  Mixed arrow/null:     725.2 ms (+4.7%)

Dataset: 500,000 rows x 50 cols, 100 estimators (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:      1554.4 ms
  Full arrow:          1385.9 ms (-10.8%)
  Mixed arrow/numpy:   1435.5 ms (-7.7%)
  Mixed arrow/null:    1431.4 ms (-7.9%)

Dataset: 1,000,000 rows x 50 cols, 100 estimators (50 iterations)
--------------------------------------------------------------------------------
  Numpy baseline:      2242.0 ms
  Full arrow:          2228.1 ms (-0.6%)
  Mixed arrow/numpy:   2322.6 ms (+3.6%)
  Mixed arrow/null:    2226.8 ms (-0.7%)

Generating plot...
```
</details>

## Compatibility

Requires `pyarrow` and `cffi` installed (same as existing Arrow support).

## Open Questions

- Should PyArrow support be mentioned in the docstrings that already mention pandas DataFrame/Series?
- Should PyArrow support be documented in user-facing guides?
- Should the benchmark scripts be committed to the repo?
- Feedback on benchmark methodology?
- Are there missing edge cases / tests that should still be added?
- Should the minimum pandas/pyarrow versions where this works be documented?
