### PR TITLE
[ci] [R-package] fix docs build, test pkgdown build in CI

### DIFF
--- a/.ci/build-docs.R
+++ b/.ci/build-docs.R
@@ -1,0 +1,19 @@
+loadNamespace("pkgdown")
+loadNamespace("roxygen2")
+
+roxygen2::roxygenize(
+    "R-package/"
+    , load = "installed"
+)
+
+pkgdown::build_site(
+    "R-package/"
+    , lazy = FALSE
+    , install = FALSE
+    , devel = FALSE
+    , examples = TRUE
+    , run_dont_run = TRUE
+    , seed = 42L
+    , preview = FALSE
+    , new_process = TRUE
+)

--- a/.ci/pip-envs/requirements-latest.txt
+++ b/.ci/pip-envs/requirements-latest.txt
@@ -13,7 +13,9 @@ matplotlib>=3.11.0.dev0
 numpy>=2.5.0.dev0
 pandas>=3.1.0.dev0
 pyarrow>=24.0.0.dev0
-scikit-learn>=1.9.dev0
+
+# TODO: use 'scikit-learn' nightlies again when https://github.com/scikit-learn/scikit-learn/issues/33993 is resolved
+scikit-learn==1.8.*
 scipy>=1.18.0.dev0
 
 # testing-only dependencies

--- a/.ci/pip-envs/requirements-latest.txt
+++ b/.ci/pip-envs/requirements-latest.txt
@@ -13,9 +13,7 @@ matplotlib>=3.11.0.dev0
 numpy>=2.5.0.dev0
 pandas>=3.1.0.dev0
 pyarrow>=24.0.0.dev0
-
-# TODO: use 'scikit-learn' nightlies again when https://github.com/scikit-learn/scikit-learn/issues/33993 is resolved
-scikit-learn==1.8.*
+scikit-learn>=1.9.dev0
 scipy>=1.18.0.dev0
 
 # testing-only dependencies

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Test documentation
         shell: bash --noprofile --norc {0}
         run: |
-          Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit 1
+          Rscript .ci/build-docs.R || exit 1
           num_doc_files_changed=$(
               git diff --name-only | grep --count -E "\.Rd|NAMESPACE"
           )

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           fetch-depth: 5
           persist-credentials: false
-          submodules: false
+          submodules: true
       - name: Setup and run tests
         shell: bash
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: "ubuntu-24.04"
   tools:
-    python: "mambaforge-23.11"
+    python: "miniforge3-latest"
 conda:
   environment: docs/env.yml
 formats:

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -63,4 +63,4 @@ Imports:
     utils
 SystemRequirements:
     C++17
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/R-package/pkgdown/_pkgdown.yml
+++ b/R-package/pkgdown/_pkgdown.yml
@@ -1,4 +1,5 @@
 template:
+  bootstrap: 5
   params:
     bootswatch: cerulean
 
@@ -104,3 +105,7 @@ reference:
     contents:
       - '`getLGBMThreads`'
       - '`setLGBMThreads`'
+  - title: Deprecated
+    desc: Functionality that will be removed in the future
+    contents:
+      - '`lgb.interprete`'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -274,7 +274,6 @@ def generate_r_docs(app: Sphinx) -> None:
     sh build-cran-package.sh || exit 1
     R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit 1
     Rscript .ci/build-docs.R || exit 1
-    cd {CURR_PATH.parent}
     """
     try:
         print("Building R-package documentation")
@@ -327,7 +326,7 @@ def setup(app: Sphinx) -> None:
     if first_run:
         app.connect("builder-inited", generate_r_docs)
     app.connect(
-        "build-finished", lambda app, _: copytree(CURR_PATH.parent / "lightgbm_r" / "docs", Path(app.outdir) / "R")
+        "build-finished", lambda app, _: copytree(CURR_PATH.parent / "R-package" / "docs", Path(app.outdir) / "R")
     )
     app.connect("builder-inited", replace_reference_to_r_docs)
     app.add_transform(InternalRefTransform)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -277,18 +277,7 @@ def generate_r_docs(app: Sphinx) -> None:
         {CURR_PATH.parent / "R-package" / "pkgdown"} \
         {CURR_PATH.parent / "lightgbm_r" / "pkgdown"}
     cd {CURR_PATH.parent / "lightgbm_r"}
-    Rscript -e "roxygen2::roxygenize(load = 'installed')" || exit 1
-    Rscript -e "pkgdown::build_site( \
-            lazy = FALSE \
-            , install = FALSE \
-            , devel = FALSE \
-            , examples = TRUE \
-            , run_dont_run = TRUE \
-            , seed = 42L \
-            , preview = FALSE \
-            , new_process = TRUE \
-        )
-        " || exit 1
+    Rscript .ci/build-docs.R || exit 1
     cd {CURR_PATH.parent}
     """
     try:
@@ -339,12 +328,11 @@ def setup(app: Sphinx) -> None:
         app.connect("builder-inited", generate_doxygen_xml)
     else:
         app.add_directive("doxygenfile", IgnoredDirective)
-    if RTD:  # build R docs only on Read the Docs site
-        if first_run:
-            app.connect("builder-inited", generate_r_docs)
-        app.connect(
-            "build-finished", lambda app, _: copytree(CURR_PATH.parent / "lightgbm_r" / "docs", Path(app.outdir) / "R")
-        )
+    if first_run:
+        app.connect("builder-inited", generate_r_docs)
+    app.connect(
+        "build-finished", lambda app, _: copytree(CURR_PATH.parent / "lightgbm_r" / "docs", Path(app.outdir) / "R")
+    )
     app.connect("builder-inited", replace_reference_to_r_docs)
     app.add_transform(InternalRefTransform)
     add_js_file = getattr(app, "add_js_file", False) or app.add_javascript

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,10 +273,6 @@ def generate_r_docs(app: Sphinx) -> None:
     export R_LIBS="$CONDA_PREFIX/lib/R/library"
     sh build-cran-package.sh || exit 1
     R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit 1
-    cp -R \
-        {CURR_PATH.parent / "R-package" / "pkgdown"} \
-        {CURR_PATH.parent / "lightgbm_r" / "pkgdown"}
-    cd {CURR_PATH.parent / "lightgbm_r"}
     Rscript .ci/build-docs.R || exit 1
     cd {CURR_PATH.parent}
     """

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -5,17 +5,15 @@ channels:
 dependencies:
   - breathe>=4.36
   - doxygen>=1.13.2
-  - python=3.12
+  - python=3.14
   - r-base>=4.5.1
   - r-data.table=1.17.8
   - r-jsonlite=2.0.0
-  - r-knitr=1.50
+  - r-knitr=1.51
   - r-markdown=2.0
   - r-matrix=1.7_4
-  - r-pkgdown=2.1.3
-  - r-roxygen2=7.3.3
-  # skipping scikit-learn 1.7.1 because of the problems described in
-  # https://github.com/lightgbm-org/LightGBM/issues/6978
-  - scikit-learn>=1.6.1,!=1.7.1
+  - r-pkgdown=2.2.0
+  - r-roxygen2=8.0.0
+  - scikit-learn>=1.8.0
   - sphinx>=8.1.3
   - sphinx_rtd_theme>=3.0.1

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -6,7 +6,7 @@ dependencies:
   - breathe>=4.36
   - doxygen>=1.13.2
   - python=3.14
-  - r-base>=4.5.1
+  - r-base>=4.4
   - r-data.table=1.17.8
   - r-jsonlite=2.0.0
   - r-knitr=1.51

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1209,8 +1209,9 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
     _before_kwargs, _kwargs, _after_kwargs = _base_doc.partition("**kwargs")  # type: ignore
     __init__.__doc__ = f"""
         {_before_kwargs}client : dask.distributed.Client or None, optional (default=None)
-        {" ":4}Dask client. If ``None``, ``distributed.default_client()`` will be used at runtime. The Dask client used by this class will not be saved if the model object is pickled.
-        {_kwargs}{_after_kwargs}
+        Dask client. If ``None``, ``distributed.default_client()`` will be used at runtime. The Dask client used by this class will not be saved if the model object is pickled.
+        {_kwargs}
+        {_after_kwargs}
         """
 
     def __getstate__(self) -> Dict[Any, Any]:
@@ -1417,8 +1418,9 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
     _before_kwargs, _kwargs, _after_kwargs = _base_doc.partition("**kwargs")  # type: ignore
     __init__.__doc__ = f"""
         {_before_kwargs}client : dask.distributed.Client or None, optional (default=None)
-        {" ":4}Dask client. If ``None``, ``distributed.default_client()`` will be used at runtime. The Dask client used by this class will not be saved if the model object is pickled.
-        {_kwargs}{_after_kwargs}
+        Dask client. If ``None``, ``distributed.default_client()`` will be used at runtime. The Dask client used by this class will not be saved if the model object is pickled.
+        {_kwargs}
+        {_after_kwargs}
         """
 
     def __getstate__(self) -> Dict[Any, Any]:
@@ -1590,7 +1592,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
     _before_kwargs, _kwargs, _after_kwargs = _base_doc.partition("**kwargs")  # type: ignore
     __init__.__doc__ = f"""
         {_before_kwargs}client : dask.distributed.Client or None, optional (default=None)
-        {" ":4}Dask client. If ``None``, ``distributed.default_client()`` will be used at runtime. The Dask client used by this class will not be saved if the model object is pickled.
+        Dask client. If ``None``, ``distributed.default_client()`` will be used at runtime. The Dask client used by this class will not be saved if the model object is pickled.
         {_kwargs}
         {_after_kwargs}
         """

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1591,7 +1591,8 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
     __init__.__doc__ = f"""
         {_before_kwargs}client : dask.distributed.Client or None, optional (default=None)
         {" ":4}Dask client. If ``None``, ``distributed.default_client()`` will be used at runtime. The Dask client used by this class will not be saved if the model object is pickled.
-        {_kwargs}{_after_kwargs}
+        {_kwargs}
+        {_after_kwargs}
         """
 
     def __getstate__(self) -> Dict[Any, Any]:

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1206,13 +1206,16 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         )
 
     _base_doc = LGBMClassifier.__init__.__doc__
-    _before_kwargs, _kwargs, _after_kwargs = _base_doc.partition("**kwargs")  # type: ignore
-    __init__.__doc__ = f"""
-        {_before_kwargs}client : dask.distributed.Client or None, optional (default=None)
-        Dask client. If ``None``, ``distributed.default_client()`` will be used at runtime. The Dask client used by this class will not be saved if the model object is pickled.
-        {_kwargs}
-        {_after_kwargs}
-        """
+    _before_kwargs, _, _after_kwargs = _base_doc.partition("**kwargs")  # type: ignore
+    __init__.__doc__ = (
+        _before_kwargs
+        + "client : dask.distributed.Client or None, optional (default=None)\n"
+        + "    Dask client. \n"
+        + "    If ``None``, ``distributed.default_client()`` will be used at runtime.\n"
+        + "    The Dask client used by this class will not be saved if the model object is pickled.\n"
+        + "**kwargs\n"
+        + _after_kwargs
+    )
 
     def __getstate__(self) -> Dict[Any, Any]:
         return self._lgb_dask_getstate()
@@ -1416,12 +1419,15 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
 
     _base_doc = LGBMRegressor.__init__.__doc__
     _before_kwargs, _kwargs, _after_kwargs = _base_doc.partition("**kwargs")  # type: ignore
-    __init__.__doc__ = f"""
-        {_before_kwargs}client : dask.distributed.Client or None, optional (default=None)
-        Dask client. If ``None``, ``distributed.default_client()`` will be used at runtime. The Dask client used by this class will not be saved if the model object is pickled.
-        {_kwargs}
-        {_after_kwargs}
-        """
+    __init__.__doc__ = (
+        _before_kwargs
+        + "client : dask.distributed.Client or None, optional (default=None)\n"
+        + "    Dask client. \n"
+        + "    If ``None``, ``distributed.default_client()`` will be used at runtime.\n"
+        + "    The Dask client used by this class will not be saved if the model object is pickled.\n"
+        + "**kwargs\n"
+        + _after_kwargs
+    )
 
     def __getstate__(self) -> Dict[Any, Any]:
         return self._lgb_dask_getstate()
@@ -1590,12 +1596,15 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
 
     _base_doc = LGBMRanker.__init__.__doc__
     _before_kwargs, _kwargs, _after_kwargs = _base_doc.partition("**kwargs")  # type: ignore
-    __init__.__doc__ = f"""
-        {_before_kwargs}client : dask.distributed.Client or None, optional (default=None)
-        Dask client. If ``None``, ``distributed.default_client()`` will be used at runtime. The Dask client used by this class will not be saved if the model object is pickled.
-        {_kwargs}
-        {_after_kwargs}
-        """
+    __init__.__doc__ = (
+        _before_kwargs
+        + "client : dask.distributed.Client or None, optional (default=None)\n"
+        + "    Dask client. \n"
+        + "    If ``None``, ``distributed.default_client()`` will be used at runtime.\n"
+        + "    The Dask client used by this class will not be saved if the model object is pickled.\n"
+        + "**kwargs\n"
+        + _after_kwargs
+    )
 
     def __getstate__(self) -> Dict[Any, Any]:
         return self._lgb_dask_getstate()


### PR DESCRIPTION
Fixes #7267

Something at the intersection of `{roxygen2}` 8.0.0 (new a few days ago) and changes in #7148 have led to `{pkgdown}` site build failing like this:

```text
Error:
--
  | ! in callr subprocess.
  | Caused by error in `build_reference_index(pkg)`:
  | ! In pkgdown/_pkgdown.yml, 1 topic missing from index: "lgb.interprete".
  | ℹ Either add to the reference index, or use `@keywords internal` to drop from
  | the index.
```

This fixes that and ensures that build is done in PR CI, so we can catch such issues earlier.

Other small related changes:

* introducing `.ci/build-docs.R` to avoid duplicating the `pkgdown::build_site()` call in multiple places
* bumping a few dependencies in the docs env
* using `{roxygen2}` 8.0.0

## Notes for Reviewers

### How I tested this

Enabled this branch on readthedocs and visually inspected the docs.

* RTD build: https://app.readthedocs.org/projects/lightgbm/builds/32648273/
* docs: https://lightgbm.readthedocs.io/en/fix-docs-build/pythonapi/lightgbm.DaskLGBMClassifier.html