### PR TITLE
[docs] add 'darts' and 'nvForest' to list of external repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ GBNet (use `LightGBM` as a [PyTorch Module](https://docs.pytorch.org/docs/stable
 
 cuML Forest Inference Library (GPU-accelerated inference): https://github.com/rapidsai/cuml
 
+nvForest (GPU-accelerated inference): https://github.com/rapidsai/nvforest
+
 daal4py (Intel CPU-accelerated inference): https://github.com/intel/scikit-learn-intelex/tree/master/daal4py
 
 m2cgen (model appliers for various languages): https://github.com/BayesWitnesses/m2cgen
@@ -141,6 +143,8 @@ Optuna (hyperparameter optimization framework): https://github.com/optuna/optuna
 LightGBMLSS (probabilistic modelling with LightGBM): https://github.com/StatMixedML/LightGBMLSS
 
 LightGBM-MoE (Mixture-of-Experts / regime-switching extension): https://github.com/kyo219/LightGBM-MoE
+
+darts (time series forecasting and anomaly detection with LightGBM): https://github.com/unit8co/darts
 
 mlforecast (time series forecasting with LightGBM): https://github.com/Nixtla/mlforecast
 


### PR DESCRIPTION
Adds some examples of actively-maintained open source projects using LightGBM:

* `darts` (https://github.com/unit8co/darts)
* `nvforest` (https://github.com/rapidsai/nvforest)

## Disclaimer

`nvforest` is something published by my employer. But I do genuinely think it belongs in this list... it extends `treelite` (already in this list) and has code that originated in `cuml` (already in this list).