### PR TITLE
[ci] exclude more files from biome config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,7 +146,7 @@ publish/
 *.nupkg
 nuget/
 # The packages folder can be ignored because of Package Restore
-**/packages/*
+**/packages/
 # except build/, which is used as an MSBuild target.
 !**/packages/build/
 # Uncomment if necessary however generally it will be regenerated when needed
@@ -326,6 +326,7 @@ coverage.xml
 *.py.cover
 .hypothesis/
 .pytest_cache/
+.ruff_cache/
 cover/
 **/coverage.html
 **/coverage.html.zip
@@ -424,7 +425,7 @@ R-package/src-x64
 R-package/src-i386
 R-package/**/VERSION.txt
 **/Makevars.win
-lightgbm_r/*
+lightgbm_r/
 lightgbm*.tar.gz
 lightgbm*.tgz
 lightgbm.Rcheck/

--- a/biome.json
+++ b/biome.json
@@ -8,10 +8,12 @@
     "files": {
         "includes": [
             "**",
+            "!**/lib",
             "!build",
             "!external_libs",
             "!lightgbm-python",
-            "!lightgbm_r"
+            "!lightgbm_r",
+            "!R-package/docs"
         ]
     },
     "formatter": {


### PR DESCRIPTION
## Description

* adds a few more exclusions to `biome` configuration
* replaces `{dir}/*` with `{dir}/` in `.gitignore`
  - _the form without `/*` is stronger, because it excludes the entire directory instead of just the files at its first level_

## Details

In the last couple days, I've seen `pre-commit run --all-files` emitting tons of errors from `biome`, like this:

```text
/Users/jlamb/repos/LightGBM/.lgb-dev/lib/python3.12/site-packages/distributed/http/static/js/anime.min.js project  INTERNAL  ━━━━━━━━━━
  ⚠ Biome encountered an unusually large amount of types which exceeded the limit of 200,000.
    Either you are analyzing very large files (did you make sure to exclude your build/ or dist/ folder?), or you've encountered a bug in Biome.
```

Those came from 2 sources:

* I'd built the `{pkgdown}` site locally, which wrote a ton of JavaScript files in `R-package/docs`
* started using virtual environments created with `python -m venv`, and installed some packages which vendor JavaScript files (like `distributed`)

The exclusions added to `biome.json` in this PR tell `biome` to ignore those directories.