### PR TITLE
[python-package] [ci] simplify test-skipping logic

### DIFF
--- a/.ci/test-windows.ps1
+++ b/.ci/test-windows.ps1
@@ -147,7 +147,7 @@ if ($env:TASK -eq "bdist") {
     $env:LIGHTGBM_TEST_DUAL_CPU_GPU = "0"
 }
 
-pytest $tests ; Assert-Output $?
+pytest -ra $tests ; Assert-Output $?
 
 if (($env:TASK -eq "regular") -or (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python"))) {
     Set-Location "$env:BUILD_SOURCESDIRECTORY/examples/python-guide"

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -130,7 +130,7 @@ if [[ $TASK == "sdist" ]]; then
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
         cp "./dist/lightgbm-${LGB_VER}.tar.gz" "${BUILD_ARTIFACTSTAGINGDIRECTORY}" || exit 1
     fi
-    pytest ./tests/python_package_test || exit 1
+    pytest -ra ./tests/python_package_test || exit 1
     exit 0
 elif [[ $TASK == "bdist" ]]; then
     if [[ $OS_NAME == "macos" ]]; then
@@ -177,7 +177,7 @@ elif [[ $TASK == "bdist" ]]; then
         export LIGHTGBM_TEST_DUAL_CPU_GPU=1
     fi
     pip install -v ./dist/*.whl || exit 1
-    pytest ./tests || exit 1
+    pytest -ra ./tests || exit 1
     exit 0
 fi
 
@@ -192,13 +192,13 @@ if [[ $TASK == "gpu" ]]; then
             --config-settings=cmake.define.USE_GPU=ON \
             "./dist/lightgbm-${LGB_VER}.tar.gz" \
         || exit 1
-        pytest ./tests/python_package_test || exit 1
+        pytest -ra ./tests/python_package_test || exit 1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         sh ./build-python.sh bdist_wheel --gpu || exit 1
         sh ./.ci/check-python-dists.sh ./dist || exit 1
         pip install "$(echo "./dist/lightgbm-${LGB_VER}"*.whl)" -v || exit 1
-        pytest ./tests || exit 1
+        pytest -ra ./tests || exit 1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         cmake -B build -S . -DUSE_GPU=ON
@@ -217,13 +217,13 @@ elif [[ $TASK == "cuda" ]]; then
             --config-settings=cmake.define.USE_CUDA=ON \
             "./dist/lightgbm-${LGB_VER}.tar.gz" \
         || exit 1
-        pytest ./tests/python_package_test || exit 1
+        pytest -ra ./tests/python_package_test || exit 1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         sh ./build-python.sh bdist_wheel --cuda || exit 1
         sh ./.ci/check-python-dists.sh ./dist || exit 1
         pip install "$(echo "./dist/lightgbm-${LGB_VER}"*.whl)" -v || exit 1
-        pytest ./tests || exit 1
+        pytest -ra ./tests || exit 1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         cmake -B build -S . -DUSE_CUDA=ON
@@ -237,13 +237,13 @@ elif [[ $TASK == "mpi" ]]; then
             --config-settings=cmake.define.USE_MPI=ON \
             "./dist/lightgbm-${LGB_VER}.tar.gz" \
         || exit 1
-        pytest ./tests/python_package_test || exit 1
+        pytest -ra ./tests/python_package_test || exit 1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         sh ./build-python.sh bdist_wheel --mpi || exit 1
         sh ./.ci/check-python-dists.sh ./dist || exit 1
         pip install "$(echo "./dist/lightgbm-${LGB_VER}"*.whl)" -v || exit 1
-        pytest ./tests || exit 1
+        pytest -ra ./tests || exit 1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         cmake -B build -S . -DUSE_MPI=ON -DUSE_DEBUG=ON
@@ -255,7 +255,7 @@ fi
 cmake --build build --target _lightgbm -j4 || exit 1
 
 sh ./build-python.sh install --precompile || exit 1
-pytest ./tests || exit 1
+pytest -ra ./tests || exit 1
 
 if [[ $TASK == "regular" ]]; then
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -4,7 +4,6 @@ import numbers
 import re
 import warnings
 from copy import deepcopy
-from os import getenv
 from pathlib import Path
 
 import numpy as np
@@ -14,9 +13,8 @@ from sklearn.datasets import dump_svmlight_file, load_svmlight_file, make_blobs
 from sklearn.model_selection import train_test_split
 
 import lightgbm as lgb
-from lightgbm.compat import PANDAS_INSTALLED, pd_DataFrame, pd_Series
 
-from .utils import dummy_obj, load_breast_cancer, mse_obj, np_assert_array_equal
+from .utils import BuildInfo, dummy_obj, load_breast_cancer, mse_obj, np_assert_array_equal
 
 
 def test_basic(tmp_path):
@@ -51,7 +49,7 @@ def test_basic(tmp_path):
     assert bst.current_iteration() == 20
     assert bst.num_trees() == 20
     assert bst.num_model_per_iteration() == 1
-    if getenv("TASK", "") != "cuda":
+    if BuildInfo.has_cuda:
         assert bst.lower_bound() == pytest.approx(-2.9040190126976606)
         assert bst.upper_bound() == pytest.approx(3.3182142872462883)
 
@@ -554,7 +552,7 @@ def test_dataset_construction_overwrites_user_provided_metadata_fields():
     X = np.array([[1.0, 2.0], [3.0, 4.0]])
 
     position = np.array([0.0, 1.0], dtype=np.float32)
-    if getenv("TASK", "") == "cuda":
+    if BuildInfo.has_cuda:
         position = None
 
     dtrain = lgb.Dataset(
@@ -574,7 +572,7 @@ def test_dataset_construction_overwrites_user_provided_metadata_fields():
     assert dtrain.get_init_score() == [0.312, 0.708]
     assert dtrain.label == [1, 2]
     assert dtrain.get_label() == [1, 2]
-    if getenv("TASK", "") != "cuda":
+    if BuildInfo.has_cuda:
         np_assert_array_equal(dtrain.position, np.array([0.0, 1.0], dtype=np.float32), strict=True)
         np_assert_array_equal(dtrain.get_position(), np.array([0.0, 1.0], dtype=np.float32), strict=True)
     assert dtrain.weight == [0.5, 1.5]
@@ -606,7 +604,7 @@ def test_dataset_construction_overwrites_user_provided_metadata_fields():
     np_assert_array_equal(dtrain.get_label(), expected_label, strict=True)
     np_assert_array_equal(dtrain.get_field("label"), expected_label, strict=True)
 
-    if getenv("TASK", "") != "cuda":
+    if not BuildInfo.has_cuda:
         expected_position = np.array([0.0, 1.0], dtype=np.float32)
         np_assert_array_equal(dtrain.position, expected_position, strict=True)
         np_assert_array_equal(dtrain.get_position(), expected_position, strict=True)
@@ -723,7 +721,7 @@ def test_list_to_1d_numpy(collection, dtype, rng):
 
     if collection.startswith("pd"):
         pd = pytest.importorskip("pandas")
-        y = pd_Series(y)
+        y = pd.Series(y)
         if pd.api.types.is_object_dtype(y):
             with pytest.raises(
                 ValueError,
@@ -762,9 +760,8 @@ def test_init_score_for_multiclass_classification(init_score_type, rng):
     if init_score_type == "array":
         init_score = np.array(init_score)
     elif init_score_type == "dataframe":
-        if not PANDAS_INSTALLED:
-            pytest.skip("Pandas is not installed.")
-        init_score = pd_DataFrame(init_score)
+        pd = pytest.importorskip("pandas")
+        init_score = pd.DataFrame(init_score)
     data = rng.uniform(size=(10, 2))
     ds = lgb.Dataset(data, init_score=init_score).construct()
     np.testing.assert_equal(ds.get_field("init_score"), init_score)
@@ -1082,7 +1079,7 @@ def test_equal_datasets_from_one_and_several_matrices_w_different_layouts(rng, t
         pytest.param(
             "position",
             marks=pytest.mark.skipif(
-                getenv("TASK", "") == "cuda",
+                BuildInfo.has_cuda,
                 reason="Positions in learning to rank is not supported in CUDA version yet",
             ),
         ),

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -5,7 +5,6 @@ import inspect
 import re
 import socket
 from itertools import groupby
-from os import getenv
 from sys import platform
 from urllib.parse import urlparse
 
@@ -14,7 +13,11 @@ from sklearn.metrics import accuracy_score, r2_score
 
 import lightgbm as lgb
 
-from .utils import np_assert_array_equal, sklearn_multiclass_custom_objective
+from .utils import (
+    BuildInfo,
+    np_assert_array_equal,
+    sklearn_multiclass_custom_objective,
+)
 
 if platform in {"cygwin", "win32"}:
     pytest.skip("lightgbm.dask is not currently supported on Windows", allow_module_level=True)
@@ -53,9 +56,9 @@ task_to_local_factory = {
 }
 
 pytestmark = [
-    pytest.mark.skipif(getenv("TASK", "") == "mpi", reason="Fails to run with MPI interface"),
-    pytest.mark.skipif(getenv("TASK", "") == "gpu", reason="Fails to run with GPU interface"),
-    pytest.mark.skipif(getenv("TASK", "") == "cuda", reason="Fails to run with CUDA interface"),
+    pytest.mark.skipif(BuildInfo.has_cuda, reason="Fails to run with CUDA interface"),
+    pytest.mark.skipif(BuildInfo.has_gpu, reason="Fails to run with GPU interface"),
+    pytest.mark.skipif(BuildInfo.has_mpi, reason="Fails to run with MPI interface"),
 ]
 
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -7,7 +7,6 @@ import pickle
 import platform
 import random
 import re
-from os import getenv
 from pathlib import Path
 from shutil import copyfile
 
@@ -27,10 +26,10 @@ from sklearn.metrics import (
 from sklearn.model_selection import GroupKFold, TimeSeriesSplit, train_test_split
 
 import lightgbm as lgb
-from lightgbm.compat import PANDAS_INSTALLED, pd_DataFrame, pd_Series
 
 from .utils import (
     SERIALIZERS,
+    BuildInfo,
     assert_all_trees_valid,
     assert_silent,
     dummy_obj,
@@ -298,7 +297,7 @@ def test_missing_value_handle_none():
         pytest.param(
             True,
             marks=pytest.mark.skipif(
-                getenv("TASK", "") == "cuda",
+                BuildInfo.has_cuda,
                 reason="Skip because quantized training with categorical features is not supported for cuda version",
             ),
         ),
@@ -348,7 +347,7 @@ def test_categorical_handle(use_quantized_grad):
         pytest.param(
             True,
             marks=pytest.mark.skipif(
-                getenv("TASK", "") == "cuda",
+                BuildInfo.has_cuda,
                 reason="Skip because quantized training with categorical features is not supported for cuda version",
             ),
         ),
@@ -398,7 +397,7 @@ def test_categorical_handle_na(use_quantized_grad):
         pytest.param(
             True,
             marks=pytest.mark.skipif(
-                getenv("TASK", "") == "cuda",
+                BuildInfo.has_cuda,
                 reason="Skip because quantized training with categorical features is not supported for cuda version",
             ),
         ),
@@ -564,9 +563,7 @@ def test_multi_class_error():
     assert results["training"]["multi_error@2"][-1] == pytest.approx(0)
 
 
-@pytest.mark.skipif(
-    getenv("TASK", "") == "cuda", reason="Skip due to differences in implementation details of CUDA version"
-)
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Skip due to differences in implementation details of CUDA version")
 def test_auc_mu(rng):
     # should give same result as binary auc for 2 classes
     X, y = load_digits(n_class=10, return_X_y=True)
@@ -738,9 +735,7 @@ def simulate_position_bias(file_dataset_in, file_query_in, file_dataset_out, bas
     return positions_all
 
 
-@pytest.mark.skipif(
-    getenv("TASK", "") == "cuda", reason="Positions in learning to rank is not supported in CUDA version yet"
-)
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Positions in learning to rank is not supported in CUDA version yet")
 def test_ranking_with_position_information_with_file(tmp_path):
     rank_example_dir = Path(__file__).absolute().parents[2] / "examples" / "lambdarank"
     params = {
@@ -791,9 +786,7 @@ def test_ranking_with_position_information_with_file(tmp_path):
         lgb.train(params, lgb_train, valid_sets=lgb_valid, num_boost_round=50)
 
 
-@pytest.mark.skipif(
-    getenv("TASK", "") == "cuda", reason="Positions in learning to rank is not supported in CUDA version yet"
-)
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Positions in learning to rank is not supported in CUDA version yet")
 def test_ranking_with_position_information_with_dataset_constructor(tmp_path):
     rank_example_dir = Path(__file__).absolute().parents[2] / "examples" / "lambdarank"
     params = {
@@ -835,14 +828,18 @@ def test_ranking_with_position_information_with_dataset_constructor(tmp_path):
     # the performance of the unbiased LambdaMART should outperform the plain LambdaMART on the dataset with position bias
     assert gbm_baseline.best_score["valid_0"]["ndcg@3"] + 0.03 <= gbm_unbiased.best_score["valid_0"]["ndcg@3"]
 
-    if PANDAS_INSTALLED:
+    try:
+        import pandas as pd  # noqa: PLC0415
+
         # test setting positions through Dataset constructor with pandas Series
-        lgb_train = lgb.Dataset(str(tmp_path / "rank.train"), params=params, position=pd_Series(positions))
+        lgb_train = lgb.Dataset(str(tmp_path / "rank.train"), params=params, position=pd.Series(positions))
         lgb_valid = [lgb_train.create_valid(str(tmp_path / "rank.test"))]
         gbm_unbiased_pandas_series = lgb.train(params, lgb_train, valid_sets=lgb_valid, num_boost_round=50)
         assert (
             gbm_unbiased.best_score["valid_0"]["ndcg@3"] == gbm_unbiased_pandas_series.best_score["valid_0"]["ndcg@3"]
         )
+    except ImportError:
+        pass
 
     # test setting positions through set_position
     lgb_train = lgb.Dataset(str(tmp_path / "rank.train"), params=params)
@@ -1744,9 +1741,9 @@ def test_all_expected_params_are_written_out_to_model_text(tmp_path):
     #
     # passed-in force_col_wise / force_row_wise parameters are ignored on CUDA and GPU builds...
     # https://github.com/lightgbm-org/LightGBM/blob/1d7ee63686272bceffd522284127573b511df6be/src/io/config.cpp#L375-L377
-    if getenv("TASK", "") == "cuda":
+    if BuildInfo.has_cuda:
         device_entries = ["[force_col_wise: 0]", "[force_row_wise: 1]", "[device_type: cuda]", "[gpu_use_dp: 1]"]
-    elif getenv("TASK", "") == "gpu":
+    elif BuildInfo.has_gpu:
         device_entries = ["[force_col_wise: 1]", "[force_row_wise: 0]", "[device_type: gpu]", "[gpu_use_dp: 0]"]
     else:
         device_entries = ["[force_col_wise: 0]", "[force_row_wise: 0]", "[device_type: cpu]", "[gpu_use_dp: 0]"]
@@ -2014,7 +2011,7 @@ def test_contribs_sparse_multiclass():
 
 
 @pytest.mark.skipif(
-    getenv("TASK", "") == "cuda", reason="Skip because int64 sparse matrix indices are not supported for CUDA version"
+    BuildInfo.has_cuda, reason="Skip because int64 sparse matrix indices are not supported for CUDA version"
 )
 def test_predict_contrib_int64():
     X, y = make_multilabel_classification(n_samples=100, sparse=True, n_features=5, n_classes=1, n_labels=2)
@@ -2181,7 +2178,7 @@ def generate_trainset_for_monotone_constraints_tests(x3_to_category=True):
     return lgb.Dataset(x, label=y, categorical_feature=categorical_features, free_raw_data=False)
 
 
-@pytest.mark.skipif(getenv("TASK", "") == "cuda", reason="Monotone constraints are not yet supported by CUDA version")
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Monotone constraints are not yet supported by CUDA version")
 @pytest.mark.parametrize("test_with_categorical_variable", [True, False])
 def test_monotone_constraints(test_with_categorical_variable):
     def is_increasing(y):
@@ -2266,7 +2263,7 @@ def test_monotone_constraints(test_with_categorical_variable):
                 assert are_interactions_enforced(constrained_model, feature_sets)
 
 
-@pytest.mark.skipif(getenv("TASK", "") == "cuda", reason="Monotone constraints are not yet supported by CUDA version")
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Monotone constraints are not yet supported by CUDA version")
 def test_monotone_penalty():
     def are_first_splits_non_monotone(tree, n, monotone_constraints):
         if n <= 0:
@@ -2309,7 +2306,7 @@ def test_monotone_penalty():
 
 
 # test if a penalty as high as the depth indeed prohibits all monotone splits
-@pytest.mark.skipif(getenv("TASK", "") == "cuda", reason="Monotone constraints are not yet supported by CUDA version")
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Monotone constraints are not yet supported by CUDA version")
 def test_monotone_penalty_max():
     max_depth = 5
     monotone_constraints = [1, -1, 0]
@@ -3151,9 +3148,7 @@ def test_model_size():
         pytest.skipTest("not enough RAM")
 
 
-@pytest.mark.skipif(
-    getenv("TASK", "") == "cuda", reason="Skip due to differences in implementation details of CUDA version"
-)
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Skip due to differences in implementation details of CUDA version")
 def test_get_split_value_histogram(rng_fixed_seed):
     X, y = make_synthetic_regression()
     X = np.repeat(X, 3, axis=0)
@@ -3240,9 +3235,7 @@ def test_get_split_value_histogram(rng_fixed_seed):
         gbm.get_split_value_histogram(2)
 
 
-@pytest.mark.skipif(
-    getenv("TASK", "") == "cuda", reason="Skip due to differences in implementation details of CUDA version"
-)
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Skip due to differences in implementation details of CUDA version")
 def test_early_stopping_for_only_first_metric():
     def metrics_combination_train_regression(valid_sets, metric_list, assumed_iteration, first_metric_only, feval=None):
         params = {
@@ -4211,7 +4204,7 @@ def test_dump_model_hook():
     assert "LV" in dumped_model_str
 
 
-@pytest.mark.skipif(getenv("TASK", "") == "cuda", reason="Forced splits are not yet supported by CUDA version")
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Forced splits are not yet supported by CUDA version")
 def test_force_split_with_feature_fraction(tmp_path):
     X, y = make_synthetic_regression()
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
@@ -4748,11 +4741,11 @@ def test_train_only_raises_num_rounds_warning_when_expected(capsys):
     assert_silent(capsys)
 
 
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason="pandas is not installed")
 def test_validate_features():
+    pd = pytest.importorskip("pandas")
     X, y = make_synthetic_regression()
     features = ["x1", "x2", "x3", "x4"]
-    df = pd_DataFrame(X, columns=features)
+    df = pd.DataFrame(X, columns=features)
     ds = lgb.Dataset(df, y)
     bst = lgb.train({"num_leaves": 15, "verbose": -1}, ds, num_boost_round=10)
     assert bst.feature_name() == features

--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -5,16 +5,16 @@ import pytest
 from sklearn.model_selection import train_test_split
 
 import lightgbm as lgb
-from lightgbm.compat import GRAPHVIZ_INSTALLED, MATPLOTLIB_INSTALLED, PANDAS_INSTALLED, pd_DataFrame
-
-if MATPLOTLIB_INSTALLED:
-    import matplotlib
-
-    matplotlib.use("Agg")
-if GRAPHVIZ_INSTALLED:
-    import graphviz
 
 from .utils import load_breast_cancer, make_synthetic_regression
+
+
+@pytest.fixture(scope="function")
+def matplotlib():
+    mpl = pytest.importorskip("matplotlib")
+    # use non-interactive, in-memory renderer
+    mpl.use("Agg")
+    return mpl
 
 
 @pytest.fixture(scope="module")
@@ -44,8 +44,7 @@ def params():
     return {"objective": "binary", "verbose": -1, "num_leaves": 3}
 
 
-@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason="matplotlib is not installed")
-def test_plot_importance(params, breast_cancer_split, train_data):
+def test_plot_importance(params, breast_cancer_split, train_data, matplotlib):
     X_train, _, y_train, _ = breast_cancer_split
 
     gbm0 = lgb.train(params, train_data, num_boost_round=10)
@@ -155,8 +154,7 @@ def test_plot_importance(params, breast_cancer_split, train_data):
     assert first_bar1 != first_bar3
 
 
-@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason="matplotlib is not installed")
-def test_plot_importance_zero_splits():
+def test_plot_importance_zero_splits(matplotlib):
     X, y = load_breast_cancer(return_X_y=True)
     model = lgb.train(
         params={
@@ -175,8 +173,7 @@ def test_plot_importance_zero_splits():
     assert len(ax.patches) == X.shape[1]
 
 
-@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason="matplotlib is not installed")
-def test_plot_split_value_histogram(params, breast_cancer_split, train_data):
+def test_plot_split_value_histogram(params, breast_cancer_split, train_data, matplotlib):
     X_train, _, y_train, _ = breast_cancer_split
 
     gbm0 = lgb.train(params, train_data, num_boost_round=10)
@@ -248,10 +245,8 @@ def test_plot_split_value_histogram(params, breast_cancer_split, train_data):
         lgb.plot_split_value_histogram(gbm0, 0)  # was not used in splitting
 
 
-@pytest.mark.skipif(
-    not MATPLOTLIB_INSTALLED or not GRAPHVIZ_INSTALLED, reason="matplotlib or graphviz is not installed"
-)
-def test_plot_tree(breast_cancer_split):
+def test_plot_tree(breast_cancer_split, matplotlib):
+    pytest.importorskip("graphviz")
     X_train, _, y_train, _ = breast_cancer_split
     gbm = lgb.LGBMClassifier(n_estimators=10, num_leaves=3, verbose=-1)
     gbm.fit(X_train, y_train)
@@ -266,8 +261,8 @@ def test_plot_tree(breast_cancer_split):
     assert int(h) == 8
 
 
-@pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
 def test_create_tree_digraph(tmp_path, breast_cancer_split):
+    graphviz = pytest.importorskip("graphviz")
     X_train, _, y_train, _ = breast_cancer_split
 
     constraints = [-1, 1] * int(X_train.shape[1] / 2)
@@ -303,8 +298,8 @@ def test_create_tree_digraph(tmp_path, breast_cancer_split):
     assert "count" not in graph_body
 
 
-@pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
 def test_tree_with_categories_below_max_category_values(tmp_path):
+    graphviz = pytest.importorskip("graphviz")
     X_train, y_train = _categorical_data(2, 10)
     params = {
         "n_estimators": 10,
@@ -348,8 +343,8 @@ def test_tree_with_categories_below_max_category_values(tmp_path):
     assert "||...||" not in graph_body
 
 
-@pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
 def test_tree_with_categories_above_max_category_values(tmp_path):
+    graphviz = pytest.importorskip("graphviz")
     X_train, y_train = _categorical_data(20, 30)
     params = {
         "n_estimators": 10,
@@ -446,8 +441,8 @@ def test_numeric_split_direction(use_missing, zero_as_missing):
             assert expected_leaf_zero != expected_leaf_nan
 
 
-@pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
 def test_example_case_in_tree_digraph():
+    pytest.importorskip("graphviz")
     rng = np.random.RandomState(0)
     x1 = rng.rand(100)
     cat = rng.randint(1, 3, size=x1.size)
@@ -512,25 +507,23 @@ def test_example_case_in_tree_digraph():
     assert makes_categorical_splits
 
 
-@pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
 @pytest.mark.parametrize("input_type", ["array", "dataframe"])
 def test_empty_example_case_on_tree_digraph_raises_error(input_type):
+    pytest.importorskip("graphviz")
     X, y = make_synthetic_regression()
     if input_type == "dataframe":
-        if not PANDAS_INSTALLED:
-            pytest.skip(reason="pandas is not installed")
-        X = pd_DataFrame(X)
+        pd = pytest.importorskip("pandas")
+        X = pd.DataFrame(X)
+        example_case = pd.DataFrame(X[:0])
+    else:
+        example_case = X[:0]
     ds = lgb.Dataset(X, y)
     bst = lgb.train({"num_leaves": 3}, ds, num_boost_round=1)
-    example_case = X[:0]
-    if input_type == "dataframe":
-        example_case = pd_DataFrame(example_case)
     with pytest.raises(ValueError, match="example_case must have a single row."):
         lgb.create_tree_digraph(bst, tree_index=0, example_case=example_case)
 
 
-@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason="matplotlib is not installed")
-def test_plot_metrics(params, breast_cancer_split, train_data):
+def test_plot_metrics(params, breast_cancer_split, train_data, matplotlib):
     X_train, X_test, y_train, y_test = breast_cancer_split
     test_data = lgb.Dataset(X_test, y_test, reference=train_data)
     params.update({"metric": {"binary_logloss", "binary_error"}})

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -5,7 +5,6 @@ import math
 import re
 import warnings
 from functools import partial
-from os import getenv
 from pathlib import Path
 
 import joblib
@@ -38,6 +37,7 @@ from lightgbm.compat import (
 )
 
 from .utils import (
+    BuildInfo,
     assert_silent,
     load_breast_cancer,
     load_digits,
@@ -188,9 +188,7 @@ def test_regression():
     assert gbm.evals_result_["valid_0"]["l2"][gbm.best_iteration_ - 1] == pytest.approx(ret)
 
 
-@pytest.mark.skipif(
-    getenv("TASK", "") == "cuda", reason="Skip due to differences in implementation details of CUDA version"
-)
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Skip due to differences in implementation details of CUDA version")
 def test_multiclass():
     X, y = load_digits(n_class=10, return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
@@ -203,9 +201,7 @@ def test_multiclass():
     assert gbm.evals_result_["valid_0"]["multi_logloss"][gbm.best_iteration_ - 1] == pytest.approx(ret)
 
 
-@pytest.mark.skipif(
-    getenv("TASK", "") == "cuda", reason="Skip due to differences in implementation details of CUDA version"
-)
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Skip due to differences in implementation details of CUDA version")
 def test_lambdarank():
     rank_example_dir = Path(__file__).absolute().parents[2] / "examples" / "lambdarank"
     X_train, y_train = load_svmlight_file(str(rank_example_dir / "rank.train"))
@@ -1433,9 +1429,7 @@ def test_nan_handle(rng):
     np.testing.assert_allclose(gbm.evals_result_["training"]["l2"], np.nan)
 
 
-@pytest.mark.skipif(
-    getenv("TASK", "") == "cuda", reason="Skip due to differences in implementation details of CUDA version"
-)
+@pytest.mark.skipif(BuildInfo.has_cuda, reason="Skip due to differences in implementation details of CUDA version")
 def test_first_metric_only():
     def fit_and_check(eval_set_names, metric_names, assumed_iteration, first_metric_only):
         params["first_metric_only"] = first_metric_only

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import os
 import pickle
 from functools import lru_cache
 from inspect import getfullargspec
@@ -264,3 +265,15 @@ def assert_all_trees_valid(model_dump):
     for idx, tree in enumerate(model_dump["tree_info"]):
         assert tree["tree_index"] == idx, f"tree {idx} should have tree_index={idx}. Full tree: {tree}"
         assert_subtree_valid(tree["tree_structure"])
+
+
+# This mapping from CI-time environment variables is a placeholder
+# until there is a more reliable way to detect which customizations
+# LightGBM was built with.
+#
+# see https://github.com/lightgbm-org/LightGBM/issues/7273
+#
+class BuildInfo:
+    has_cuda = os.getenv("TASK", "") == "cuda"
+    has_gpu = os.getenv("TASK", "") == "gpu"
+    has_mpi = os.getenv("TASK", "") == "mpi"


### PR DESCRIPTION
Contributes to #7273

We've seen an increase in activity and first-time contributors here recently, which is exciting!

I'd like to make it easier for contributors and reviewers to work on the Python tests, as those are a place full of LightGBM-specific conventions and accumulated tech debt / complexity.

This PR is a first step:

* consolidates various `getenv("TASK")` calls into a small data structure with values like `BuildInfo.has_cuda`
  - _this centralizes the mapping from CI-time environment variables to which tests run_
  - _should make updating the tests easier if we eventually do #7273_
* replaces many uses of `lgb.compat.{module}_INSTALLED` imports with `pytest.importorskip()`
  - _removing this LightGBM-specific convention from view makes the tests easier for new contributors to modify_
  - _makes the code easier for humans and automated tools to read and modify (no need to think about `pd.DataFrame` vs. `pd_DataFrame`)_
* adds `-ra` to all `pytest` invocations, so we'll get a nice summary of which tests were skipped and why in logs

## Notes for Reviewers

I tried to intentionally avoid code paths (like `test_arrow.py`) that'd cause conflicts with #7275. Planning another PR like this after that's merged.