### PR TITLE
[nuget] add README to NuGet package (fixes #6827)

### DIFF
--- a/.ci/README_nuget.md
+++ b/.ci/README_nuget.md
@@ -1,0 +1,54 @@
+# LightGBM
+
+[![NuGet Version](https://img.shields.io/nuget/v/lightgbm?logo=nuget&logoColor=white)](https://www.nuget.org/packages/LightGBM)
+[![License](https://img.shields.io/github/license/lightgbm-org/lightgbm.svg)](https://github.com/lightgbm-org/LightGBM/blob/master/LICENSE)
+
+LightGBM is a gradient boosting framework that uses tree-based learning algorithms. It is designed to be distributed and efficient with the following advantages:
+
+- Faster training speed and higher efficiency.
+- Lower memory usage.
+- Better accuracy.
+- Support for parallel, distributed, and GPU learning.
+- Capable of handling large-scale data.
+
+## About This Package
+
+The `LightGBM` NuGet package provides the native LightGBM shared library (`lib_lightgbm`) for .NET applications on Windows, Linux, and macOS (x64).
+
+It includes:
+- `lib_lightgbm.dll` / `lib_lightgbm.so` / `lib_lightgbm.dylib` — the native LightGBM library
+- `lightgbm.exe` — the LightGBM CLI executable (Windows only)
+- MSBuild integration via `.props` and `.targets` files for automatic native library deployment
+
+## Getting Started
+
+### Installation
+
+```shell
+dotnet add package LightGBM
+```
+
+### Usage
+
+After installing the package, the native LightGBM library is automatically available in your build output. You can use it with any .NET binding (such as [LightGBM.Net](https://github.com/ralfbrown/LightGBM.Net) or via P/Invoke) to call LightGBM's C API from your .NET application.
+
+```csharp
+// Example: Load LightGBM native library via P/Invoke
+[DllImport("lib_lightgbm")]
+public static extern int LGBM_GetLastError();
+
+// Check that the library loads correctly
+var lastError = LGBM_GetLastError();
+Console.WriteLine($"LightGBM loaded successfully, last error code: {lastError}");
+```
+
+### Resources
+
+- [GitHub Repository](https://github.com/lightgbm-org/LightGBM)
+- [Documentation](https://lightgbm.readthedocs.io/)
+- [Python Package Documentation](https://lightgbm.readthedocs.io/en/latest/Python-Intro.html)
+- [R Package Documentation](https://lightgbm.readthedocs.io/en/latest/R/articles/)
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/lightgbm-org/LightGBM/blob/master/LICENSE) file for details.

--- a/.ci/create-nuget.py
+++ b/.ci/create-nuget.py
@@ -18,6 +18,8 @@ if __name__ == "__main__":
     windows_folder_path.mkdir(parents=True, exist_ok=True)
     build_folder_path = nuget_dir / "build"
     build_folder_path.mkdir(parents=True, exist_ok=True)
+    readme_source = nuget_dir.parent / "README_nuget.md"
+    copyfile(readme_source, nuget_dir / "README.md")
     print(f"Looking for libraries in '{source}'")
     copyfile(source / "lib_lightgbm.so", linux_folder_path / "lib_lightgbm.so")
     copyfile(source / "lib_lightgbm.dylib", osx_folder_path / "lib_lightgbm.dylib")
@@ -36,11 +38,13 @@ if __name__ == "__main__":
         <projectUrl>https://github.com/lightgbm-org/LightGBM</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>A fast, distributed, high performance gradient boosting framework</description>
+        <readme>README.md</readme>
         <copyright>Copyright {datetime.datetime.now().year} @ Microsoft</copyright>
         <tags>machine-learning data-mining distributed native boosting gbdt</tags>
         <dependencies> </dependencies>
     </metadata>
         <files>
+        <file src="README.md" target=""/>
         <file src="build\**" target="build"/>
         <file src="runtimes\**" target="runtimes"/>
         </files>


### PR DESCRIPTION
@
## Summary

Add a README file to the LightGBM NuGet package so it renders properly on nuget.org.

## Changes
- Created `.ci/README_nuget.md` — NuGet-specific README with install instructions and usage example
- Modified `.ci/create-nuget.py` — copy README to build directory, add `<readme>` and `<file>` entries in .nuspec

## Issue
Fixes #6827

## Verification
- Ran `create-nuget.py` and verified the generated `.nuspec` contains `<readme>README.md</readme>` and `<file src="README.md" target=""/>`
- Verified README.md is copied into the `nuget/` build directory
@