### PR TITLE
[dask] suppress default n_jobs/num_threads warning

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -571,9 +571,14 @@ def _train(
     # Some passed-in parameters can be removed:
     #   * 'num_machines': set automatically from Dask worker list
     #   * 'num_threads': overridden to match nthreads on each Dask process
+    _num_threads_aliases = _ConfigAliases.get("num_threads")
     for param_alias in _ConfigAliases.get("num_machines", "num_threads"):
         if param_alias in params:
-            _log_warning(f"Parameter {param_alias} will be ignored.")
+            param_val = params[param_alias]
+            is_num_threads_alias = param_alias in _num_threads_aliases
+            # suppress warning for default num_threads values (None, -1)
+            if not is_num_threads_alias or (param_val is not None and param_val != -1):
+                _log_warning(f"Parameter {param_alias} will be ignored.")
             params.pop(param_alias)
 
     # Split arrays/dataframes into parts. Arrange parts into dicts to enforce co-locality


### PR DESCRIPTION
## Summary

Suppress the unavoidable `Parameter n_jobs will be ignored` warning in Dask estimators when `n_jobs` (or `num_threads`) is set to the default value `None` or `-1`.

## Changes

- `python-package/lightgbm/dask.py`: only emit the ignored-parameter warning for `num_threads` aliases when the value is explicitly set (not `None` or `-1`)

## Issue

Fixes #6797

## Verification

- Ran 8 test cases covering: `n_jobs=None`, `n_jobs=-1`, `n_jobs=4`, `num_threads=None`, `num_threads=2`, `num_thread=6` (alias), `num_machines=2`, and combined `n_jobs=None + num_machines=2`. All passed.