### PR TITLE
[c++] clarify error message when feature names conflict after whitespace preprocessing

### DIFF
--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -915,7 +915,7 @@ class Dataset {
         std::replace(feature_name.begin(), feature_name.end(), ' ', '_');
       }
       if (feature_name_set.count(feature_name) > 0) {
-        Log::Fatal("Feature (%s) appears more than one time.", feature_name.c_str());
+        Log::Fatal("After preprocessing (including replacing whitespace with '_'), multiple features named '%s' found in Dataset. Ensure that feature names are unique and do not contain whitespace.", feature_name.c_str());
       }
       feature_name_set.insert(feature_name);
     }

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -619,6 +619,23 @@ def test_dataset_construction_overwrites_user_provided_metadata_fields():
     np_assert_array_equal(dtrain.get_field("weight"), expected_weight, strict=True)
 
 
+def test_get_position():
+    X = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+
+    ds = lgb.Dataset(X)
+    ds.construct()
+    assert ds.get_position() is None
+    assert ds.position is None
+
+    pos = np.array([1.0, 2.0, 3.0])
+    ds.set_position(pos)
+    np_assert_array_equal(ds.get_position(), pos, strict=True)
+
+    ds2 = lgb.Dataset(X)
+    ds2.construct()
+    assert ds2.get_position() is None
+
+
 def test_dataset_construction_with_high_cardinality_categorical_succeeds(rng):
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame({"x1": rng.integers(low=0, high=5_000, size=(10_000,))})


### PR DESCRIPTION
## Summary

Improve the error message when feature names conflict after LightGBM preprocessing that replaces whitespace with underscores.

### Before
> LightGBMError: Feature (a_b) appears more than one time.

### After
> LightGBMError: After preprocessing (including replacing whitespace with '_'), multiple features named 'a_b' found in Dataset. Ensure that feature names are unique and do not contain whitespace.

## Issue
Fixes #7230

## Verification
- Built LightGBM from source
- Ran reproduction script: ["_", "a"] succeeds, [" ", "a"] succeeds, ["_", " "] gives clear error