### PR TITLE
fix: clarify error message when whitespace in feature names causes collision

### DIFF
--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -915,7 +915,7 @@ class Dataset {
         std::replace(feature_name.begin(), feature_name.end(), ' ', '_');
       }
       if (feature_name_set.count(feature_name) > 0) {
-        Log::Fatal("Feature (%s) appears more than one time.", feature_name.c_str());
+        Log::Fatal("Feature (%s) appears more than one time. After preprocessing (replacing whitespace with '_'), multiple features resolved to this name. Ensure feature names are unique and do not contain whitespace.", feature_name.c_str());
       }
       feature_name_set.insert(feature_name);
     }


### PR DESCRIPTION
﻿## Summary

Improves the error message when feature names collide after LightGBM replaces whitespace with underscores.

## Issue

Closes #7230

## Changes

When two features differ only by whitespace vs underscore (e.g. "a b" and "a_b"), LightGBM silently normalizes spaces to underscores during preprocessing. The previous error:
> LightGBMError: Feature (a_b) appears more than one time.

Now reads:
> LightGBMError: Feature (a_b) appears more than one time. After preprocessing (replacing whitespace with '_'), multiple features resolved to this name. Ensure feature names are unique and do not contain whitespace.

This change is in include/LightGBM/dataset.h -- only the error message string was modified.

## Verification

- Change is a string-only modification to a Log::Fatal() call
- Follows the maintainer's suggested message wording from the issue
