### PR TITLE
[ci] add retry flags to wget in setup.sh for flaky network (fixes #7294)

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -74,7 +74,7 @@ else  # Linux
         elif [[ $COMPILER == "clang-17" ]]; then
             sudo apt-get install --no-install-recommends -y \
                 wget
-            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+            wget --retry-connrefused --waitretry=5 --tries=5 -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
             sudo apt-add-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main
             sudo apt-add-repository deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main
             sudo apt-get update


### PR DESCRIPTION
## Summary

Add retry flags to the \wget\ call in \.ci/setup.sh\ that downloads the LLVM GPG key.
This call occasionally fails with exit code 4 (network error) due to transient
issues reaching \pt.llvm.org\, causing flaky CI failures.

## Changes

- \.ci/setup.sh\: added \--retry-connrefused --waitretry=5 --tries=5\ to the \wget\ command on line 77

## Issue

Fixes #7294

## Verification

No CI runner available to reproduce the flaky failure, but the change is
a standard use of wget's built-in retry mechanism. The \--retry-connrefused\
flag ensures retries even on connection refusal, \--waitretry=5\ adds a 5-second
pause between attempts, and \--tries=5\ allows up to 5 total attempts.