### PR TITLE
[c++] Fix crash when monotone_constraints_method is set without monotone_constraints

### DIFF
--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -458,6 +458,10 @@ void Config::CheckParamConflict(const std::unordered_map<std::string, std::strin
     Log::Warning("Cannot use \"intermediate\" or \"advanced\" monotone constraints with feature fraction different from 1, auto set monotone constraints to \"basic\" method.");
     monotone_constraints_method = "basic";
   }
+  if ((monotone_constraints_method == "intermediate" || monotone_constraints_method == "advanced") && monotone_constraints.empty()) {
+    Log::Warning("\"%s\" monotone constraints method has no effect without providing monotone_constraints. Auto-set to \"basic\" method.", monotone_constraints_method.c_str());
+    monotone_constraints_method = "basic";
+  }
   if (max_depth > 0 && monotone_penalty >= max_depth) {
     Log::Warning("Monotone penalty greater than tree depth. Monotone features won't be used.");
   }

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2267,6 +2267,16 @@ def test_monotone_constraints(test_with_categorical_variable):
 
 
 @pytest.mark.skipif(getenv("TASK", "") == "cuda", reason="Monotone constraints are not yet supported by CUDA version")
+def test_monotone_constraints_method_without_constraints():
+    trainset = generate_trainset_for_monotone_constraints_tests()
+    for method in ["intermediate", "advanced"]:
+        params = {
+            "monotone_constraints_method": method,
+        }
+        lgb.train(params, trainset)
+
+
+@pytest.mark.skipif(getenv("TASK", "") == "cuda", reason="Monotone constraints are not yet supported by CUDA version")
 def test_monotone_penalty():
     def are_first_splits_non_monotone(tree, n, monotone_constraints):
         if n <= 0:


### PR DESCRIPTION
﻿## Summary

Fix a segmentation fault that occurs when `monotone_constraints_method` is set to "intermediate" or "advanced" but `monotone_constraints` is not provided.

## Changes

- `src/io/config.cpp`: added validation in `CheckParamConflict()` that detects this configuration, emits a warning, and falls back to "basic"
- `tests/python_package_test/test_engine.py`: added test

## Issue

Fixes #6841

## Verification

- The reproduction case now completes with a warning instead of crashing
