### PR TITLE
[python-package] Add setter for feature_names_in_ property (fixes #6849)

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -711,6 +711,7 @@ class LGBMModel(_LGBMModelBase):
         self._fitted_with_feature_names: bool = False
         self._n_features: int = -1
         self._n_features_in: int = -1
+        self._feature_names_in: Optional[np.ndarray] = None
         self._classes: Optional[np.ndarray] = None
         self._n_classes: int = -1
         self.set_params(**kwargs)
@@ -1400,6 +1401,21 @@ class LGBMModel(_LGBMModelBase):
             functions used internally in ``lightgbm``.
         """
         pass
+
+    @feature_names_in_.setter
+    def feature_names_in_(self, value: np.ndarray) -> None:
+        """Set feature names from dataset used in ``fit``.
+
+        Starting with ``scikit-learn`` 1.6, ``scikit-learn`` expects to be able to directly
+        set this property in functions like ``validate_data()``.
+
+        .. note::
+
+            Do not call ``estimator.feature_names_in_ = some_array`` or anything else that invokes
+            this method. It is only here for compatibility with ``scikit-learn`` validation
+            functions used internally in ``lightgbm``.
+        """
+        self._feature_names_in = value
 
 
 class LGBMRegressor(_LGBMRegressorBase, LGBMModel):


### PR DESCRIPTION
## Summary

Adds a setter for the \eature_names_in_\ property on \LGBMModel\, following the same pattern as the existing \
_features_in_\ setter.

Starting with scikit-learn 1.6, functions like \alidate_data()\ expect to be able to directly set \eature_names_in_\ on sklearn-compatible estimators. Without a setter, passing a Polars DataFrame (or any non-pandas, non-pyarrow input with column names) to \it()\ raises:

\\\
AttributeError: property 'feature_names_in_' of 'LGBMRegressor' object has no setter
\\\

## Changes

- Added backing field \self._feature_names_in\ in \__init__\
- Added \@feature_names_in_.setter\ that stores the value

## Related

Fixes #6849