### PR TITLE
[dask] suppress default n_jobs/num_threads warning

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -74,7 +74,7 @@ else  # Linux
         elif [[ $COMPILER == "clang-17" ]]; then
             sudo apt-get install --no-install-recommends -y \
                 wget
-            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+            wget --retry-connrefused --waitretry=5 --tries=5 -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
             sudo apt-add-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main
             sudo apt-add-repository deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main
             sudo apt-get update

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -571,9 +571,14 @@ def _train(
     # Some passed-in parameters can be removed:
     #   * 'num_machines': set automatically from Dask worker list
     #   * 'num_threads': overridden to match nthreads on each Dask process
-    for param_alias in _ConfigAliases.get("num_machines", "num_threads"):
+    for param_alias in _ConfigAliases.get("num_machines"):
         if param_alias in params:
             _log_warning(f"Parameter {param_alias} will be ignored.")
+            params.pop(param_alias)
+    for param_alias in _ConfigAliases.get("num_threads"):
+        if param_alias in params:
+            if params[param_alias] not in (None, -1):
+                _log_warning(f"Parameter {param_alias} will be ignored.")
             params.pop(param_alias)
 
     # Split arrays/dataframes into parts. Arrange parts into dicts to enforce co-locality


### PR DESCRIPTION
## Summary

Suppress the unavoidable 'Parameter n_jobs will be ignored.' warning in Dask estimators when \
um_threads\ or its aliases (including \
_jobs\) are set to their default values (\None\ or \-1\).

The previous code grouped \
um_machines\ and \
um_threads\ aliases together, so \
_jobs\ (present by default in all Dask estimator constructors) always triggered a warning.

### Changes
- Split the alias loop into two separate loops for \
um_machines\ and \
um_threads\
- For \
um_threads\ aliases, only emit the warning when the value is not \None\ or \-1\ (the defaults)
- \
um_machines\ behavior is unchanged

## Issue

Fixes #6797

## Verification

- [ ] Existing Dask tests pass
- [ ] Warning is not emitted with default parameters
- [ ] Warning is still emitted for explicit non-default values