### PR TITLE
[python-package] add test for Booster.shuffle_models()

### DIFF
--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -1220,3 +1220,21 @@ def test_refit_correctly_handles_categorical_features_in_params(rng) -> None:
         match=re.escape("Using refit() to change which columns are treated as categorical is not supported"),
     ):
         loaded_bst_new = loaded_bst.refit(X_new, y_new, categorical_feature=[0, 1])
+
+
+def test_shuffle_models():
+    X, y = load_breast_cancer(return_X_y=True)
+    X_train, X_test, y_train, _ = train_test_split(
+        X, y, test_size=0.1, random_state=2
+    )
+    ds = lgb.Dataset(X_train, label=y_train)
+    bst = lgb.train(
+        {"objective": "binary", "verbose": -1, "num_threads": 1},
+        ds,
+        num_boost_round=20,
+    )
+    pred_before = bst.predict(X_test)
+    result = bst.shuffle_models()
+    assert result is bst
+    pred_after = bst.predict(X_test)
+    np.testing.assert_allclose(pred_before, pred_after)


### PR DESCRIPTION
## Summary

Adds a unit test for \Booster.shuffle_models()\, covering the 2-line method at \asic.py:4520-4547\. Verifies that:
- the method returns \self\
- predictions remain identical after shuffling (additive ensemble property)

## Issue

Fixes #7031 (item: \Booster.shuffle_models()\)

## Verification

\\\
python -m pytest tests/python_package_test/test_basic.py::test_shuffle_models -xvs
\\\

1 passed in 0.86s