### PR TITLE
[R-package][win] explicitly link R_LIB to _lightgbm target for MSVC (fixes #7098)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -668,6 +668,7 @@ if(__BUILD_FOR_R)
   endif()
   target_link_libraries(lightgbm_objs PUBLIC ${R_LIB})
   target_link_libraries(lightgbm_capi_objs PUBLIC ${R_LIB})
+  target_link_libraries(_lightgbm PUBLIC ${R_LIB})
 endif()
 
 #-- Google C++ tests


### PR DESCRIPTION
## Summary

Fix MSVC link failure when building R-package on Windows. \lightgbm_objs\ and
\lightgbm_capi_objs\ are OBJECT libraries; their \	arget_link_libraries()\
dependencies are not propagated to consuming targets. Therefore \R_LIB\ must
be explicitly linked to \_lightgbm\ as well.

## Changes

- \CMakeLists.txt\: added \	arget_link_libraries(_lightgbm PUBLIC \)\
  inside the \if(__BUILD_FOR_R)\ block

## Issue

Fixes #7098

## Verification

Cannot test locally (no R + MSVC environment), but the change is a standard
CMake fix: OBJECT library link interfaces are not propagated, so the final
SHARED library needs an explicit link to the R import library.