### PR TITLE
[python-package][tests] add test for create_tree_digraph() with a 1-row DataFrame (ref #7031)

### DIFF
--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -304,6 +304,20 @@ def test_create_tree_digraph(tmp_path, breast_cancer_split):
 
 
 @pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
+def test_create_tree_digraph_with_dataframe_example_case(breast_cancer_split):
+    pd = pytest.importorskip("pandas")
+    X_train, _, y_train, _ = breast_cancer_split
+
+    X_train_df = pd.DataFrame(X_train)
+    gbm = lgb.LGBMClassifier(n_estimators=10, num_leaves=3, verbose=-1)
+    gbm.fit(X_train_df, y_train)
+
+    example_case = X_train_df.iloc[[0]]
+    graph = lgb.create_tree_digraph(gbm, example_case=example_case, tree_index=0)
+    assert isinstance(graph, graphviz.Digraph)
+
+
+@pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
 def test_tree_with_categories_below_max_category_values(tmp_path):
     X_train, y_train = _categorical_data(2, 10)
     params = {


### PR DESCRIPTION
## Summary

Add a unit test for \create_tree_digraph()\ with a 1-row pandas DataFrame as \example_case\.

## Changes

- Added \	est_create_tree_digraph_with_dataframe_example_case()\ to \	ests/python_package_test/test_plotting.py\
  - Trains a model with a pandas DataFrame
  - Passes a 1-row DataFrame as \example_case\ to \create_tree_digraph()\
  - Asserts the result is a \graphviz.Digraph\ instance

## Issue

Ref #7031

## Verification

\\\
pytest tests/python_package_test/test_plotting.py::test_create_tree_digraph_with_dataframe_example_case -xvs
\\\

1 test passed.