### PR TITLE
[c++] warn and fallback when monotone_constraints_method is set without monotone_constraints (fixes #6841)

### DIFF
--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -458,6 +458,10 @@ void Config::CheckParamConflict(const std::unordered_map<std::string, std::strin
     Log::Warning("Cannot use \"intermediate\" or \"advanced\" monotone constraints with feature fraction different from 1, auto set monotone constraints to \"basic\" method.");
     monotone_constraints_method = "basic";
   }
+  if (monotone_constraints.empty() && (monotone_constraints_method == std::string("intermediate") || monotone_constraints_method == std::string("advanced"))) {
+    Log::Warning("monotone_constraints_method is set to \"%s\" but monotone_constraints is not set; falling back to \"basic\" method.", monotone_constraints_method.c_str());
+    monotone_constraints_method = "basic";
+  }
   if (max_depth > 0 && monotone_penalty >= max_depth) {
     Log::Warning("Monotone penalty greater than tree depth. Monotone features won't be used.");
   }

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2342,6 +2342,20 @@ def test_monotone_penalty_max():
         np_assert_array_equal(constrained_model.predict(x), unconstrained_model_predictions, strict=True)
 
 
+def test_monotone_constraints_method_without_monotone_constraints(capsys):
+    X, y = make_synthetic_regression()
+    ds = lgb.Dataset(X, y)
+    params = {
+        "monotone_constraints_method": "advanced",
+        "num_leaves": 5,
+        "verbosity": 0,
+    }
+    lgb.train(params, ds, num_boost_round=1)
+    stdout = capsys.readouterr().out
+    expected_msg = "monotone_constraints_method is set to \"advanced\" but monotone_constraints is not set"
+    assert expected_msg in stdout
+
+
 def test_max_bin_by_feature():
     col1 = np.arange(0, 100)[:, np.newaxis]
     col2 = np.zeros((100, 1))


### PR DESCRIPTION
﻿## Summary

When monotone_constraints_method is set to "intermediate" or "advanced" without providing monotone_constraints, LightGBM crashes with a segfault (SIGSEGV). This happens because the advanced/intermediate constraint classes access elements of the empty monotone_constraints vector.

This fix adds a validation check in Config::CheckParamConflict() that emits a warning and falls back to the "basic" method when monotone_constraints is empty.

## Issue

Fixes #6841

## Verification

- New Python test 	est_monotone_constraints_method_without_monotone_constraints verifies that training completes successfully and the expected warning is emitted
- All existing monotone constraint tests continue to pass
