### PR TITLE
[python-package] fix performance regression in predict() by caching feature_name_ (#7229)

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -709,6 +709,7 @@ class LGBMModel(_LGBMModelBase):
         self._class_weight: Optional[Union[Dict, str]] = None
         self._class_map: Optional[Dict[int, int]] = None
         self._fitted_with_feature_names: bool = False
+        self._fitted_feature_names: Optional[List[str]] = None
         self._n_features: int = -1
         self._n_features_in: int = -1
         self._classes: Optional[np.ndarray] = None
@@ -1145,6 +1146,7 @@ class LGBMModel(_LGBMModelBase):
         # This attribute informs self.features_in_, but isn't set until here
         # because Dataset.construct(), called by train(), is responsible for updating it.
         self._fitted_with_feature_names = train_set._has_non_default_feature_names
+        self._fitted_feature_names = self._Booster.feature_name()
 
         self._evals_result = evals_result
         self._best_iteration = self._Booster.best_iteration
@@ -1358,7 +1360,8 @@ class LGBMModel(_LGBMModelBase):
         """
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError("No feature_name found. Need to call fit beforehand.")
-        return self._Booster.feature_name()  # type: ignore[union-attr]
+        assert self._fitted_feature_names is not None
+        return self._fitted_feature_names
 
     @property
     def feature_names_in_(self) -> np.ndarray:

--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -304,6 +304,20 @@ def test_create_tree_digraph(tmp_path, breast_cancer_split):
 
 
 @pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
+def test_create_tree_digraph_with_dataframe_example_case(breast_cancer_split):
+    pd = pytest.importorskip("pandas")
+    X_train, _, y_train, _ = breast_cancer_split
+
+    X_train_df = pd.DataFrame(X_train)
+    gbm = lgb.LGBMClassifier(n_estimators=10, num_leaves=3, verbose=-1)
+    gbm.fit(X_train_df, y_train)
+
+    example_case = X_train_df.iloc[[0]]
+    graph = lgb.create_tree_digraph(gbm, example_case=example_case, tree_index=0)
+    assert isinstance(graph, graphviz.Digraph)
+
+
+@pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
 def test_tree_with_categories_below_max_category_values(tmp_path):
     X_train, y_train = _categorical_data(2, 10)
     params = {


### PR DESCRIPTION
## Summary

Fix a performance regression where \predict()\ and \predict_proba()\ became extremely slow for models with many features (issue #7229).

**Root cause**: The \eature_name_\ property called the C API (\LGBM_BoosterGetFeatureNames\, allocating a 255-byte buffer per feature) on every access. After \alidate_data()\ was added to \predict()\ in #6783 (LightGBM 4.6.0), this property was accessed on every prediction call, causing O(n_features) C API overhead per prediction.

**Fix**: Cache feature names after fitting. The C API is called once during \it()\ and the result is stored in \_fitted_feature_names\. Subsequent accesses return the cached list.

## Changes

3 lines added in \python-package/lightgbm/sklearn.py\:

1. Initialize \_fitted_feature_names\ in \__init__\
2. Cache feature names from \_Booster.feature_name()\ after training in \it()\
3. Return cached value from \eature_name_\ property

## Issue

Fixes #7229

## Verification

- Code review: follows the same pattern as other fitted attributes (\_n_features\, \_best_iteration\, etc.)
- Before-fit error behavior preserved (\LGBMNotFittedError\ still raised)
- Feature name consistency maintained between \eature_name_\ and \eature_names_in_\
- All existing tests should pass (no behavioral change, only caching)