### PR TITLE
[python-package] Preserve --no-isolation when --precompile clears BUILD_ARGS (fixes #6951)

### DIFF
--- a/build-python.sh
+++ b/build-python.sh
@@ -299,7 +299,16 @@ if test "${INSTALL}" = true; then
     if test "${PRECOMPILE}" = true; then
         BUILD_SDIST=false
         BUILD_WHEEL=true
+        # Preserve --no-isolation, but clear cmake-related args
+        _keep_no_isolation=false
+        case " ${BUILD_ARGS} " in
+            *" --no-isolation "*) _keep_no_isolation=true ;;
+        esac
         BUILD_ARGS=""
+        if test "${_keep_no_isolation}" = true; then
+            BUILD_ARGS="--no-isolation"
+        fi
+        unset _keep_no_isolation
         rm -rf \
             ./cmake \
             ./CMakeLists.txt \


### PR DESCRIPTION
﻿## Summary

When --precompile --no-isolation install is passed to uild-python.sh, the --precompile block resets BUILD_ARGS="", discarding the --no-isolation flag that was added earlier. This causes python -m build --wheel to run with build isolation enabled, creating a temporary virtual environment and re-downloading dependencies.

## Changes

In the --precompile block of uild-python.sh:
- Before clearing BUILD_ARGS, check if --no-isolation was set
- After clearing, restore --no-isolation if it was present

## Related

Fixes #6951
