### PR TITLE
[python-package] cache feature_name_ to avoid C API call on every predict() (fixes #7229)

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -711,6 +711,7 @@ class LGBMModel(_LGBMModelBase):
         self._fitted_with_feature_names: bool = False
         self._n_features: int = -1
         self._n_features_in: int = -1
+        self._cached_feature_name: Optional[List[str]] = None
         self._classes: Optional[np.ndarray] = None
         self._n_classes: int = -1
         self.set_params(**kwargs)
@@ -1134,6 +1135,7 @@ class LGBMModel(_LGBMModelBase):
             init_model=init_model,
             callbacks=callbacks,
         )
+        self._cached_feature_name = None
 
         # This populates the property self.n_features_, the number of features in the fitted model,
         # and so should only be set after fitting.
@@ -1358,7 +1360,9 @@ class LGBMModel(_LGBMModelBase):
         """
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError("No feature_name found. Need to call fit beforehand.")
-        return self._Booster.feature_name()  # type: ignore[union-attr]
+        if self._cached_feature_name is None:
+            self._cached_feature_name = self._Booster.feature_name()  # type: ignore[union-attr]
+        return self._cached_feature_name
 
     @property
     def feature_names_in_(self) -> np.ndarray:


### PR DESCRIPTION
## Summary

Cache \eature_name_\ after first access to avoid repeated C API calls on every \predict()\ / \predict_proba()\.

Since scikit-learn 1.6, \LGBMModel.predict()\ calls \alidate_data()\ which accesses \self.feature_names_in_\. This property (line 1381) calls \self.feature_name_\ which was previously calling \self._Booster.feature_name()\ — a C API call — every time. For models with thousands of features, this creates a 255-byte \ctypes.create_string_buffer\ allocation per feature on every prediction call.

## Changes

- \python-package/lightgbm/sklearn.py\: cache the result of \Booster.feature_name()\ in \_cached_feature_name\ after the first access, reset it after \it()\ completes

## Issue

Fixes #7229

## Verification

The change is minimal and correctness-preserving: after \it()\, \_cached_feature_name\ is \None\, so the first access to \eature_name_\ calls the C API once and caches the result. Subsequent accesses return the cached list without any C API call. The cache is reset at the start of each \it()\ to handle re-fitting.