### PR TITLE
[python-package] fix get_split_value_histogram() bin edges to use actual threshold values

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -5166,9 +5166,9 @@ class Booster:
 
         bins : int, str or None, optional (default=None)
             The maximum number of bins.
-            If None, or int and > number of unique split values and ``xgboost_style=True``,
-            the number of bins equals number of unique split values.
-            If str, it should be one from the list of the supported values by ``numpy.histogram()`` function.
+            If None, the bin edges are set to the unique split values of the feature.
+            If int and ``xgboost_style=True``, the number of bins is capped at the number of unique split values.
+            If str, it should be one of the values supported by ``numpy.histogram()``.
         xgboost_style : bool, optional (default=False)
             Whether the returned result should be in the same form as it is in XGBoost.
             If False, the returned value is tuple of 2 numpy arrays as it is in ``numpy.histogram()`` function.
@@ -5205,9 +5205,15 @@ class Booster:
         for tree_info in tree_infos:
             add(tree_info["tree_structure"])
 
-        if bins is None or isinstance(bins, int) and xgboost_style:
+        if bins is None:
+            unique_vals = np.unique(values)
+            if len(unique_vals) > 1:
+                bins = unique_vals
+            else:
+                bins = 1
+        elif isinstance(bins, int) and xgboost_style:
             n_unique = len(np.unique(values))
-            bins = max(min(n_unique, bins) if bins is not None else n_unique, 1)
+            bins = max(min(n_unique, bins), 1)
         hist, bin_edges = np.histogram(values, bins=bins)
         if xgboost_style:
             ret = np.column_stack((bin_edges[1:], hist))

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -4867,3 +4867,26 @@ def test_equal_predict_from_row_major_and_col_major_data():
     preds_col = bst.predict(X_col)
 
     np.testing.assert_allclose(preds_row, preds_col)
+
+
+def test_get_split_value_histogram():
+    X, y = make_synthetic_regression()
+    params = {"num_leaves": 8, "verbose": -1, "min_data_in_leaf": 5}
+    bst = lgb.train(params, lgb.Dataset(X, y), num_boost_round=10)
+
+    hist, bin_edges = bst.get_split_value_histogram(0)
+    assert len(bin_edges) > 1
+    assert len(hist) == len(bin_edges) - 1
+
+    df = bst.trees_to_dataframe()
+    df_split = df[df["split_gain"].notna()]
+    feat0 = df_split[df_split["split_feature"] == "Column_0"]["threshold"]
+    expected = np.sort(feat0.unique())
+    np.testing.assert_array_equal(bin_edges, expected)
+
+    result = bst.get_split_value_histogram(0, xgboost_style=True)
+    assert len(result) > 0
+    np.testing.assert_allclose(result["SplitValue"].values, expected[1:])
+
+    assert bst.get_split_value_histogram(0, bins=3, xgboost_style=True) is not None
+    assert bst.get_split_value_histogram(0, bins="auto") is not None


### PR DESCRIPTION
## Summary
\get_split_value_histogram()\ was passing an integer count to \
p.histogram()\ when \ins=None\, creating evenly-spaced bins that don't match actual split thresholds. Now uses the unique threshold values as bin edges by default.

## Issue
Fixes #7155

## Verification
- \in_edges\ from \get_split_value_histogram()\ now exactly matches \sorted(set(trees_to_dataframe() threshold values))\
- Added \	est_get_split_value_histogram()\ unit test
- Explicit \ins=int\ and \ins=str\ overrides still work as before