### PR TITLE
fix: cache feature_name_ to avoid C API call on every predict() (fixes #7229)

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -709,6 +709,7 @@ class LGBMModel(_LGBMModelBase):
         self._class_weight: Optional[Union[Dict, str]] = None
         self._class_map: Optional[Dict[int, int]] = None
         self._fitted_with_feature_names: bool = False
+        self._cached_feature_name: Optional[List[str]] = None
         self._n_features: int = -1
         self._n_features_in: int = -1
         self._classes: Optional[np.ndarray] = None
@@ -1134,6 +1135,7 @@ class LGBMModel(_LGBMModelBase):
             init_model=init_model,
             callbacks=callbacks,
         )
+        self._cached_feature_name = None
 
         # This populates the property self.n_features_, the number of features in the fitted model,
         # and so should only be set after fitting.
@@ -1358,7 +1360,9 @@ class LGBMModel(_LGBMModelBase):
         """
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError("No feature_name found. Need to call fit beforehand.")
-        return self._Booster.feature_name()  # type: ignore[union-attr]
+        if self._cached_feature_name is None:
+            self._cached_feature_name = self._Booster.feature_name()  # type: ignore[union-attr]
+        return self._cached_feature_name
 
     @property
     def feature_names_in_(self) -> np.ndarray:


### PR DESCRIPTION
## Summary

Caches `feature_name_` on first access to avoid calling the C API (`LGBM_BoosterGetFeatureNames`) on every `predict()` / `predict_proba()` call.

## Issue

Closes #7229

## Root Cause

In 4.6.0, `predict()` switched to `validate_data()` (sklearn 1.6+), which accesses `feature_names_in_` on every call. `feature_names_in_` is a property that calls `feature_name_`, which is also a property calling `_Booster.feature_name()` via the C API. For models with many features, this allocates a ctypes buffer per feature on every prediction.

## Change

- Cache `feature_name_` result in `_cached_feature_name` after the first C API call
- Clear cache after `fit()` / refit to ensure fresh data
- `feature_names_in_` automatically benefits since it delegates to `feature_name_`

## Verification

Manual test confirms cache is populated on first access, reused on subsequent calls, and cleared after refit.
