### PR TITLE
[python-package] prevent segfault in reset_parameter() on unknown params (#6479)

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -4095,7 +4095,19 @@ class Booster:
         self : Booster
             Booster with new parameters.
         """
-        params_str = _param_dict_to_str(params)
+        if not params:
+            return self
+        if _ConfigAliases.aliases is None:
+            _ConfigAliases.aliases = _ConfigAliases._get_all_param_aliases()
+        all_known_keys = set()
+        for main_name, aliases in _ConfigAliases.aliases.items():
+            all_known_keys.add(main_name)
+            all_known_keys.update(aliases)
+        unknown_params = {k: v for k, v in params.items() if k not in all_known_keys}
+        known_params = {k: v for k, v in params.items() if k in all_known_keys}
+        for key in unknown_params:
+            _log_warning(f"Unknown parameter: {key}")
+        params_str = _param_dict_to_str(known_params)
         if params_str:
             _safe_call(
                 _LIB.LGBM_BoosterResetParameter(
@@ -4103,7 +4115,7 @@ class Booster:
                     _c_str(params_str),
                 )
             )
-        self.params.update(params)
+        self.params.update(known_params)
         return self
 
     def update(


### PR DESCRIPTION
## Summary

Fix a segfault in \Booster.reset_parameter()\ when unknown parameter keys are passed. The C API (\LGBM_BoosterResetParameter\) crashes with an access violation on unrecognized parameters instead of returning a proper error.

**Fix**: Before passing parameters to the C API, validate each key against all known LightGBM config parameter aliases. Unknown parameters are filtered out and a warning is emitted. Only known parameters are forwarded to the C API, preventing the segfault entirely from the Python side.

## Changes

In \python-package/lightgbm/basic.py\, \Booster.reset_parameter()\:
1. Build the set of all known parameter keys from \_ConfigAliases\ (cached after first call)
2. Split the input params into known and unknown groups
3. Warn about unknown parameters
4. Only pass known parameters to \LGBM_BoosterResetParameter\
5. Only update \self.params\ with known parameters

## Issue

Fixes #6479

## Verification

- Code review confirms unknown params are filtered before C API call
- Known params work identically to before
- \_ConfigAliases.aliases\ is properly initialized with caching