### PR TITLE
[c++] clarify error message when feature names differ only by whitespace (fixes #7230)

### DIFF
--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -915,7 +915,7 @@ class Dataset {
         std::replace(feature_name.begin(), feature_name.end(), ' ', '_');
       }
       if (feature_name_set.count(feature_name) > 0) {
-        Log::Fatal("Feature (%s) appears more than one time.", feature_name.c_str());
+        Log::Fatal("Feature (%s) appears more than one time. LightGBM replaces whitespace with '_' in feature names, which can cause conflicts. Ensure all feature names are unique and do not differ only by whitespace.", feature_name.c_str());
       }
       feature_name_set.insert(feature_name);
     }

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1449,6 +1449,16 @@ def test_feature_name():
     assert feature_names == gbm.feature_name()
 
 
+def test_feature_name_whitespace_conflict_error_message():
+    import pandas as pd
+    X = pd.DataFrame([[1, 0.10], [2, 0.11]], columns=['_', ' '])
+    y = [0, 1]
+    train_data = lgb.Dataset(X, label=y)
+    params = {"objective": "binary", "metric": "binary_logloss", "verbose": -1}
+    with pytest.raises(lgb.basic.LightGBMError, match="whitespace"):
+        lgb.train(params, train_data, num_boost_round=1)
+
+
 def test_feature_name_with_non_ascii(rng, tmp_path):
     X_train = rng.normal(size=(100, 4))
     y_train = rng.normal(size=(100,))


### PR DESCRIPTION
﻿## Summary

When feature names contain whitespace, LightGBM silently replaces spaces with underscores (_). This can lead to conflicts where two features with names differing only by whitespace (e.g., "_" and " ") are mapped to the same name, producing a cryptic error:

> LightGBMError: Feature (_) appears more than one time.

This change clarifies the error message by explaining the whitespace-to-underscore replacement rule, helping users understand why the conflict occurred.

### Before

> Feature (_) appears more than one time.

### After

> Feature (_) appears more than one time. LightGBM replaces whitespace with '_' in feature names, which can cause conflicts. Ensure all feature names are unique and do not differ only by whitespace.

## Issue

Fixes #7230

## Verification

- Manually tested with the reproducible example from the issue
- The improved error message is confirmed in the Python exception
