### PR TITLE
[R-package] clean up more autoconf / automake files

### DIFF
--- a/R-package/cleanup
+++ b/R-package/cleanup
@@ -1,2 +1,6 @@
 #!/bin/sh
+rm -f aclocal.m4
+rm -rf ./autom4te.cache
+rm -f config.log
+rm -f config.status
 rm -f src/Makevars


### PR DESCRIPTION
Fixes #7330 

Some (but not all) R CI jobs on R-devel are failing like this:

```text
* checking top-level files ... NOTE
Non-standard files/directories found at top level:
  ‘config.log’ ‘config.status’
```

Those are files that are sometimes generated by `autoconf`. You can see them in the auto-generated `configure`:

https://github.com/lightgbm-org/LightGBM/blob/1c0970bbb764a140cca525f5c26e85bc01624779/R-package/configure#L1377

https://github.com/lightgbm-org/LightGBM/blob/1c0970bbb764a140cca525f5c26e85bc01624779/R-package/configure#L1690

This fixes that by removing those after the build in `cleanup`.

I also added a few other common `autoconf` / `autoreconf` / `automake` files to that script, found by searching the CRAN mirror for other packages' `cleanup` scripts: https://github.com/search?q=org%3Acran+path%3Acleanup+language%3AShell&type=code&l=Shell