### PR TITLE
[python-package] [dask] remove an unnecessary check on Dask installation

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1096,8 +1096,6 @@ class _DaskLGBMModel:
         eval_at: Optional[Union[List[int], Tuple[int, ...]]] = None,
         **kwargs: Any,
     ) -> "_DaskLGBMModel":
-        if not DASK_INSTALLED:
-            raise LightGBMError("dask is required for lightgbm.dask")
         if not all((DASK_INSTALLED, PANDAS_INSTALLED, SKLEARN_INSTALLED)):
             raise LightGBMError("dask, pandas and scikit-learn are required for lightgbm.dask")
 


### PR DESCRIPTION
During `fit()`, Dask estimators call 2 checks on whether `dask` is installed. This removes one of them, to simplify the code a bit.