### PR TITLE
fix: suppress Dask warning for default n_jobs

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -573,7 +573,8 @@ def _train(
     #   * 'num_threads': overridden to match nthreads on each Dask process
     for param_alias in _ConfigAliases.get("num_machines", "num_threads"):
         if param_alias in params:
-            _log_warning(f"Parameter {param_alias} will be ignored.")
+            if not (param_alias == "n_jobs" and params[param_alias] is None):
+                _log_warning(f"Parameter {param_alias} will be ignored.")
             params.pop(param_alias)
 
     # Split arrays/dataframes into parts. Arrange parts into dicts to enforce co-locality

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -4,6 +4,7 @@
 import inspect
 import re
 import socket
+import warnings
 from itertools import groupby
 from sys import platform
 from urllib.parse import urlparse
@@ -1209,6 +1210,19 @@ def test_warns_and_continues_on_unrecognized_tree_learner(cluster):
             dask_regressor = dask_regressor.fit(X, y)
 
         assert dask_regressor.fitted_
+
+
+def test_dask_estimator_does_not_warn_for_default_n_jobs(cluster):
+    with Client(cluster) as client:
+        X = da.random.random((1e3, 10))
+        y = da.random.random((1e3, 1))
+        dask_regressor = lgb.DaskLGBMRegressor(client=client, time_out=5, n_estimators=1, num_leaves=2)
+
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            dask_regressor.fit(X, y)
+
+        assert dask_regressor.fitted_
+        assert not [w for w in caught_warnings if "Parameter n_jobs will be ignored." in str(w.message)]
 
 
 @pytest.mark.parametrize("tree_learner", ["data_parallel", "voting_parallel"])


### PR DESCRIPTION
Closes #6797.

## Summary

Suppress the Dask training warning for the default `n_jobs=None` value on Dask estimators.

Dask training overrides thread counts per worker, so user-provided thread parameters should still warn before being ignored. However, `n_jobs=None` is the default constructor value, so emitting `Parameter n_jobs will be ignored.` during a normal Dask estimator fit is noisy.

This keeps the warning for explicit non-default thread parameters while silently removing the default `n_jobs=None`.

## Tests

- `python3 -m py_compile python-package/lightgbm/dask.py tests/python_package_test/test_dask.py`

Could not run the targeted pytest locally because this environment does not have `pytest` installed, and importing the local package also requires a built `lib_lightgbm.dylib`.
