### PR TITLE
[c_api] add option to disable fast predict locks

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -1054,6 +1054,14 @@ Predict Parameters
 
    -  **Note**: be very careful setting this parameter to ``true``
 
+-  ``predict_disable_fast_lock`` :raw-html:`<a id="predict_disable_fast_lock" title="Permalink to this parameter" href="#predict_disable_fast_lock">&#x1F517;&#xFE0E;</a>`, default = ``false``, type = bool
+
+   -  used only with C API fast single-row prediction functions, such as ``LGBM_BoosterPredictForMatSingleRowFast``
+
+   -  if ``true``, LightGBM will not acquire its internal locks during fast single-row prediction
+
+   -  **Note**: only set this to ``true`` when you guarantee that the same fast-config handle is not used concurrently and that the booster is not modified during prediction
+
 -  ``pred_early_stop`` :raw-html:`<a id="pred_early_stop" title="Permalink to this parameter" href="#pred_early_stop">&#x1F517;&#xFE0E;</a>`, default = ``false``, type = bool
 
    -  used only in ``prediction`` task

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -1060,6 +1060,8 @@ Predict Parameters
 
    -  if ``true``, LightGBM will not acquire its internal locks during fast single-row prediction
 
+   -  this is useful for applications serving predictions from multiple different models that control parallel execution themselves and can avoid unnecessary mutex contention in LightGBM
+
    -  **Note**: only set this to ``true`` when you guarantee that the same fast-config handle is not used concurrently and that the booster is not modified during prediction
 
 -  ``pred_early_stop`` :raw-html:`<a id="pred_early_stop" title="Permalink to this parameter" href="#pred_early_stop">&#x1F517;&#xFE0E;</a>`, default = ``false``, type = bool

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -1060,9 +1060,9 @@ Predict Parameters
 
    -  if ``true``, LightGBM will not acquire its internal locks during fast single-row prediction
 
-   -  this is useful for applications serving predictions from multiple different models that control parallel execution themselves and can avoid unnecessary mutex contention in LightGBM
+   -  useful for advanced applications that handle synchronization outside LightGBM and need to avoid per-call mutex overhead in low-latency fast single-row prediction
 
-   -  **Note**: only set this to ``true`` when you guarantee that the same fast-config handle is not used concurrently and that the booster is not modified during prediction
+   -  **Note**: only set this to ``true`` when you guarantee that the same fast-config handle is not used concurrently and that the booster is not modified or freed during prediction
 
 -  ``pred_early_stop`` :raw-html:`<a id="pred_early_stop" title="Permalink to this parameter" href="#pred_early_stop">&#x1F517;&#xFE0E;</a>`, default = ``false``, type = bool
 

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -1164,7 +1164,9 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSRSingleRow(BoosterHandle handle,
  * \param num_iteration Number of iterations for prediction, <= 0 means no limit
  * \param data_type Type of ``data`` pointer, can be ``C_API_DTYPE_FLOAT32`` or ``C_API_DTYPE_FLOAT64``
  * \param num_col Number of columns
- * \param parameter Other parameters for prediction, e.g. early stopping for prediction
+ * \param parameter Other parameters for prediction, e.g. early stopping for prediction.
+ *   To skip internal locks in ``LGBM_BoosterPredictForCSRSingleRowFast``, pass ``predict_disable_fast_lock=true``.
+ *   Only do this when synchronization is handled outside of LightGBM.
  * \param[out] out_fastConfig FastConfig object with which you can call ``LGBM_BoosterPredictForCSRSingleRowFast``
  * \return 0 when it succeeds, -1 when failure happens
  */
@@ -1190,6 +1192,8 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSRSingleRowFastInit(BoosterHandle h
  *   instead of at each prediction.
  *   If you use a different number of threads in other calls, you need to start the setup process over,
  *   or that number of threads will be used for these calls as well.
+ *   If ``predict_disable_fast_lock=true`` was passed to ``LGBM_BoosterPredictForCSRSingleRowFastInit``,
+ *   this call does not acquire LightGBM's internal locks. The caller must synchronize externally.
  *
  * \note
  * You should pre-allocate memory for ``out_result``:
@@ -1352,7 +1356,9 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForMatSingleRow(BoosterHandle handle,
  * \param num_iteration Number of iterations for prediction, <= 0 means no limit
  * \param data_type Type of ``data`` pointer, can be ``C_API_DTYPE_FLOAT32`` or ``C_API_DTYPE_FLOAT64``
  * \param ncol Number of columns
- * \param parameter Other parameters for prediction, e.g. early stopping for prediction
+ * \param parameter Other parameters for prediction, e.g. early stopping for prediction.
+ *   To skip internal locks in ``LGBM_BoosterPredictForMatSingleRowFast``, pass ``predict_disable_fast_lock=true``.
+ *   Only do this when synchronization is handled outside of LightGBM.
  * \param[out] out_fastConfig FastConfig object with which you can call ``LGBM_BoosterPredictForMatSingleRowFast``
  * \return 0 when it succeeds, -1 when failure happens
  */
@@ -1378,6 +1384,8 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForMatSingleRowFastInit(BoosterHandle h
  *   instead of at each prediction.
  *   If you use a different number of threads in other calls, you need to start the setup process over,
  *   or that number of threads will be used for these calls as well.
+ *   If ``predict_disable_fast_lock=true`` was passed to ``LGBM_BoosterPredictForMatSingleRowFastInit``,
+ *   this call does not acquire LightGBM's internal locks. The caller must synchronize externally.
  *
  * \param fastConfig_handle FastConfig object handle returned by ``LGBM_BoosterPredictForMatSingleRowFastInit``
  * \param data Single-row array data (no other way than row-major form).

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -1166,6 +1166,7 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSRSingleRow(BoosterHandle handle,
  * \param num_col Number of columns
  * \param parameter Other parameters for prediction, e.g. early stopping for prediction.
  *   To skip internal locks in ``LGBM_BoosterPredictForCSRSingleRowFast``, pass ``predict_disable_fast_lock=true``.
+ *   This is useful for applications serving multiple different models that control parallel execution themselves.
  *   Only do this when synchronization is handled outside of LightGBM.
  * \param[out] out_fastConfig FastConfig object with which you can call ``LGBM_BoosterPredictForCSRSingleRowFast``
  * \return 0 when it succeeds, -1 when failure happens
@@ -1358,6 +1359,7 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForMatSingleRow(BoosterHandle handle,
  * \param ncol Number of columns
  * \param parameter Other parameters for prediction, e.g. early stopping for prediction.
  *   To skip internal locks in ``LGBM_BoosterPredictForMatSingleRowFast``, pass ``predict_disable_fast_lock=true``.
+ *   This is useful for applications serving multiple different models that control parallel execution themselves.
  *   Only do this when synchronization is handled outside of LightGBM.
  * \param[out] out_fastConfig FastConfig object with which you can call ``LGBM_BoosterPredictForMatSingleRowFast``
  * \return 0 when it succeeds, -1 when failure happens

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -1166,8 +1166,9 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSRSingleRow(BoosterHandle handle,
  * \param num_col Number of columns
  * \param parameter Other parameters for prediction, e.g. early stopping for prediction.
  *   To skip internal locks in ``LGBM_BoosterPredictForCSRSingleRowFast``, pass ``predict_disable_fast_lock=true``.
- *   This is useful for applications serving multiple different models that control parallel execution themselves.
- *   Only do this when synchronization is handled outside of LightGBM.
+ *   This is useful for advanced applications that handle synchronization outside LightGBM
+ *   and need to avoid per-call mutex overhead in low-latency fast single-row prediction.
+ *   Only do this when the same FastConfig handle is not used concurrently and the Booster is not modified or freed during prediction.
  * \param[out] out_fastConfig FastConfig object with which you can call ``LGBM_BoosterPredictForCSRSingleRowFast``
  * \return 0 when it succeeds, -1 when failure happens
  */
@@ -1195,6 +1196,7 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSRSingleRowFastInit(BoosterHandle h
  *   or that number of threads will be used for these calls as well.
  *   If ``predict_disable_fast_lock=true`` was passed to ``LGBM_BoosterPredictForCSRSingleRowFastInit``,
  *   this call does not acquire LightGBM's internal locks. The caller must synchronize externally.
+ *   Do not use the same FastConfig handle concurrently or modify/free the Booster during prediction.
  *
  * \note
  * You should pre-allocate memory for ``out_result``:
@@ -1359,8 +1361,9 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForMatSingleRow(BoosterHandle handle,
  * \param ncol Number of columns
  * \param parameter Other parameters for prediction, e.g. early stopping for prediction.
  *   To skip internal locks in ``LGBM_BoosterPredictForMatSingleRowFast``, pass ``predict_disable_fast_lock=true``.
- *   This is useful for applications serving multiple different models that control parallel execution themselves.
- *   Only do this when synchronization is handled outside of LightGBM.
+ *   This is useful for advanced applications that handle synchronization outside LightGBM
+ *   and need to avoid per-call mutex overhead in low-latency fast single-row prediction.
+ *   Only do this when the same FastConfig handle is not used concurrently and the Booster is not modified or freed during prediction.
  * \param[out] out_fastConfig FastConfig object with which you can call ``LGBM_BoosterPredictForMatSingleRowFast``
  * \return 0 when it succeeds, -1 when failure happens
  */
@@ -1388,6 +1391,7 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForMatSingleRowFastInit(BoosterHandle h
  *   or that number of threads will be used for these calls as well.
  *   If ``predict_disable_fast_lock=true`` was passed to ``LGBM_BoosterPredictForMatSingleRowFastInit``,
  *   this call does not acquire LightGBM's internal locks. The caller must synchronize externally.
+ *   Do not use the same FastConfig handle concurrently or modify/free the Booster during prediction.
  *
  * \param fastConfig_handle FastConfig object handle returned by ``LGBM_BoosterPredictForMatSingleRowFastInit``
  * \param data Single-row array data (no other way than row-major form).

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -867,8 +867,8 @@ struct Config {
   // [no-save]
   // desc = used only with C API fast single-row prediction functions, such as ``LGBM_BoosterPredictForMatSingleRowFast``
   // desc = if ``true``, LightGBM will not acquire its internal locks during fast single-row prediction
-  // desc = useful for applications serving predictions from multiple different models that control parallel execution themselves and can avoid unnecessary mutex contention in LightGBM
-  // desc = **Note**: only set this to ``true`` when you guarantee that the same fast-config handle is not used concurrently and that the booster is not modified during prediction
+  // desc = useful for advanced applications that handle synchronization outside LightGBM and need to avoid per-call mutex overhead in low-latency fast single-row prediction
+  // desc = **Note**: only set this to ``true`` when you guarantee that the same fast-config handle is not used concurrently and that the booster is not modified or freed during prediction
   bool predict_disable_fast_lock = false;
 
   // [no-save]

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -867,6 +867,7 @@ struct Config {
   // [no-save]
   // desc = used only with C API fast single-row prediction functions, such as ``LGBM_BoosterPredictForMatSingleRowFast``
   // desc = if ``true``, LightGBM will not acquire its internal locks during fast single-row prediction
+  // desc = useful for applications serving predictions from multiple different models that control parallel execution themselves and can avoid unnecessary mutex contention in LightGBM
   // desc = **Note**: only set this to ``true`` when you guarantee that the same fast-config handle is not used concurrently and that the booster is not modified during prediction
   bool predict_disable_fast_lock = false;
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -865,6 +865,12 @@ struct Config {
   bool predict_disable_shape_check = false;
 
   // [no-save]
+  // desc = used only with C API fast single-row prediction functions, such as ``LGBM_BoosterPredictForMatSingleRowFast``
+  // desc = if ``true``, LightGBM will not acquire its internal locks during fast single-row prediction
+  // desc = **Note**: only set this to ``true`` when you guarantee that the same fast-config handle is not used concurrently and that the booster is not modified during prediction
+  bool predict_disable_fast_lock = false;
+
+  // [no-save]
   // desc = used only in ``prediction`` task
   // desc = used only in ``classification`` and ``ranking`` applications
   // desc = used only for predicting normal or raw scores

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -136,13 +136,13 @@ struct SingleRowPredictor {
 
   void Predict(std::function<std::vector<std::pair<int, double>>(int row_idx)> get_row_fun,
                double* out_result, int64_t* out_len) const {
-    UNIQUE_LOCK(single_row_predictor_mutex)
-    yamc::shared_lock<yamc::alternate::shared_mutex> booster_shared_lock(booster_mutex);
-
-    auto one_row = get_row_fun(0);
-    single_row_predictor_inner.predict_function(one_row, out_result);
-
-    *out_len = single_row_predictor_inner.num_pred_in_one_row;
+    if (config.predict_disable_fast_lock) {
+      PredictInner(get_row_fun, out_result, out_len);
+    } else {
+      UNIQUE_LOCK(single_row_predictor_mutex)
+      yamc::shared_lock<yamc::alternate::shared_mutex> booster_shared_lock(booster_mutex);
+      PredictInner(get_row_fun, out_result, out_len);
+    }
   }
 
  public:
@@ -151,6 +151,14 @@ struct SingleRowPredictor {
   const int32_t num_cols;
 
  private:
+  void PredictInner(std::function<std::vector<std::pair<int, double>>(int row_idx)> get_row_fun,
+                    double* out_result, int64_t* out_len) const {
+    auto one_row = get_row_fun(0);
+    single_row_predictor_inner.predict_function(one_row, out_result);
+
+    *out_len = single_row_predictor_inner.num_pred_in_one_row;
+  }
+
   SingleRowPredictorInner single_row_predictor_inner;
 
   // Prevent the booster from being modified while we have a predictor relying on it during prediction

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -293,6 +293,7 @@ const std::unordered_set<std::string>& Config::parameter_set() {
   "predict_leaf_index",
   "predict_contrib",
   "predict_disable_shape_check",
+  "predict_disable_fast_lock",
   "pred_early_stop",
   "pred_early_stop_freq",
   "pred_early_stop_margin",
@@ -583,6 +584,8 @@ void Config::GetMembersFromString(const std::unordered_map<std::string, std::str
   GetBool(params, "predict_contrib", &predict_contrib);
 
   GetBool(params, "predict_disable_shape_check", &predict_disable_shape_check);
+
+  GetBool(params, "predict_disable_fast_lock", &predict_disable_fast_lock);
 
   GetBool(params, "pred_early_stop", &pred_early_stop);
 
@@ -906,6 +909,7 @@ const std::unordered_map<std::string, std::vector<std::string>>& Config::paramet
     {"predict_leaf_index", {"is_predict_leaf_index", "leaf_index"}},
     {"predict_contrib", {"is_predict_contrib", "contrib"}},
     {"predict_disable_shape_check", {}},
+    {"predict_disable_fast_lock", {}},
     {"pred_early_stop", {}},
     {"pred_early_stop_freq", {}},
     {"pred_early_stop_margin", {}},
@@ -1052,6 +1056,7 @@ const std::unordered_map<std::string, std::string>& Config::ParameterTypes() {
     {"predict_leaf_index", "bool"},
     {"predict_contrib", "bool"},
     {"predict_disable_shape_check", "bool"},
+    {"predict_disable_fast_lock", "bool"},
     {"pred_early_stop", "bool"},
     {"pred_early_stop_freq", "int"},
     {"pred_early_stop_margin", "double"},

--- a/tests/cpp_tests/test_single_row.cpp
+++ b/tests/cpp_tests/test_single_row.cpp
@@ -125,53 +125,56 @@ void test_predict_type(int predict_type, int num_predicts) {
         t.join();
     }
 
-    // Now let's run with the single row fast prediction API:
-    FastConfigHandle fast_configs[kNThreads];
-    for (int i = 0; i < kNThreads; i++) {
-        result = LGBM_BoosterPredictForMatSingleRowFastInit(
-            booster_handle,
-            predict_type,          // predict_type
-            0,                     // start_iteration
-            -1,                    // num_iteration
-            C_API_DTYPE_FLOAT64,
-            n_features,
-            "",
-            &fast_configs[i]);
-        EXPECT_EQ(0, result) << "LGBM_BoosterPredictForMatSingleRowFastInit result code: " << result;
-    }
+    const char* fast_config_parameters[] = {"", "predict_disable_fast_lock=true"};
+    for (const char* fast_config_parameter : fast_config_parameters) {
+        // Now let's run with the single row fast prediction API:
+        FastConfigHandle fast_configs[kNThreads];
+        for (int i = 0; i < kNThreads; i++) {
+            result = LGBM_BoosterPredictForMatSingleRowFastInit(
+                booster_handle,
+                predict_type,          // predict_type
+                0,                     // start_iteration
+                -1,                    // num_iteration
+                C_API_DTYPE_FLOAT64,
+                n_features,
+                fast_config_parameter,
+                &fast_configs[i]);
+            EXPECT_EQ(0, result) << "LGBM_BoosterPredictForMatSingleRowFastInit result code: " << result;
+        }
 
-    std::vector<double> single_row_output(output_size * test_set_size, -1);
-    std::vector<std::thread> single_row_threads(kNThreads);
-    int batch_size = (test_set_size + kNThreads - 1) / kNThreads;  // round up
-    for (int i = 0; i < kNThreads; i++) {
-        single_row_threads[i] = std::thread(
-            [
-                i, batch_size, test_set_size, output_size, n_features,
-                    test = &test[0], fast_configs = &fast_configs[0], single_row_output = &single_row_output[0]
-            ]() {
-                int result;
-                int64_t written;
-                for (int j = i * batch_size; j < std::min((i + 1) * batch_size, test_set_size); j++) {
-                    result = LGBM_BoosterPredictForMatSingleRowFast(
-                        fast_configs[i],
-                        &test[j * n_features],
-                        &written,
-                        &single_row_output[j * output_size]);
-                    EXPECT_EQ(0, result) << "LGBM_BoosterPredictForMatSingleRowFast result code: " << result;
-                    EXPECT_EQ(written, output_size) << "LGBM_BoosterPredictForMatSingleRowFast unexpected written output size";
-                }
-            });
-      }
-    for (std::thread& t : single_row_threads) {
-        t.join();
-    }
+        std::vector<double> single_row_output(output_size * test_set_size, -1);
+        std::vector<std::thread> single_row_threads(kNThreads);
+        int batch_size = (test_set_size + kNThreads - 1) / kNThreads;  // round up
+        for (int i = 0; i < kNThreads; i++) {
+            single_row_threads[i] = std::thread(
+                [
+                    i, batch_size, test_set_size, output_size, n_features,
+                        test = &test[0], fast_configs = &fast_configs[0], single_row_output = &single_row_output[0]
+                ]() {
+                    int result;
+                    int64_t written;
+                    for (int j = i * batch_size; j < std::min((i + 1) * batch_size, test_set_size); j++) {
+                        result = LGBM_BoosterPredictForMatSingleRowFast(
+                            fast_configs[i],
+                            &test[j * n_features],
+                            &written,
+                            &single_row_output[j * output_size]);
+                        EXPECT_EQ(0, result) << "LGBM_BoosterPredictForMatSingleRowFast result code: " << result;
+                        EXPECT_EQ(written, output_size) << "LGBM_BoosterPredictForMatSingleRowFast unexpected written output size";
+                    }
+                });
+        }
+        for (std::thread& t : single_row_threads) {
+            t.join();
+        }
 
-    EXPECT_EQ(single_row_output, mat_output) << "LGBM_BoosterPredictForMatSingleRowFast output mismatch with LGBM_BoosterPredictForMat";
+        EXPECT_EQ(single_row_output, mat_output) << "LGBM_BoosterPredictForMatSingleRowFast output mismatch with LGBM_BoosterPredictForMat";
 
-    // Free all:
-    for (int i = 0; i < kNThreads; i++) {
-        result = LGBM_FastConfigFree(fast_configs[i]);
-        EXPECT_EQ(0, result) << "LGBM_FastConfigFree result code: " << result;
+        // Free all:
+        for (int i = 0; i < kNThreads; i++) {
+            result = LGBM_FastConfigFree(fast_configs[i]);
+            EXPECT_EQ(0, result) << "LGBM_FastConfigFree result code: " << result;
+        }
     }
 
     result = LGBM_BoosterFree(booster_handle);


### PR DESCRIPTION
## Benefits

This adds an opt-in escape hatch for advanced users of the C API fast single-row prediction path who already synchronize prediction externally and want to avoid LightGBM's per-call mutex overhead.

The intended use is **not** to share one `FastConfig` concurrently across threads. The safe pattern remains one `FastConfig` per concurrently-executing predictor, with no concurrent mutation or freeing of the corresponding `Booster`. With `predict_disable_fast_lock=true`, LightGBM trusts the caller to enforce those invariants.

One example is a low-latency model-serving application with an actor / worker ownership model:

* each worker owns the `FastConfig` handles it uses, so the same handle is never used concurrently;
* model reloads are performed by swapping worker-owned handles only after in-flight requests complete;
* the application already has lifecycle synchronization guaranteeing that the `Booster` is not modified or freed while a request is using the corresponding `FastConfig`.

In that setup, LightGBM's internal fast-prediction locks are redundant and are paid on every single-row prediction.

## Working benchmark

I used this standalone benchmark against this branch, training on `examples/binary_classification/binary.train`, saving the model, loading it back, initializing one `FastConfig`, and repeatedly calling `LGBM_BoosterPredictForMatSingleRowFast()` for the first row of `examples/binary_classification/binary.test`.

```cpp
#include <LightGBM/c_api.h>

#include <chrono>
#include <cstdlib>
#include <fstream>
#include <iostream>
#include <vector>

#define CHECK(expr) do { int code = (expr); if (code != 0) { std::cerr << "failed: " #expr << " code=" << code << " msg=" << LGBM_GetLastError() << "\n"; std::exit(1); } } while (0)

static std::vector<double> load_first_row(int* n_features) {
  DatasetHandle train_dataset;
  CHECK(LGBM_DatasetCreateFromFile("examples/binary_classification/binary.train", "max_bin=15", nullptr, &train_dataset));
  BoosterHandle booster;
  CHECK(LGBM_BoosterCreate(train_dataset, "objective=binary metric=auc num_leaves=31 num_threads=1 verbose=-1", &booster));
  int empty;
  for (int i = 0; i < 51; ++i) {
    CHECK(LGBM_BoosterUpdateOneIter(booster, &empty));
  }
  CHECK(LGBM_BoosterSaveModel(booster, 0, -1, C_API_FEATURE_IMPORTANCE_SPLIT, "/tmp/fast_lock_benchmark_model.txt"));
  CHECK(LGBM_BoosterGetNumFeature(booster, n_features));
  CHECK(LGBM_BoosterFree(booster));
  CHECK(LGBM_DatasetFree(train_dataset));

  std::ifstream input("examples/binary_classification/binary.test");
  double x;
  input >> x;  // label
  std::vector<double> row(*n_features);
  for (int i = 0; i < *n_features; ++i) {
    input >> row[i];
  }
  return row;
}

static double run(FastConfigHandle fast_config, const std::vector<double>& row, int iters) {
  double out = 0.0;
  int64_t written = 0;
  auto start = std::chrono::steady_clock::now();
  for (int i = 0; i < iters; ++i) {
    CHECK(LGBM_BoosterPredictForMatSingleRowFast(fast_config, row.data(), &written, &out));
  }
  auto end = std::chrono::steady_clock::now();
  if (written != 1) {
    std::exit(2);
  }
  return std::chrono::duration<double, std::nano>(end - start).count() / iters;
}

int main(int argc, char** argv) {
  int iters = argc > 1 ? std::atoi(argv[1]) : 1000000;
  int n_features = 0;
  std::vector<double> row = load_first_row(&n_features);

  BoosterHandle booster;
  int num_iterations = 0;
  CHECK(LGBM_BoosterCreateFromModelfile("/tmp/fast_lock_benchmark_model.txt", &num_iterations, &booster));

  for (const char* params : {"", "predict_disable_fast_lock=true"}) {
    FastConfigHandle fc;
    CHECK(LGBM_BoosterPredictForMatSingleRowFastInit(
        booster, C_API_PREDICT_NORMAL, 0, -1, C_API_DTYPE_FLOAT64, n_features, params, &fc));
    std::cout << (params[0] ? params : "default locks") << ": " << run(fc, row, iters) << " ns/prediction\n";
    CHECK(LGBM_FastConfigFree(fc));
  }
  CHECK(LGBM_BoosterFree(booster));
}
```

Build / run command:

```shell
cmake -S . -B build -DBUILD_CPP_TEST=ON -DUSE_OPENMP=OFF -DCMAKE_BUILD_TYPE=Release
cmake --build build --target _lightgbm -j2
g++ -O3 -DNDEBUG -std=c++17 \
  -Iinclude \
  -Iexternal_libs/fast_double_parser/include \
  -Iexternal_libs/fmt/include \
  -Iexternal_libs/compute/include \
  -Iexternal_libs/eigen \
  /tmp/fast_lock_benchmark.cpp \
  -L. -l_lightgbm -Wl,-rpath,$PWD \
  -o /tmp/fast_lock_benchmark
/tmp/fast_lock_benchmark 1000000
```

Result on my local environment, 51-tree model, `USE_OPENMP=OFF`, release build:

```text
default locks: 751.756 ns/prediction
predict_disable_fast_lock=true: 702.255 ns/prediction
```

For an even smaller 1-tree model, where mutex overhead is a larger fraction of total prediction time:

```text
default locks: 163.003 ns/prediction
predict_disable_fast_lock=true: 119.741 ns/prediction
```

## Safety

The option is documented as unsafe unless the caller guarantees all of the following:

* the same `FastConfig` handle is not used concurrently;
* the associated `Booster` is not modified during prediction;
* the associated `Booster` is not freed during prediction.

## Tests

* `python .ci/parameter-generator.py`
* `git diff --check`
* Built `_lightgbm` with `cmake -S . -B build -DBUILD_CPP_TEST=ON -DUSE_OPENMP=OFF -DCMAKE_BUILD_TYPE=Release && cmake --build build --target _lightgbm -j2`
* Ran the relevant C++ tests by compiling `test_single_row.cpp` only, because the full `testlightgbm` target currently fails to compile in unrelated `tests/cpp_tests/test_arrow.cpp` with GCC 13.3 (`explicit specialization in non-namespace scope`):

```shell
g++ -std=c++17 -O3 -DNDEBUG -DUSE_SOCKET \
  -Iinclude -Itests/cpp_tests \
  -Iexternal_libs/fast_double_parser/include \
  -Iexternal_libs/fmt/include \
  -Iexternal_libs/compute/include \
  -Iexternal_libs/eigen \
  -isystem build/_deps/googletest-src/googletest/include \
  tests/cpp_tests/test_single_row.cpp \
  tests/cpp_tests/testutils.cpp \
  tests/cpp_tests/test_main.cpp \
  build/CMakeFiles/lightgbm_capi_objs.dir/src/c_api.cpp.o \
  $(find build/CMakeFiles/lightgbm_objs.dir -name '*.o' | tr '\n' ' ') \
  build/lib/libgtest.a \
  -lpthread -ldl \
  -o /tmp/test_single_row
/tmp/test_single_row --gtest_filter='SingleRow.*'
```

```text
[==========] Running 2 tests from 1 test suite.
[----------] 2 tests from SingleRow
[ RUN      ] SingleRow.Normal
[       OK ] SingleRow.Normal (90 ms)
[ RUN      ] SingleRow.Contrib
[       OK ] SingleRow.Contrib (637 ms)
[----------] 2 tests from SingleRow (727 ms total)
[  PASSED  ] 2 tests.
```
