### PR TITLE
[python-package] remove dependency on typing_extensions.TypeGuard

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -32,13 +32,7 @@ import scipy.sparse
 from .compat import PANDAS_INSTALLED, concat, pd_CategoricalDtype, pd_DataFrame, pd_Series
 
 if TYPE_CHECKING:
-    from typing import Literal
-
-    # typing.TypeGuard was only introduced in Python 3.10
-    try:
-        from typing import TypeGuard
-    except ImportError:
-        from typing_extensions import TypeGuard
+    from typing import Literal, TypeGuard
 
 
 __all__ = [


### PR DESCRIPTION
Contributes to #7327

Now that the project's Python floor is Python 3.10 (#7276), it can depend on `typing.TypeGuard` unconditionally 😁 