### PR TITLE
[python-package] remove unused 'cffi' fixture

### DIFF
--- a/tests/python_package_test/conftest.py
+++ b/tests/python_package_test/conftest.py
@@ -1,15 +1,6 @@
 import numpy as np
 import pytest
 
-import lightgbm
-
-
-@pytest.fixture(scope="function")
-def missing_module_cffi(monkeypatch):
-    """Mock 'cffi' not being importable"""
-    monkeypatch.setattr(lightgbm.compat, "CFFI_INSTALLED", False)
-    monkeypatch.setattr(lightgbm.basic, "CFFI_INSTALLED", False)
-
 
 @pytest.fixture(scope="function")
 def rng():


### PR DESCRIPTION
Removes Python test fixture `missing_module_cffi`, which is now unused as of #7275 .