### PR TITLE
fix: raise error when forcedsplits_filename points to non-existent file

### DIFF
--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -89,6 +89,13 @@ void GBDT::Init(const Config* config, const Dataset* train_data, const Objective
 
   // load forced_splits file
   if (!config->forcedsplits_filename.empty()) {
+     // Fix #6830: check file exists before opening, instead of silently ignoring
+    std::ifstream check_file(config_->forcedsplits_filename.c_str());
+    if (!check_file.good()) {
+      Log::Fatal("forcedsplits_filename '%s' does not exist or cannot be opened.",
+                 config_->forcedsplits_filename.c_str());
+    }
+    check_file.close();
     std::ifstream forced_splits_file(config->forcedsplits_filename.c_str());
     std::stringstream buffer;
     buffer << forced_splits_file.rdbuf();


### PR DESCRIPTION
 Problem
Fixes #6830

When 'forcedsplits_filename' is set to a path that does not exist, 
LightGBM silently ignores the error and continues training without 
applying any forced splits. This makes it very hard to debug as the 
user gets no feedback that their config is wrong.

 Fix
Added a file existence check in 'src/boosting/gbdt.cpp' before 
attempting to open the forced splits file. If the file does not exist 
or cannot be opened, LightGBM now raises a fatal error with a clear 
message indicating the problematic filename.

Changes
- 'src/boosting/gbdt.cpp' → added 'check_file.good()' validation 
  before opening 'forcedsplits_filename'

Testing
Tested by passing a non-existent filename to `forcedsplits_filename` 
and confirming the fatal error message is raised correctly.