### PR TITLE
[c++] fail on incomplete binary file writes

### DIFF
--- a/src/io/file_io.cpp
+++ b/src/io/file_io.cpp
@@ -47,7 +47,13 @@ struct LocalFile : VirtualFileReader, VirtualFileWriter {
   }
 
   size_t Write(const void* buffer, size_t bytes) {
-    return fwrite(buffer, bytes, 1, file_) == 1 ? bytes : 0;
+    size_t bytes_written = fwrite(buffer, 1, bytes, file_);
+    if (bytes_written != bytes) {
+      Log::Fatal(
+          "Cannot write binary data to %s, wrote %zu of %zu bytes",
+          filename_.c_str(), bytes_written, bytes);
+    }
+    return bytes_written;
   }
 
  private:

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -2,6 +2,7 @@
 import filecmp
 import numbers
 import re
+import signal
 import warnings
 from copy import deepcopy
 from pathlib import Path
@@ -293,6 +294,25 @@ def test_save_dataset_subset_and_load_from_file(tmp_path, rng):
     ds = lgb.Dataset(data, params=params)
     ds.subset([1, 2, 3, 5, 8]).save_binary(tmp_path / "subset.bin")
     lgb.Dataset(tmp_path / "subset.bin", params=params).construct()
+
+
+def test_save_binary_raises_on_truncated_write(tmp_path, rng):
+    resource = pytest.importorskip("resource")
+    if not hasattr(signal, "SIGXFSZ"):
+        pytest.skip("SIGXFSZ is not available on this platform")
+
+    data = rng.standard_normal(size=(1000, 20))
+    ds = lgb.Dataset(data).construct()
+    original_limit = resource.getrlimit(resource.RLIMIT_FSIZE)
+    original_signal_handler = signal.getsignal(signal.SIGXFSZ)
+    try:
+        signal.signal(signal.SIGXFSZ, signal.SIG_IGN)
+        resource.setrlimit(resource.RLIMIT_FSIZE, (4096, original_limit[1]))
+        with pytest.raises(lgb.basic.LightGBMError, match="Cannot write binary data"):
+            ds.save_binary(tmp_path / "truncated.bin")
+    finally:
+        resource.setrlimit(resource.RLIMIT_FSIZE, original_limit)
+        signal.signal(signal.SIGXFSZ, original_signal_handler)
 
 
 def test_subset_group():


### PR DESCRIPTION
Fixes #7334.

## What changed

`Dataset.save_binary()` now fails immediately if the local file writer writes fewer bytes than requested. Previously, `LocalFile::Write()` collapsed any short `fwrite()` to `0`, but callers did not check the returned byte count, so `save_binary()` could return successfully after producing a truncated binary file.

This changes the local writer to report partial writes via `Log::Fatal`, which also covers aligned writes used by dataset headers, metadata, and feature groups.

## Tests

- `cmake -B build -S . -DUSE_OPENMP=OFF`
- `cmake --build build --target _lightgbm -j4`
- `sh build-python.sh install --precompile`
- `python -m pytest tests/python_package_test/test_basic.py::test_save_binary_raises_on_truncated_write tests/python_package_test/test_basic.py::test_save_dataset_subset_and_load_from_file -q`
- `python -m py_compile tests/python_package_test/test_basic.py`
- `python -m ruff check tests/python_package_test/test_basic.py`
- `pre-commit run --files src/io/file_io.cpp tests/python_package_test/test_basic.py`
- `git diff --check`
