### PR TITLE
[python-package] remove unnecessary LGBM_BoosterGetCurrentIteration() call

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -966,13 +966,6 @@ class _InnerPredictor:
         pred_parameter : dict
             Other parameters for the prediction.
         """
-        out_cur_iter = ctypes.c_int(0)
-        _safe_call(
-            _LIB.LGBM_BoosterGetCurrentIteration(
-                booster._handle,
-                ctypes.byref(out_cur_iter),
-            )
-        )
         return cls(
             booster_handle=booster._handle,
             pandas_categorical=booster.pandas_categorical,
@@ -4652,7 +4645,7 @@ class Booster:
             Loaded Booster object.
         """
         # ensure that existing Booster is freed before replacing it
-        # with a new one createdfrom file
+        # with a new one created from file
         _safe_call(_LIB.LGBM_BoosterFree(self._handle))
         self._free_buffer()
         self._handle = ctypes.c_void_p()


### PR DESCRIPTION
`_InnerPredictor.from_booster()` calls `LGBM_BoosterGetCurrentIteration()` but doesn't do anything with the return value. I don't think the package is depending on any side effect from that call and I don't see a place where `_InnerPredictor` would need that value, so I think this is just unnecessary code left behind by the refactoring in #5961 

This removes it.