### PR TITLE
[ci] remove lingering references to 'master' branch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,10 +5,9 @@ platform: x64
 configuration:
   - '3.10'
 
-# only build on 'master' / 'main' and pull requests targeting it
+# only build on 'main' and pull requests targeting it
 branches:
   only:
-    - master
     - main
 
 environment:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
 
 # automatically cancel in-progress builds if another commit is pushed
 concurrency:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
 
 # automatically cancel in-progress builds if another commit is pushed
 concurrency:

--- a/.github/workflows/optional_checks.yml
+++ b/.github/workflows/optional_checks.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
 
 # automatically cancel in-progress builds if another commit is pushed
 concurrency:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
 
 # automatically cancel in-progress builds if another commit is pushed
 concurrency:

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
 
 # automatically cancel in-progress builds if another commit is pushed
 concurrency:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
 
 # automatically cancel in-progress builds if another commit is pushed
 concurrency:

--- a/.github/workflows/swig.yml
+++ b/.github/workflows/swig.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
 
 # automatically cancel in-progress builds if another commit is pushed
 concurrency:


### PR DESCRIPTION
Contributes to #7034

In #7287, I left references to `master` in GitHub Actions configs to keep CI running on that specific PR. The branch renaming is now done, so that's not necessary... this removes them.

