### PR TITLE
[python-package] remove unnecessary old import paths in compat.py

### DIFF
--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -10,38 +10,21 @@ from typing import TYPE_CHECKING, Any, List
 try:
     from sklearn import __version__ as _sklearn_version
     from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
+    from sklearn.exceptions import NotFittedError
+    from sklearn.model_selection import BaseCrossValidator, GroupKFold, StratifiedKFold
     from sklearn.preprocessing import LabelEncoder
     from sklearn.utils.class_weight import compute_sample_weight
     from sklearn.utils.multiclass import check_classification_targets
-    from sklearn.utils.validation import assert_all_finite, check_array, check_X_y
+    from sklearn.utils.validation import _check_sample_weight, assert_all_finite, check_array, check_X_y
 
-    try:
-        from sklearn.exceptions import NotFittedError
-        from sklearn.model_selection import BaseCrossValidator, GroupKFold, StratifiedKFold
-    except ImportError:
-        from sklearn.cross_validation import BaseCrossValidator, GroupKFold, StratifiedKFold
-        from sklearn.utils.validation import NotFittedError
-    try:
-        from sklearn.utils.validation import _check_sample_weight
-
-        # As of https://github.com/scikit-learn/scikit-learn/pull/32212, scikit-learn started raising an error
-        # when sample weights are all 0. This argument allow_all_zero_weights can be used switch back
-        # to the old behavior of allowing them.
-        #
-        # This can be removed when the minimum scikit-learn version supported here is v1.9.
-        SKLEARN_CHECK_SAMPLE_WEIGHT_HAS_ALLOW_ZERO_WEIGHTS_ARG = (
-            "allow_all_zero_weights" in inspect.signature(_check_sample_weight).parameters
-        )
-
-    except ImportError:
-        from sklearn.utils.validation import check_consistent_length
-
-        SKLEARN_CHECK_SAMPLE_WEIGHT_HAS_ALLOW_ZERO_WEIGHTS_ARG = False
-
-        # dummy function to support older version of scikit-learn
-        def _check_sample_weight(sample_weight: Any, X: Any, dtype: Any = None) -> Any:
-            check_consistent_length(sample_weight, X)
-            return sample_weight
+    # As of https://github.com/scikit-learn/scikit-learn/pull/32212, scikit-learn started raising an error
+    # when sample weights are all 0. This argument allow_all_zero_weights can be used switch back
+    # to the old behavior of allowing them.
+    #
+    # This can be removed when the minimum scikit-learn version supported here is v1.9.
+    SKLEARN_CHECK_SAMPLE_WEIGHT_HAS_ALLOW_ZERO_WEIGHTS_ARG = (
+        "allow_all_zero_weights" in inspect.signature(_check_sample_weight).parameters
+    )
 
     try:
         from sklearn.utils.validation import validate_data
@@ -167,14 +150,11 @@ if TYPE_CHECKING:
 
 """pandas"""
 try:
+    from pandas import CategoricalDtype as pd_CategoricalDtype
     from pandas import DataFrame as pd_DataFrame
     from pandas import Series as pd_Series
     from pandas import concat
 
-    try:
-        from pandas import CategoricalDtype as pd_CategoricalDtype
-    except ImportError:
-        from pandas.api.types import CategoricalDtype as pd_CategoricalDtype
     PANDAS_INSTALLED = True
 except ImportError:
     PANDAS_INSTALLED = False


### PR DESCRIPTION
Contributes to #7327 

A few imports in `try-except` paths in `compat.py` are unnecessary given `lightgbm`'s current dependency ranges. This removes them, to simplify the package and make future refactorings of imports simpler.

**1 for `pandas`**

https://github.com/lightgbm-org/LightGBM/blob/cf16013c30fa508e944f6ad6c46e5057969aa45e/python-package/pyproject.toml#L47-L50

* `pandas.CategoricalDtype` has been valid since at least `pandas` 0.25.0 (https://github.com/pandas-dev/pandas/pull/26019)

**a few for `scikit-learn`**

https://github.com/lightgbm-org/LightGBM/blob/cf16013c30fa508e944f6ad6c46e5057969aa45e/python-package/pyproject.toml#L59-L61

* `sklearn.exceptions.NotFittedError` has been valid since `scikit-learn` 0.18 (https://github.com/scikit-learn/scikit-learn/pull/4826)
* `sklearn.utils._check_sample_weight` has been valid since at least `scikit-learn` 0.22 (https://github.com/scikit-learn/scikit-learn/pull/14307)
* `sklearn.model_selection.{BaseCrossValidator, GroupKFold, StratifiedKFold}` have been valide since `scikit-learn` 0.18 (https://github.com/scikit-learn/scikit-learn/pull/6660)

## Notes for Reviewers

### How I found these

I found these by asking an LLM to look for dead code (just because I suspected some of these were very old), then looked through the `git blame` for the relevant projects to find the release history.

In the future, we could probably find these by looking at code coverage (#7031).