### PR TITLE
[python-package] Add pandas tests for categorical handling and dtype validation

### DIFF
--- a/tests/python_package_test/test_arrow.py
+++ b/tests/python_package_test/test_arrow.py
@@ -1,6 +1,4 @@
 # coding: utf-8
-import filecmp
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 import numpy as np
@@ -8,7 +6,7 @@ import pytest
 
 import lightgbm as lgb
 
-from .utils import np_assert_array_equal
+from .utils import assert_datasets_equal, np_assert_array_equal
 
 pa = pytest.importorskip("pyarrow")
 
@@ -122,12 +120,6 @@ def dummy_dataset_params() -> Dict[str, Any]:
 # ----------------------------------------------------------------------------------------------- #
 
 # ------------------------------------------- DATASET ------------------------------------------- #
-
-
-def assert_datasets_equal(tmp_path: Path, lhs: lgb.Dataset, rhs: lgb.Dataset):
-    lhs._dump_text(tmp_path / "arrow.txt")
-    rhs._dump_text(tmp_path / "pandas.txt")
-    assert filecmp.cmp(tmp_path / "arrow.txt", tmp_path / "pandas.txt")
 
 
 @pytest.mark.parametrize(

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -675,16 +675,6 @@ def test_set_position_updates_self_position_with_remapped_int32_values():
     np_assert_array_equal(dtrain2.get_field("position"), expected, strict=True)
 
 
-def test_dataset_construction_with_high_cardinality_categorical_succeeds(rng):
-    pd = pytest.importorskip("pandas")
-    X = pd.DataFrame({"x1": rng.integers(low=0, high=5_000, size=(10_000,))})
-    y = rng.uniform(size=(10_000,))
-    ds = lgb.Dataset(X, y, categorical_feature=["x1"])
-    ds.construct()
-    assert ds.num_data() == 10_000
-    assert ds.num_feature() == 1
-
-
 def test_choose_param_value():
     original_params = {
         "local_listen_port": 1234,
@@ -903,37 +893,6 @@ def test_no_copy_when_single_float_dtype_dataframe(dtype, feature_name, rng):
     )[0]
     assert built_data.dtype == dtype
     assert np.shares_memory(X, built_data)
-
-
-@pytest.mark.parametrize("feature_name", [["x1"], [42], "auto"])
-@pytest.mark.parametrize("categories", ["seen", "unseen"])
-def test_categorical_code_conversion_doesnt_modify_original_data(feature_name, categories, rng):
-    pd = pytest.importorskip("pandas")
-    X = rng.choice(a=["a", "b"], size=(100, 1))
-    column_name = "a" if feature_name == "auto" else feature_name[0]
-    df = pd.DataFrame(X.copy(), columns=[column_name], dtype="category")
-    if categories == "seen":
-        pandas_categorical = [["a", "b"]]
-    else:
-        pandas_categorical = [["a"]]
-    data = lgb.basic._data_from_pandas(
-        data=df,
-        feature_name=feature_name,
-        categorical_feature="auto",
-        pandas_categorical=pandas_categorical,
-    )[0]
-    # check that the original data wasn't modified
-    np.testing.assert_equal(df[column_name], X[:, 0])
-    # check that the built data has the codes
-    if categories == "seen":
-        # if all categories were seen during training we just take the codes
-        codes = df[column_name].cat.codes
-    else:
-        # if we only saw 'a' during training we just replace its code
-        # and leave the rest as nan
-        a_code = df[column_name].cat.categories.get_loc("a")
-        codes = np.where(df[column_name] == "a", a_code, np.nan)
-    np.testing.assert_equal(codes, data[:, 0])
 
 
 @pytest.mark.parametrize("min_data_in_bin", [2, 10])

--- a/tests/python_package_test/test_pandas.py
+++ b/tests/python_package_test/test_pandas.py
@@ -1,0 +1,144 @@
+# coding: utf-8
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import lightgbm as lgb
+
+from .utils import assert_datasets_equal
+
+pd = pytest.importorskip("pandas")
+
+
+# ------------------------------------------- CATEGORICAL ----------------------------------------- #
+
+
+def test_pandas_categorical_encoding(tmp_path):
+    cat1_categories = ["a", "b", "c"]
+    cat1_values = ["a", "b", "c", "b", "a"]
+    cat2_categories = ["b", "c", "d"]
+    cat2_values = ["b", "c", "c", "d", "d"]
+    ordered_categories = ["high", "low", "mid"]
+    ordered_values = ["low", "high", "mid", "high", "low"]
+
+    df = pd.DataFrame(
+        {
+            "cat1": pd.Categorical(cat1_values, categories=cat1_categories, ordered=False),
+            "cat2": pd.Categorical(cat2_values, categories=cat2_categories, ordered=False),
+            "cat3": pd.Categorical(ordered_values, categories=ordered_categories, ordered=True),
+            "num_col": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+    )
+    y = [0, 1, 0, 1, 0]
+
+    ds = lgb.Dataset(df, label=y, params={"min_data_in_bin": 1})
+    ds.construct()
+
+    assert ds.num_data() == 5
+    assert ds.num_feature() == 4
+    assert ds.get_feature_name() == ["cat1", "cat2", "cat3", "num_col"]
+
+    assert ds.categorical_feature == "auto"
+    assert len(ds.pandas_categorical) == 3
+    assert ds.pandas_categorical[0] == cat1_categories
+    assert ds.pandas_categorical[1] == cat2_categories
+    assert ds.pandas_categorical[2] == ordered_categories
+    assert ds.params["categorical_column"] == [0, 1]  # ordered categorical not treated as categorical by default
+
+    # Verify correct encodings
+    ref_df = pd.DataFrame(
+        {
+            "cat1": [cat1_categories.index(v) for v in cat1_values],  # [0, 1, 2, 1, 0]
+            "cat2": [cat2_categories.index(v) for v in cat2_values],  # [0, 1, 1, 2, 2],
+            "cat3": [ordered_categories.index(v) for v in ordered_values],  # [1, 0, 2, 0, 1],
+            "num_col": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+    )
+    ref_ds = lgb.Dataset(ref_df, label=y, categorical_feature=[0, 1], params={"min_data_in_bin": 1})
+    ref_ds.construct()
+
+    assert_datasets_equal(tmp_path, ds, ref_ds)
+
+
+def test_pandas_categorical_encoding_unseen_category(tmp_path):
+    train_categories = ["a", "b", "c"]
+    train_values = ["a", "b", "c", "a", "b"]
+    valid_values = ["a", "c", "d", "d", "a"]  # "d" is unseen in training data
+
+    params = {"min_data_in_bin": 1, "min_data_in_leaf": 1}
+    train_df = pd.DataFrame({"cat_col": pd.Categorical(train_values), "num_col": [1.0, 2.0, 3.0, 4.0, 5.0]})
+    valid_df = pd.DataFrame({"cat_col": pd.Categorical(valid_values), "num_col": [6.0, 7.0, 8.0, 9.0, 10.0]})
+
+    train_ds = lgb.Dataset(train_df, label=[0, 1, 0, 1, 0], params=params)
+    valid_ds = lgb.Dataset(valid_df, label=[1, 0, 1, 0, 1], reference=train_ds, params=params)
+    train_ds.construct()
+    valid_ds.construct()
+
+    # Verify unseen category is encoded as NaN
+    ref_valid_df = pd.DataFrame(
+        {
+            "cat_col": pd.Categorical(["a", "c", None, None, "a"], categories=train_categories),
+            "num_col": [6.0, 7.0, 8.0, 9.0, 10.0],
+        }
+    )
+    ref_valid_ds = lgb.Dataset(ref_valid_df, label=[1, 0, 1, 0, 1], reference=train_ds, params=params)
+    ref_valid_ds.construct()
+
+    assert_datasets_equal(tmp_path, valid_ds, ref_valid_ds)
+
+
+# ---------------------------------------- DTYPE VALIDATION --------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("dtype", "values"),
+    [
+        (pd.Int8Dtype(), [1, 2, 3]),
+        (pd.Int16Dtype(), [1, 2, 3]),
+        (pd.Int32Dtype(), [1, 2, 3]),
+        (pd.Int64Dtype(), [1, 2, 3]),
+        (pd.UInt8Dtype(), [1, 2, 3]),
+        (pd.UInt16Dtype(), [1, 2, 3]),
+        (pd.UInt32Dtype(), [1, 2, 3]),
+        (pd.UInt64Dtype(), [1, 2, 3]),
+        (pd.Float32Dtype(), [1.0, 2.0, 3.0]),
+        (pd.Float64Dtype(), [1.0, 2.0, 3.0]),
+        (pd.BooleanDtype(), [True, False, True]),
+        (pd.SparseDtype(), [1.0, 2.0, 3.0]),
+    ],
+)
+def test_pandas_supported_dtypes(tmp_path, dtype, values):
+    df = pd.DataFrame({"test_col": pd.Series(values, dtype=dtype), "num_col": [4.0, 5.0, 6.0]})
+    y = [0, 1, 0]
+
+    ds = lgb.Dataset(df, label=y, params={"min_data_in_bin": 1})
+    ds.construct()
+
+    assert ds.num_data() == 3
+    assert ds.num_feature() == 2
+    assert ds.get_feature_name() == ["test_col", "num_col"]
+    assert ds.get_label().tolist() == y
+
+    # Verify values are preserved
+    ref_df = pd.DataFrame({"test_col": values, "num_col": [4.0, 5.0, 6.0]})
+    ref_ds = lgb.Dataset(ref_df, label=y, params={"min_data_in_bin": 1})
+    ref_ds.construct()
+
+    assert_datasets_equal(tmp_path, ds, ref_ds)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "values"),
+    [
+        (pd.StringDtype(), ["a", "b", "c"]),
+        (pd.DatetimeTZDtype(tz=ZoneInfo("UTC")), ["2020-01-01", "2020-01-02", "2020-01-03"]),
+        (pd.PeriodDtype(freq="Y"), [pd.Period("2024"), pd.Period("2025"), pd.Period("2026")]),
+        (pd.IntervalDtype(subtype="int64"), [pd.Interval(0, 1), pd.Interval(1, 2), pd.Interval(2, 3)]),
+    ],
+)
+def test_pandas_unsupported_dtypes(dtype, values):
+    df = pd.DataFrame({"test_col": pd.Series(values, dtype=dtype), "num_col": [1.0, 2.0, 3.0]})
+    y = [0, 1, 0]
+
+    with pytest.raises(ValueError, match="pandas dtypes must be int, float or bool"):
+        lgb.Dataset(df, label=y).construct()

--- a/tests/python_package_test/test_pandas.py
+++ b/tests/python_package_test/test_pandas.py
@@ -145,6 +145,7 @@ def test_pandas_categorical_code_conversion_doesnt_modify_original_data(feature_
         (pd.Float64Dtype(), [1.0, 2.0, 3.0]),
         (pd.BooleanDtype(), [True, False, True]),
         (pd.SparseDtype(), [1.0, 2.0, 3.0]),
+        # Categorical dtypes are supported, but tested separately
     ],
 )
 def test_pandas_supported_dtypes(tmp_path, dtype, values):

--- a/tests/python_package_test/test_pandas.py
+++ b/tests/python_package_test/test_pandas.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from zoneinfo import ZoneInfo
 
+import numpy as np
 import pytest
 
 import lightgbm as lgb
@@ -85,6 +86,45 @@ def test_pandas_categorical_encoding_unseen_category(tmp_path):
     ref_valid_ds.construct()
 
     assert_datasets_equal(tmp_path, valid_ds, ref_valid_ds)
+
+
+def test_dataset_construction_with_high_cardinality_categorical_succeeds(rng):
+    X = pd.DataFrame({"x1": rng.integers(low=0, high=5_000, size=(10_000,))})
+    y = rng.uniform(size=(10_000,))
+    ds = lgb.Dataset(X, y, categorical_feature=["x1"])
+    ds.construct()
+    assert ds.num_data() == 10_000
+    assert ds.num_feature() == 1
+
+
+@pytest.mark.parametrize("feature_name", [["x1"], [42], "auto"])
+@pytest.mark.parametrize("categories", ["seen", "unseen"])
+def test_categorical_code_conversion_doesnt_modify_original_data(feature_name, categories, rng):
+    X = rng.choice(a=["a", "b"], size=(100, 1))
+    column_name = "a" if feature_name == "auto" else feature_name[0]
+    df = pd.DataFrame(X.copy(), columns=[column_name], dtype="category")
+    if categories == "seen":
+        pandas_categorical = [["a", "b"]]
+    else:
+        pandas_categorical = [["a"]]
+    data = lgb.basic._data_from_pandas(
+        data=df,
+        feature_name=feature_name,
+        categorical_feature="auto",
+        pandas_categorical=pandas_categorical,
+    )[0]
+    # check that the original data wasn't modified
+    np.testing.assert_equal(df[column_name], X[:, 0])
+    # check that the built data has the codes
+    if categories == "seen":
+        # if all categories were seen during training we just take the codes
+        codes = df[column_name].cat.codes
+    else:
+        # if we only saw 'a' during training we just replace its code
+        # and leave the rest as nan
+        a_code = df[column_name].cat.categories.get_loc("a")
+        codes = np.where(df[column_name] == "a", a_code, np.nan)
+    np.testing.assert_equal(codes, data[:, 0])
 
 
 # ---------------------------------------- DTYPE VALIDATION --------------------------------------- #

--- a/tests/python_package_test/test_pandas.py
+++ b/tests/python_package_test/test_pandas.py
@@ -88,7 +88,7 @@ def test_pandas_categorical_encoding_unseen_category(tmp_path):
     assert_datasets_equal(tmp_path, valid_ds, ref_valid_ds)
 
 
-def test_dataset_construction_with_high_cardinality_categorical_succeeds(rng):
+def test_pandas_dataset_construction_with_high_cardinality_categorical_succeeds(rng):
     X = pd.DataFrame({"x1": rng.integers(low=0, high=5_000, size=(10_000,))})
     y = rng.uniform(size=(10_000,))
     ds = lgb.Dataset(X, y, categorical_feature=["x1"])
@@ -99,7 +99,7 @@ def test_dataset_construction_with_high_cardinality_categorical_succeeds(rng):
 
 @pytest.mark.parametrize("feature_name", [["x1"], [42], "auto"])
 @pytest.mark.parametrize("categories", ["seen", "unseen"])
-def test_categorical_code_conversion_doesnt_modify_original_data(feature_name, categories, rng):
+def test_pandas_categorical_code_conversion_doesnt_modify_original_data(feature_name, categories, rng):
     X = rng.choice(a=["a", "b"], size=(100, 1))
     column_name = "a" if feature_name == "auto" else feature_name[0]
     df = pd.DataFrame(X.copy(), columns=[column_name], dtype="category")

--- a/tests/python_package_test/test_pandas.py
+++ b/tests/python_package_test/test_pandas.py
@@ -97,12 +97,18 @@ def test_pandas_dataset_construction_with_high_cardinality_categorical_succeeds(
     assert ds.num_feature() == 1
 
 
-@pytest.mark.parametrize("feature_name", [["x1"], [42], "auto"])
+@pytest.mark.parametrize(
+    "feature_name",
+    [
+        pytest.param(["x1"], id="feature-name"),
+        pytest.param([42], id="feature-index"),
+        pytest.param("auto", id="auto"),
+    ],
+)
 @pytest.mark.parametrize("categories", ["seen", "unseen"])
 def test_pandas_categorical_code_conversion_doesnt_modify_original_data(feature_name, categories, rng):
     X = rng.choice(a=["a", "b"], size=(100, 1))
-    column_name = "a" if feature_name == "auto" else feature_name[0]
-    df = pd.DataFrame(X.copy(), columns=[column_name], dtype="category")
+    df = pd.DataFrame(X.copy(), columns=["x1"], dtype="category")
     if categories == "seen":
         pandas_categorical = [["a", "b"]]
     else:
@@ -114,16 +120,16 @@ def test_pandas_categorical_code_conversion_doesnt_modify_original_data(feature_
         pandas_categorical=pandas_categorical,
     )[0]
     # check that the original data wasn't modified
-    np.testing.assert_equal(df[column_name], X[:, 0])
+    np.testing.assert_equal(df["x1"], X[:, 0])
     # check that the built data has the codes
     if categories == "seen":
         # if all categories were seen during training we just take the codes
-        codes = df[column_name].cat.codes
+        codes = df["x1"].cat.codes
     else:
         # if we only saw 'a' during training we just replace its code
         # and leave the rest as nan
-        a_code = df[column_name].cat.categories.get_loc("a")
-        codes = np.where(df[column_name] == "a", a_code, np.nan)
+        a_code = df["x1"].cat.categories.get_loc("a")
+        codes = np.where(df["x1"] == "a", a_code, np.nan)
     np.testing.assert_equal(codes, data[:, 0])
 
 

--- a/tests/python_package_test/test_polars.py
+++ b/tests/python_package_test/test_polars.py
@@ -1,6 +1,4 @@
 # coding: utf-8
-import filecmp
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 import numpy as np
@@ -8,7 +6,7 @@ import pytest
 
 import lightgbm as lgb
 
-from .utils import np_assert_array_equal
+from .utils import assert_datasets_equal, np_assert_array_equal
 
 pl = pytest.importorskip("polars")
 
@@ -97,12 +95,6 @@ def dummy_dataset_params() -> Dict[str, Any]:
 # ----------------------------------------------------------------------------------------------- #
 
 # ------------------------------------------- DATASET ------------------------------------------- #
-
-
-def assert_datasets_equal(tmp_path: Path, lhs: lgb.Dataset, rhs: lgb.Dataset):
-    lhs._dump_text(tmp_path / "polars.txt")
-    rhs._dump_text(tmp_path / "pandas.txt")
-    assert filecmp.cmp(tmp_path / "polars.txt", tmp_path / "pandas.txt")
 
 
 @pytest.mark.parametrize(

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -1,8 +1,10 @@
 # coding: utf-8
+import filecmp
 import os
 import pickle
 from functools import lru_cache
 from inspect import getfullargspec
+from pathlib import Path
 
 import cloudpickle
 import joblib
@@ -277,3 +279,9 @@ class BuildInfo:
     has_cuda = os.getenv("TASK", "") == "cuda"
     has_gpu = os.getenv("TASK", "") == "gpu"
     has_mpi = os.getenv("TASK", "") == "mpi"
+
+
+def assert_datasets_equal(tmp_path: Path, lhs: lgb.Dataset, rhs: lgb.Dataset) -> None:
+    lhs._dump_text(tmp_path / "lhs.txt")
+    rhs._dump_text(tmp_path / "rhs.txt")
+    assert filecmp.cmp(tmp_path / "lhs.txt", tmp_path / "rhs.txt")


### PR DESCRIPTION
See https://github.com/lightgbm-org/LightGBM/pull/7343#discussion_r3564868781

This PR introduces pandas-specific tests for **categorical handling** and **dtype validation**. This serves two purposes:
- Detect breaking changes for pandas when implementing dataframe backend-agnosic categorical handling (#7343)
- Reduce reviewing effort by acting as a blueprint for future polars/pyarrow tests

Additionally, two tests in `test_basic.py` are directly about pandas categorical handling. These are also moved to test_pandas.py.
