### PR TITLE
[c++] validate child and split feature indices when loading text models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,6 +701,7 @@ if(BUILD_CPP_TEST)
       tests/cpp_tests/test_chunked_array.cpp
       tests/cpp_tests/test_common.cpp
       tests/cpp_tests/test_main.cpp
+      tests/cpp_tests/test_model_load.cpp
       tests/cpp_tests/test_serialize.cpp
       tests/cpp_tests/test_single_row.cpp
       tests/cpp_tests/test_stream.cpp

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -283,6 +283,11 @@ class Tree {
 
   void RecomputeMaxDepth();
 
+  /*! \brief Check that child and split feature indices read from a text model
+   *  are in range, to reject malformed models instead of accessing memory
+   *  out of bounds during prediction. */
+  void ValidateStructure(int num_features) const;
+
   int NextLeafId() const { return num_leaves_; }
 
   /*! \brief Get the linear model constant term (bias) of one leaf */

--- a/include/LightGBM/utils/openmp_wrapper.h
+++ b/include/LightGBM/utils/openmp_wrapper.h
@@ -58,7 +58,9 @@ class ThreadExceptionHelper {
   }
   void ReThrow() {
     if (ex_ptr_ != nullptr) {
-      std::rethrow_exception(ex_ptr_);
+      auto ex_ptr = ex_ptr_;
+      ex_ptr_ = nullptr;
+      std::rethrow_exception(ex_ptr);
     }
   }
   void CaptureException() {

--- a/src/boosting/gbdt_model_text.cpp
+++ b/src/boosting/gbdt_model_text.cpp
@@ -540,6 +540,7 @@ bool GBDT::LoadModelFromString(const char* buffer, size_t len) {
           p = Common::SkipNewLine(p);
           size_t used_len = 0;
           models_.emplace_back(new Tree(p, &used_len));
+          models_.back()->ValidateStructure(max_feature_idx_ + 1);
           p += used_len;
         } else {
           break;
@@ -567,6 +568,7 @@ bool GBDT::LoadModelFromString(const char* buffer, size_t len) {
         cur_p = Common::SkipNewLine(cur_p);
         size_t used_len = 0;
         models_[i].reset(new Tree(cur_p, &used_len));
+        models_[i]->ValidateStructure(max_feature_idx_ + 1);
       } else {
         Log::Fatal("Model format error, expect a tree here. met %s", cur_line.c_str());
       }

--- a/src/io/tree.cpp
+++ b/src/io/tree.cpp
@@ -1057,4 +1057,69 @@ void Tree::RecomputeMaxDepth() {
   }
 }
 
+void Tree::ValidateStructure(int num_features) const {
+  for (int i = 0; i < num_leaves_ - 1; ++i) {
+    for (int child : {left_child_[i], right_child_[i]}) {
+      // a child is either a leaf, encoded as ~leaf_index with
+      // leaf_index in [0, num_leaves_), or an internal node index;
+      // index 0 is the root and can never be a child
+      bool is_leaf_ref = (child < 0) && (child >= -num_leaves_);
+      bool is_internal_ref = (child > 0) && (child < num_leaves_ - 1);
+      if (!is_leaf_ref && !is_internal_ref) {
+        Log::Fatal("Tree model string format error, child index out of range: %d", child);
+      }
+    }
+    if (split_feature_[i] < 0 || split_feature_[i] >= num_features) {
+      Log::Fatal("Tree model string format error, split_feature out of range: %d", split_feature_[i]);
+    }
+  }
+
+  // the internal nodes must form a valid tree: no cycles, no node with
+  // multiple parents, and every node reachable from the root
+  if (num_leaves_ > 1) {
+    // 0 = unvisited, 1 = on the current path, 2 = fully processed
+    std::vector<int8_t> state(num_leaves_ - 1, 0);
+    std::vector<std::pair<int, int>> stack;
+    stack.emplace_back(0, 0);
+    state[0] = 1;
+    while (!stack.empty()) {
+      int node = stack.back().first;
+      int phase = stack.back().second;
+      if (phase == 2) {
+        state[node] = 2;
+        stack.pop_back();
+        continue;
+      }
+      stack.back().second = phase + 1;
+      int child = (phase == 0) ? left_child_[node] : right_child_[node];
+      if (child >= 0) {
+        if (state[child] == 1) {
+          Log::Fatal("Tree model string format error, cycle detected at internal node %d", child);
+        }
+        if (state[child] == 2) {
+          Log::Fatal("Tree model string format error, internal node %d has multiple parents", child);
+        }
+        state[child] = 1;
+        stack.emplace_back(child, 0);
+      }
+    }
+    for (int i = 0; i < num_leaves_ - 1; ++i) {
+      if (state[i] == 0) {
+        Log::Fatal("Tree model string format error, internal node %d is not reachable from the root", i);
+      }
+    }
+  }
+
+  if (is_linear_) {
+    // linear leaf models index into the feature vector at prediction time
+    for (int leaf = 0; leaf < num_leaves_; ++leaf) {
+      for (int feat : leaf_features_[leaf]) {
+        if (feat < 0 || feat >= num_features) {
+          Log::Fatal("Tree model string format error, leaf_features out of range: %d", feat);
+        }
+      }
+    }
+  }
+}
+
 }  // namespace LightGBM

--- a/tests/cpp_tests/test_model_load.cpp
+++ b/tests/cpp_tests/test_model_load.cpp
@@ -1,0 +1,156 @@
+/*!
+ * Copyright (c) 2026 The LightGBM developers. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for license information.
+ */
+
+#include <gtest/gtest.h>
+#include <LightGBM/c_api.h>
+
+#include <string>
+
+namespace {
+
+std::string MakeTreeSection(const std::string& left_child, const std::string& right_child,
+                            const std::string& split_feature) {
+  return
+      "Tree=0\n"
+      "num_leaves=3\n"
+      "num_cat=0\n"
+      "split_feature=" + split_feature + "\n"
+      "split_gain=1 1\n"
+      "threshold=0.5 0.5\n"
+      "decision_type=2 2\n"
+      "left_child=" + left_child + "\n"
+      "right_child=" + right_child + "\n"
+      "leaf_value=0.1 0.2 0.3\n"
+      "leaf_weight=1 1 1\n"
+      "\n";
+}
+
+std::string MakeModel(const std::string& left_child, const std::string& right_child,
+                      const std::string& split_feature, bool with_tree_sizes = false) {
+  std::string tree_section = MakeTreeSection(left_child, right_child, split_feature);
+  std::string model =
+      "tree\n"
+      "version=v4\n"
+      "num_class=1\n"
+      "num_tree_per_iteration=1\n"
+      "label_index=0\n"
+      "max_feature_idx=2\n"
+      "objective=regression\n"
+      "feature_names=f0 f1 f2\n"
+      "feature_infos=[0:1] [0:1] [0:1]\n";
+  if (with_tree_sizes) {
+    model += "tree_sizes=" + std::to_string(tree_section.size()) + "\n";
+  }
+  model += "\n" + tree_section + "end of trees\n";
+  return model;
+}
+
+std::string MakeLinearModel(const std::string& leaf_features) {
+  std::string model =
+      "tree\n"
+      "version=v4\n"
+      "num_class=1\n"
+      "num_tree_per_iteration=1\n"
+      "label_index=0\n"
+      "max_feature_idx=2\n"
+      "objective=regression\n"
+      "feature_names=f0 f1 f2\n"
+      "feature_infos=[0:1] [0:1] [0:1]\n"
+      "\n"
+      "Tree=0\n"
+      "num_leaves=3\n"
+      "num_cat=0\n"
+      "split_feature=0 1\n"
+      "split_gain=1 1\n"
+      "threshold=0.5 0.5\n"
+      "decision_type=2 2\n"
+      "left_child=1 -1\n"
+      "right_child=-2 -3\n"
+      "leaf_value=0.1 0.2 0.3\n"
+      "leaf_weight=1 1 1\n"
+      "is_linear=1\n"
+      "leaf_const=0.01 0.02 0.03\n"
+      "num_features=2 1 1\n"
+      "leaf_features=" + leaf_features + "\n"
+      "leaf_coeff=0.5 0.5 0.5 0.5\n"
+      "\n"
+      "end of trees\n";
+  return model;
+}
+
+int LoadModel(const std::string& model_text, BoosterHandle* out) {
+  int num_iterations = 0;
+  return LGBM_BoosterLoadModelFromString(model_text.c_str(), &num_iterations, out);
+}
+
+void ExpectLoadError(const std::string& model_text, const std::string& error_substr) {
+  BoosterHandle booster = nullptr;
+  int result = LoadModel(model_text, &booster);
+  EXPECT_NE(0, result) << "model unexpectedly loaded";
+  std::string error = LGBM_GetLastError();
+  EXPECT_NE(std::string::npos, error.find(error_substr))
+      << "expected error containing '" << error_substr << "', got: " << error;
+}
+
+}  // namespace
+
+TEST(ModelLoad, ValidTextModelLoads) {
+  BoosterHandle booster = nullptr;
+  int result = LoadModel(MakeModel("1 -1", "-2 -3", "0 1"), &booster);
+  ASSERT_EQ(0, result) << LGBM_GetLastError();
+  EXPECT_EQ(0, LGBM_BoosterFree(booster));
+}
+
+TEST(ModelLoad, RejectsOutOfRangeLeftChildIndex) {
+  // the first variant is the out-of-bounds write case from the security report
+  for (const std::string left_child : {"-1000000000 -1", "1000000000 -1", "0 -1"}) {
+    ExpectLoadError(MakeModel(left_child, "-2 -3", "0 1"), "child index out of range");
+  }
+}
+
+TEST(ModelLoad, RejectsOutOfRangeRightChildIndex) {
+  ExpectLoadError(MakeModel("1 -1", "-2000000000 -3", "0 1"), "child index out of range");
+}
+
+TEST(ModelLoad, RejectsOutOfRangeSplitFeature) {
+  // the huge positive variant is the out-of-bounds read case from the security report
+  for (const std::string split_feature : {"2000000000 1", "-1 1"}) {
+    ExpectLoadError(MakeModel("1 -1", "-2 -3", split_feature), "split_feature out of range");
+  }
+}
+
+TEST(ModelLoad, RejectsOutOfRangeChildIndexWithTreeSizes) {
+  // same rejection must happen via the parallel loading path used when the
+  // model file contains tree_sizes, and must return an error (not abort)
+  ExpectLoadError(MakeModel("-1000000000 -1", "-2 -3", "0 1", true), "child index out of range");
+  ExpectLoadError(MakeModel("1 -1", "-2 -3", "2000000000 1", true), "split_feature out of range");
+}
+
+TEST(ModelLoad, RejectsCyclicTree) {
+  // node 1 splits on itself
+  ExpectLoadError(MakeModel("1 1", "-2 -3", "0 1"), "cycle detected");
+}
+
+TEST(ModelLoad, RejectsNodeWithMultipleParents) {
+  // node 1 is the left and the right child of the root
+  ExpectLoadError(MakeModel("1 -1", "1 -2", "0 1"), "multiple parents");
+}
+
+TEST(ModelLoad, RejectsUnreachableNode) {
+  // node 1 is never referenced as a child
+  ExpectLoadError(MakeModel("-1 -1", "-2 -2", "0 1"), "not reachable");
+}
+
+TEST(ModelLoad, ValidLinearModelLoads) {
+  BoosterHandle booster = nullptr;
+  int result = LoadModel(MakeLinearModel("0 1 2 0"), &booster);
+  ASSERT_EQ(0, result) << LGBM_GetLastError();
+  EXPECT_EQ(0, LGBM_BoosterFree(booster));
+}
+
+TEST(ModelLoad, RejectsOutOfRangeLeafFeatures) {
+  ExpectLoadError(MakeLinearModel("2000000000 1 2 0"), "leaf_features out of range");
+  ExpectLoadError(MakeLinearModel("-1 1 2 0"), "leaf_features out of range");
+}


### PR DESCRIPTION
### Description

Fixes #7357 (GHSA-wvg4-4w35-4jc9).

The text model parser checks the *length* of `left_child` / `right_child` / `split_feature` but never validates the *values*, which are later used as array indices: `RecomputeLeafDepths` (via SHAP / `predict_contrib`) writes `leaf_depth_[~child]` with an attacker-controlled index (OOB write), and the `Decision()` hot path reads `feature_values[split_feature_[node]]` (OOB read).

Changes:

1. Add `Tree::ValidateStructure(num_features)` and call it for every tree loaded from a text model (both paths in `GBDT::LoadModelFromString`). A child must be a valid leaf reference (`~leaf` with leaf in `[0, num_leaves)`) or an internal node index (index 0 is the root and can never be a child); `split_feature` must be within the model's feature count. Malformed models are rejected with `Tree model string format error, child index out of range: ...`, same style as the existing format errors.

2. Fix `ThreadExceptionHelper::ReThrow()` so the rejection actually surfaces instead of aborting. It rethrew without clearing the stored exception, and the destructor rethrew it again during unwinding → `std::terminate` for any parse error on the `tree_sizes` (parallel) path, which is what all LightGBM-produced models use. It now clears the pointer before rethrowing; malformed models return a catchable error / C API error code. This also fixes the same abort for pre-existing parse errors like "expect a tree here".

Verified on current main before the fix: `left_child=-1000000000` with `predict_contrib=true` segfaults in `Tree::RecomputeLeafDepths` (confirmed in gdb), `split_feature=2000000000` with plain `predict` segfaults. After the fix both are rejected at load time, via the CLI and the C API.

Tests: new `tests/cpp_tests/test_model_load.cpp` (valid model; out-of-range left/right child; root-as-child; out-of-range split feature; with and without `tree_sizes`). Full `testlightgbm` suite passes (39/39).
