### PR TITLE
Fix CUDA quantisation buffer overflow and reduction typo

### DIFF
--- a/src/treelearner/cuda/cuda_gradient_discretizer.cu
+++ b/src/treelearner/cuda/cuda_gradient_discretizer.cu
@@ -72,9 +72,10 @@ __global__ void ReduceBlockMinMaxKernel(
   __syncthreads();
   grad_max_val = ShuffleReduceMax<score_t>(grad_max_val, shared_mem_buffer, blockDim.x);
   __syncthreads();
-  hess_max_val = ShuffleReduceMax<score_t>(hess_max_val, shared_mem_buffer, blockDim.x);
+  hess_min_val = ShuffleReduceMin<score_t>(hess_min_val, shared_mem_buffer, blockDim.x);
   __syncthreads();
   hess_max_val = ShuffleReduceMax<score_t>(hess_max_val, shared_mem_buffer, blockDim.x);
+  
   if (threadIdx.x == 0) {
     const score_t grad_abs_max = max(fabs(grad_min_val), fabs(grad_max_val));
     const score_t hess_abs_max = max(fabs(hess_min_val), fabs(hess_max_val));

--- a/src/treelearner/cuda/cuda_gradient_discretizer.hpp
+++ b/src/treelearner/cuda/cuda_gradient_discretizer.hpp
@@ -58,7 +58,7 @@ class CUDAGradientDiscretizer: public GradientDiscretizer, public NCCLInfo {
   void Init(const data_size_t num_data, const int num_leaves,
     const int num_features, const Dataset* train_data) override {
     GradientDiscretizer::Init(num_data, num_leaves, num_features, train_data);
-    discretized_gradients_and_hessians_.Resize(num_data * 2);
+    discretized_gradients_and_hessians_.Resize(num_data * 4);
     num_reduce_blocks_ = (num_data + CUDA_GRADIENT_DISCRETIZER_BLOCK_SIZE - 1) / CUDA_GRADIENT_DISCRETIZER_BLOCK_SIZE;
     grad_min_block_buffer_.Resize(num_reduce_blocks_);
     grad_max_block_buffer_.Resize(num_reduce_blocks_);


### PR DESCRIPTION
**Summary**
This PR fixes two critical bugs in the CUDA gradient discretiser that cause the engine to immediately throw an `illegal memory access` segmentation fault when `use_quantized_grad=true` is passed to the CUDA backend.

**Bug 1: Buffer Overflow in `cuda_gradient_discretizer.hpp`**
The `discretized_gradients_and_hessians_` array is typed as a `CUDAVector<int8_t>`. In the `Init` method, it was incorrectly allocated using `Resize(num_data * 2)`. However, the CUDA kernel casts this pointer to `int16_t*` and packs two values per index (gradient and Hessian), requiring 4 bytes per row. The 2x sizing causes a 100% buffer overflow. This has been updated to `Resize(num_data * 4)`.

**Bug 2: Copy-Paste Typo in `cuda_gradient_discretizer.cu`**
Inside `ReduceBlockMinMaxKernel`, `hess_max_val = ShuffleReduceMax` was called twice sequentially. The reduction for `hess_min_val` using `ShuffleReduceMin` was completely omitted, resulting in corrupted Hessian scaling values across the warp. This has been corrected.