### PR TITLE
[c++] Fix \param names that do not match the signatures

### DIFF
--- a/src/boosting/dart.hpp
+++ b/src/boosting/dart.hpp
@@ -37,7 +37,6 @@ class DART: public GBDT {
   * \param train_data Training data
   * \param objective_function Training objective function
   * \param training_metrics Training metrics
-  * \param output_model_filename Filename of output model
   */
   void Init(const Config* config, const Dataset* train_data,
             const ObjectiveFunction* objective_function,

--- a/src/treelearner/data_partition.hpp
+++ b/src/treelearner/data_partition.hpp
@@ -98,7 +98,7 @@ class DataPartition {
   * \param dataset dataset that holds the bin data
   * \param feature index of the feature to split on
   * \param threshold threshold that want to split
-  * \param num_threshold number of thresholds
+  * \param num_threshold number of "words" in the bitset for categorical features, 1 for continuous features
   * \param default_left whether missing values go to the left leaf
   * \param right_leaf index of right leaf
   */

--- a/src/treelearner/data_partition.hpp
+++ b/src/treelearner/data_partition.hpp
@@ -82,8 +82,8 @@ class DataPartition {
   /*!
   * \brief Get the data indices of one leaf
   * \param leaf index of leaf
-  * \param indices output data indices
-  * \return number of data on this leaf
+  * \param out_len number of data on this leaf
+  * \return the data indices of this leaf
   */
   const data_size_t* GetIndexOnLeaf(int leaf, data_size_t* out_len) const {
     // copy reference, maybe unsafe, but faster
@@ -95,8 +95,11 @@ class DataPartition {
   /*!
   * \brief Split the data
   * \param leaf index of leaf
-  * \param feature_bins feature bin data
+  * \param dataset dataset that holds the bin data
+  * \param feature index of the feature to split on
   * \param threshold threshold that want to split
+  * \param num_threshold number of thresholds
+  * \param default_left whether missing values go to the left leaf
   * \param right_leaf index of right leaf
   */
   void Split(int leaf, const Dataset* dataset, int feature,

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -56,7 +56,7 @@ class FeatureHistogram {
    * \brief Init the feature histogram
    * \param data the histogram data for this feature
    * \param data_int16 the 16-bit histogram data for this feature (used for quantized training via 'use_quantized_grad')
-   * \param meta pointer to a FeatureMetaInfo object for this feature, with details like how missing values are handled, and a pointer to the Config object with parameters
+   * \param meta pointer to a FeatureMetaInfo object for this feature, with details like how missing values are handled and a pointer to the Config object with parameters
    */
   void Init(hist_t* data, int16_t* data_int16, const FeatureMetainfo* meta) {
     meta_ = meta;
@@ -68,7 +68,7 @@ class FeatureHistogram {
   /*!
    * \brief Init the feature histogram
    * \param data the histogram data for this feature
-   * \param meta pointer to a FeatureMetaInfo object for this feature, with details like how missing values are handled, and a pointer to the Config object with parameters
+   * \param meta pointer to a FeatureMetaInfo object for this feature, with details like how missing values are handled and a pointer to the Config object with parameters
    */
   void Init(hist_t* data, const FeatureMetainfo* meta) {
     meta_ = meta;

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -55,8 +55,8 @@ class FeatureHistogram {
   /*!
    * \brief Init the feature histogram
    * \param data the histogram data for this feature
-   * \param data_int16 the 16-bit histogram data for this feature
-   * \param meta the meta information of this feature
+   * \param data_int16 the 16-bit histogram data for this feature (used for quantized training via 'use_quantized_grad')
+   * \param meta pointer to a FeatureMetaInfo object for this feature, with details like how missing values are handled, and a pointer to the Config object with parameters
    */
   void Init(hist_t* data, int16_t* data_int16, const FeatureMetainfo* meta) {
     meta_ = meta;
@@ -68,7 +68,7 @@ class FeatureHistogram {
   /*!
    * \brief Init the feature histogram
    * \param data the histogram data for this feature
-   * \param meta the meta information of this feature
+   * \param meta pointer to a FeatureMetaInfo object for this feature, with details like how missing values are handled, and a pointer to the Config object with parameters
    */
   void Init(hist_t* data, const FeatureMetainfo* meta) {
     meta_ = meta;

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -54,8 +54,9 @@ class FeatureHistogram {
 
   /*!
    * \brief Init the feature histogram
-   * \param feature the feature data for this histogram
-   * \param min_num_data_one_leaf minimal number of data in one leaf
+   * \param data the histogram data for this feature
+   * \param data_int16 the 16-bit histogram data for this feature
+   * \param meta the meta information of this feature
    */
   void Init(hist_t* data, int16_t* data_int16, const FeatureMetainfo* meta) {
     meta_ = meta;
@@ -66,8 +67,8 @@ class FeatureHistogram {
 
   /*!
    * \brief Init the feature histogram
-   * \param feature the feature data for this histogram
-   * \param min_num_data_one_leaf minimal number of data in one leaf
+   * \param data the histogram data for this feature
+   * \param meta the meta information of this feature
    */
   void Init(hist_t* data, const FeatureMetainfo* meta) {
     meta_ = meta;


### PR DESCRIPTION
Five Doxygen blocks name parameters the functions do not take. Doxygen silently drops a `\param` whose name is not in the signature, so in each case the documented parameter disappears from the generated docs and the real parameters are left undocumented.

- `DART::Init` still documents `output_model_filename`. The parameter is gone from the signature (and from the `Boosting::Init` interface it overrides); this was the only reference left in the tree.
- `DataPartition::GetIndexOnLeaf` documents `indices` as a parameter and describes the count as the return value. It is the other way round: `out_len` is the output parameter and the indices are returned.
- `DataPartition::Split` documents `feature_bins`, which does not exist, while `dataset`, `feature`, `num_threshold` and `default_left` had no entry at all.
- Both `FeatureHistogram::Init` overloads document `feature` and `min_num_data_one_leaf` instead of `data`, `data_int16` and `meta`.

Comments only — no functional change. I checked each signature and the call sites before rewording, and kept the wording in the style already used around them.
