### PR TITLE
[R-package] [docs] [ci] re-render with {roxygen2} 8.1.0, update pixi download URL, avoid free-threaded CPython in conda-based CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,8 @@ install:
   - git submodule update --init --recursive  # get `external_libs` folder
   - set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH%
   - set PYTHON_VERSION=%CONFIGURATION%
-  - powershell.exe -ExecutionPolicy ByPass -c "Invoke-RestMethod https://pixi.sh/install.ps1 | Invoke-Expression"
+  # yamllint disable-line rule:line-length
+  - powershell.exe -ExecutionPolicy ByPass -c "Invoke-RestMethod https://pixi.prefix.dev/install.ps1 | Invoke-Expression"
   - set PATH=C:\Users\appveyor\.pixi\bin;%PATH%
   - ps: |
       $env:APPVEYOR = "true"

--- a/.ci/test-windows.ps1
+++ b/.ci/test-windows.ps1
@@ -80,7 +80,21 @@ if ($env:PYTHON_VERSION -eq "3.10") {
     conda config --add channels nodefaults ; Assert-Output $?
     conda config --add channels conda-forge ; Assert-Output $?
     conda config --set channel_priority strict ; Assert-Output $?
-    conda install -q -y conda "python=$env:PYTHON_VERSION[build=*_cp*]" ; Assert-Output $?
+
+    # From Python 3.13 onwards, CPython packages on conda-forge have build strings
+    # with formats like "*_cp314".
+    #
+    # Have to be specific here (no trailing wildcard) to avoid unintentionally pulling
+    # in free-threaded builds (e.g. "*_cp314t").
+    $PythonMajorVersion, $PythonMinorVersion = $env:PYTHON_VERSION.Split(".")
+    if ([int]$PythonMajorVersion -gt 3 -or ([int]$PythonMajorVersion -eq 3 -and [int]$PythonMinorVersion -gt 12)) {
+        $env:PYTHON_ABI_TAG = "cp$($env:PYTHON_VERSION -replace '\.', '')"
+    } else {
+        $env:PYTHON_ABI_TAG = "cpython"
+    }
+    $env:CONDA_PYTHON_REQUIREMENT = "python=$env:PYTHON_VERSION[build=*_$env:PYTHON_ABI_TAG]"
+
+    conda install -q -y conda "$env:CONDA_PYTHON_REQUIREMENT" ; Assert-Output $?
 
     # print output of 'conda info', to help in submitting bug reports
     Write-Output "conda info:"
@@ -93,7 +107,7 @@ if ($env:PYTHON_VERSION -eq "3.10") {
         "-y",
         "-n", "$env:CONDA_ENV",
         "--file", "$env:CONDA_REQUIREMENT_FILE",
-        "python=$env:PYTHON_VERSION[build=*_cp*]"
+        "$env:CONDA_PYTHON_REQUIREMENT"
     )
     conda create @condaParams ; Assert-Output $?
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -83,9 +83,19 @@ if [[ "$TASK" == "cpp-tests" ]]; then
     exit 0
 fi
 
-# including python=version=[build=*_cp*] to ensure that conda prefers CPython and doesn't fall back to
-# other implementations like pypy
-CONDA_PYTHON_REQUIREMENT="python=${PYTHON_VERSION}[build=*_cp*]"
+# From Python 3.13 onwards, CPython packages on conda-forge have build strings
+# with formats like "*_cp314".
+#
+# Have to be specific here (no trailing wildcard) to avoid unintentionally pulling
+# in free-threaded builds (e.g. "*_cp314t").
+PYTHON_MAJOR_VERSION="${PYTHON_VERSION%%.*}"
+PYTHON_MINOR_VERSION="${PYTHON_VERSION#*.}"
+if (( PYTHON_MAJOR_VERSION > 3 || (PYTHON_MAJOR_VERSION == 3 && PYTHON_MINOR_VERSION > 12) )); then
+    PYTHON_ABI_TAG="cp${PYTHON_VERSION//./}"
+else
+    PYTHON_ABI_TAG="cpython"
+fi
+CONDA_PYTHON_REQUIREMENT="python=${PYTHON_VERSION}[build=*_${PYTHON_ABI_TAG}]"
 
 if [[ $TASK == "if-else" ]]; then
     conda create -q -y -n "${CONDA_ENV}" "${CONDA_PYTHON_REQUIREMENT}" numpy

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -63,4 +63,4 @@ Imports:
     utils
 SystemRequirements:
     C++17
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/R-package/NAMESPACE
+++ b/R-package/NAMESPACE
@@ -46,21 +46,29 @@ importClassesFrom(Matrix,dsparseMatrix)
 importClassesFrom(Matrix,dsparseVector)
 importFrom(Matrix,Matrix)
 importFrom(R6,R6Class)
-importFrom(data.table,":=")
-importFrom(data.table,as.data.table)
-importFrom(data.table,data.table)
-importFrom(data.table,rbindlist)
-importFrom(data.table,set)
-importFrom(data.table,setnames)
-importFrom(data.table,setorder)
-importFrom(data.table,setorderv)
-importFrom(graphics,barplot)
-importFrom(graphics,par)
+importFrom(data.table,
+  ":=",
+  as.data.table,
+  data.table,
+  rbindlist,
+  set,
+  setnames,
+  setorder,
+  setorderv
+)
+importFrom(graphics,
+  barplot,
+  par
+)
 importFrom(jsonlite,fromJSON)
-importFrom(methods,is)
-importFrom(methods,new)
+importFrom(methods,
+  is,
+  new
+)
 importFrom(parallel,detectCores)
 importFrom(stats,quantile)
-importFrom(utils,modifyList)
-importFrom(utils,read.delim)
+importFrom(utils,
+  modifyList,
+  read.delim
+)
 useDynLib(lightgbm , .registration = TRUE)

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -13,7 +13,7 @@ dependencies:
   - r-markdown=2.0
   - r-matrix=1.7_4
   - r-pkgdown=2.2.0
-  - r-roxygen2=8.0.0
+  - r-roxygen2>=8.0.0,<8.2
   - scikit-learn>=1.8.0
   - sphinx>=8.1.3
   - sphinx_rtd_theme>=3.0.1


### PR DESCRIPTION
Fixes #7387 

The latest `{roxygen2}` release broke CI here, because rendering with it results in changes to the `NAMESPACE` file.

Posit folks claim in https://opensource.posit.co/blog/2026-08-04_roxygen2-8-1-0/#merged-importfrom-directives that grouping imports into 1 `importFrom` per library makes library-loading time faster 🤷🏻 

This fixes it by re-rendering with `{roxygen2}` 8.1.0.

Contributes to https://github.com/lightgbm-org/LightGBM/issues/7391

* pins Python in conda environments to non-free-threaded CPython