### PR TITLE
[ci] [R-package] replace version placeholders before docs build

### DIFF
--- a/.ci/build-docs.R
+++ b/.ci/build-docs.R
@@ -1,19 +1,46 @@
-loadNamespace("pkgdown")
-loadNamespace("roxygen2")
+build_docs <- function() {
+    loadNamespace("pkgdown")
+    loadNamespace("roxygen2")
 
-roxygen2::roxygenize(
-    "R-package/"
-    , load = "installed"
-)
+    description_path <- file.path("R-package", "DESCRIPTION")
+    description_contents <- readLines(description_path)
+    on.exit(writeLines(description_contents, description_path), add = TRUE)
 
-pkgdown::build_site(
-    "R-package/"
-    , lazy = FALSE
-    , install = FALSE
-    , devel = FALSE
-    , examples = TRUE
-    , run_dont_run = TRUE
-    , seed = 42L
-    , preview = FALSE
-    , new_process = TRUE
-)
+    lgb_version <- readLines("VERSION.txt", n = 1L)
+    lgb_version <- gsub("rc", "-", lgb_version, fixed = TRUE)
+    docs_description <- gsub(
+        "~~VERSION~~"
+        , lgb_version
+        , description_contents
+        , fixed = TRUE
+    )
+    docs_description <- gsub(
+        "~~DATE~~"
+        , as.character(Sys.Date())
+        , docs_description
+        , fixed = TRUE
+    )
+    if (any(grepl("~~(VERSION|DATE)~~", docs_description))) {
+        stop("Failed to replace placeholders in R-package/DESCRIPTION")
+    }
+    writeLines(docs_description, description_path)
+
+    roxygen2::roxygenize(
+        "R-package/"
+        , load = "installed"
+    )
+
+    pkgdown::build_site(
+        "R-package/"
+        , lazy = FALSE
+        , install = FALSE
+        , devel = FALSE
+        , examples = TRUE
+        , run_dont_run = TRUE
+        , seed = 42L
+        , preview = FALSE
+        , new_process = TRUE
+    )
+}
+
+build_docs()


### PR DESCRIPTION
## Summary

- replace the `~~VERSION~~` and `~~DATE~~` placeholders before generating the R `pkgdown` site
- derive the documentation version from the repository's `VERSION.txt`, using the same `rc` conversion as the R package build
- restore the tracked `R-package/DESCRIPTION` contents after the build, including when documentation generation fails
- fail early if either placeholder survives substitution

## Root cause

The docs workflow installs a staged CRAN package whose `DESCRIPTION` placeholders have already been replaced, but `pkgdown::build_site()` reads metadata from the source `R-package/DESCRIPTION`. Since the docs refactor in #7268, that source file still contains `~~VERSION~~`, so the placeholder is rendered into the published R reference site.

Fixes #7383.

## Validation

- `git diff --check`
- locally simulated the fixed-string substitutions against `VERSION.txt` and verified neither placeholder remains

An R runtime is not available on this Windows machine, so the existing `r-package-check-docs` CI job remains the end-to-end validation of the R/pkgdown build.
