### PR TITLE
[c++] fix Booster.refit() segfault with linear_tree on single-class data

### DIFF
--- a/src/treelearner/linear_tree_learner.cpp
+++ b/src/treelearner/linear_tree_learner.cpp
@@ -138,6 +138,19 @@ Tree* LinearTreeLearner<TREE_LEARNER_TYPE>::Train(const score_t* gradients, cons
 template <typename TREE_LEARNER_TYPE>
 Tree* LinearTreeLearner<TREE_LEARNER_TYPE>::FitByExistingTree(const Tree* old_tree, const score_t* gradients, const score_t *hessians) const {
   auto tree = TREE_LEARNER_TYPE::FitByExistingTree(old_tree, gradients, hessians);
+  if (!old_tree->is_linear()) {
+    // old_tree was never trained as a linear tree -- e.g. a constant tree
+    // produced when the objective determined this class didn't need
+    // boosting (single-class data), which is built via the plain
+    // Tree(max_leaves, false, /*is_linear=*/false) placeholder and so
+    // never had its per-leaf linear-model arrays (leaf_features_,
+    // leaf_coeff_, leaf_const_) allocated. Forcing SetIsLinear(true) on
+    // it here would leave those arrays empty while CalculateLinear's
+    // is_refit path indexes into them (e.g. LeafFeatures()), reading
+    // past the end of a zero-length vector. Refit it as the constant
+    // tree it actually is instead.
+    return tree;
+  }
   bool has_nan = false;
   if (any_nan_) {
     for (int i = 0; i < tree->num_leaves() - 1 ; ++i) {

--- a/src/treelearner/linear_tree_learner.h
+++ b/src/treelearner/linear_tree_learner.h
@@ -42,6 +42,16 @@ class LinearTreeLearner: public TREE_LEARNER_TYPE {
   void AddPredictionToScore(const Tree* tree,
                             double* out_score) const override {
     CHECK_LE(tree->num_leaves(), this->data_partition_->num_leaves());
+    if (!tree->is_linear()) {
+      // tree was never trained as a linear tree (e.g. the constant
+      // placeholder built when a class doesn't need boosting), so its
+      // leaf_const_/leaf_coeff_ arrays were never allocated. Reading
+      // them here (via LeafConst/LeafCoeffs below) would index past the
+      // end of a zero-length vector. Fall back to the plain non-linear
+      // implementation, same as TREE_LEARNER_TYPE would use directly.
+      TREE_LEARNER_TYPE::AddPredictionToScore(tree, out_score);
+      return;
+    }
     bool has_nan = false;
     if (any_nan_) {
       for (int i = 0; i < tree->num_leaves() - 1 ; ++i) {

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -3926,6 +3926,36 @@ def test_linear_single_leaf():
     assert log_loss(y_train, y_pred) < 0.661
 
 
+def test_linear_refit_single_class_does_not_segfault(rng):
+    # a linear-tree model refit on data containing only one label class
+    # produces trees that were never actually trained as linear (the
+    # objective decides that class doesn't need boosting), which used to
+    # segfault refit() by reading un-allocated per-leaf linear-model
+    # arrays. See https://github.com/lightgbm-org/LightGBM/issues/6792.
+    X = rng.integers(low=0, high=10, size=(1_000, 5))
+    y = np.ones(shape=(X.shape[0],))
+    categorical_feature = list(range(X.shape[1]))
+
+    train_data = lgb.Dataset(X, label=y, categorical_feature=categorical_feature)
+    bst = lgb.train(
+        train_set=train_data,
+        params={"objective": "binary", "num_leaves": 7, "linear_tree": True, "verbose": -1},
+        num_boost_round=2,
+    )
+    # must not crash the process
+    refit_bst = bst.refit(X, label=y, categorical_feature=categorical_feature)
+    assert isinstance(refit_bst, lgb.Booster)
+    y_pred = refit_bst.predict(X)
+    assert np.all(np.isfinite(y_pred))
+
+    # those constant trees must stay non-linear, so that the (num_leaves <= 1
+    # && !is_linear) early return in Tree's model-string constructor still
+    # applies to them. Marking them linear instead makes the deserializer try
+    # to parse the legitimately-empty leaf_weight field and abort the process.
+    reloaded = lgb.Booster(model_str=refit_bst.model_to_string())
+    np.testing.assert_allclose(y_pred, reloaded.predict(X))
+
+
 def test_linear_raises_informative_errors_on_unsupported_params():
     X, y = make_synthetic_regression()
     with pytest.raises(lgb.basic.LightGBMError, match="Cannot use regression_l1 objective when fitting linear trees"):


### PR DESCRIPTION
## Summary

Fixes #6792 — `Booster.refit()` segfaults when the training label contains only one class and the model was trained with `linear_tree=True`.

## Root cause

When the label has a single class, the objective decides that class doesn't need boosting and LightGBM emits a plain constant tree, built through the `Tree(max_leaves, false, /*is_linear=*/false)` placeholder. Such a tree never has its per-leaf linear-model arrays (`leaf_features_`, `leaf_coeff_`, `leaf_const_`) allocated.

`LinearTreeLearner` treated those trees as linear regardless, giving two out-of-bounds reads with the same cause:

- `CalculateLinear()` unconditionally calls `SetIsLinear(true)`, then on the `is_refit` path reads `tree->LeafFeatures(i)` — indexing past the end of a zero-length vector.
- `AddPredictionToScore()` reads `LeafConst`/`LeafCoeffs` for the same trees.

Either one is enough to segfault the process during `refit()`.

## Fix

Check whether the tree is actually linear and fall back to the plain non-linear handling when it isn't, so a constant tree stays constant.

Keeping these trees non-linear also preserves the `(num_leaves <= 1 && !is_linear)` early return in `Tree`'s model-string constructor. Flagging them linear instead makes the deserializer parse the legitimately-empty `leaf_weight` field and abort with an uncaught `std::runtime_error`.

## Relation to #7378

#7378 targets the same issue by marking these trees linear and allocating the missing arrays. That path runs into the model-string problem described above: the resulting model aborts on deserialization rather than segfaulting, which trades one crash for another that is harder to attribute.

This PR takes the opposite direction — leave the constant tree non-linear — which keeps `model_to_string()` round-tripping. Happy to defer to #7378 or combine the two if maintainers prefer that shape; flagging the interaction so it isn't discovered after a merge.

## Testing

Added a regression test in `tests/python_package_test/test_engine.py` that refits a `linear_tree` model on single-class data and round-trips the result through `model_to_string()`, covering both the segfault and the deserialization abort.

Full Python suite on this branch: **1355 passed, 8 skipped, 12 xfailed, 4 xpassed**, matching the clean-tree baseline.
