### PR TITLE
[ci] [python-package] [R-package] sync versions from VERSION.txt

### DIFF
--- a/.ci/update-version.sh
+++ b/.ci/update-version.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
+#
+# [description]
+#     Update files in source control based on the content of 'VERSION.txt'.
+#
+# [usage]
+#
+#     update-version.sh
 
 set -e -u
 
@@ -16,17 +23,18 @@ update_file() {
     printf '%s\n' "${UPDATED_CONTENTS}" > "${TARGET_FILE}"
 }
 
-DESCRIPTION_FILE="./R-package/DESCRIPTION"
-CONFIGURE_AC_FILE="./R-package/configure.ac"
+update_file \
+    ./.appveyor.yml \
+    "s|^version: .*$|version: ${LGB_VERSION}.{build}|"
 
 update_file \
-    "${DESCRIPTION_FILE}" \
+    ./python-package/pyproject.toml \
+    "s|^version = \"[0-9a-z.]+\"$|version = \"${LGB_VERSION}\"|"
+
+update_file \
+    ./R-package/DESCRIPTION \
     "s|^Version: .*$|Version: ${LGB_VERSION}|"
-update_file \
-    "${CONFIGURE_AC_FILE}" \
-    "s|^AC_INIT.*$|AC_INIT([lightgbm], [${LGB_VERSION}], [], [lightgbm], [])|"
 
-grep -Fqx "Version: ${LGB_VERSION}" "${DESCRIPTION_FILE}"
-grep -Fqx \
-    "AC_INIT([lightgbm], [${LGB_VERSION}], [], [lightgbm], [])" \
-    "${CONFIGURE_AC_FILE}"
+update_file \
+    ./R-package/configure.ac \
+    "s|^AC_INIT.*$|AC_INIT([lightgbm], [${LGB_VERSION}], [], [lightgbm], [])|"

--- a/.ci/update-version.sh
+++ b/.ci/update-version.sh
@@ -1,33 +1,30 @@
-#!/bin/bash
+#!/bin/sh
 
-set -e -u -o pipefail
+set -e -u
 
-SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-REPO_ROOT=$(dirname "${SCRIPT_DIR}")
-LGB_VERSION=$(sed 's/rc/-/g' < "${REPO_ROOT}/VERSION.txt")
+LGB_VERSION=$(sed 's/rc/-/g' < ./VERSION.txt)
 
 if test -z "${LGB_VERSION}"; then
     echo "VERSION.txt must contain a version" >&2
     exit 1
 fi
 
-sed_in_place() {
-    if sed --version >/dev/null 2>&1; then
-        sed -E -i "$@"
-    else
-        sed -E -i '' "$@"
-    fi
+update_file() {
+    TARGET_FILE=$1
+    SED_EXPRESSION=$2
+    UPDATED_CONTENTS=$(sed "${SED_EXPRESSION}" "${TARGET_FILE}")
+    printf '%s\n' "${UPDATED_CONTENTS}" > "${TARGET_FILE}"
 }
 
-DESCRIPTION_FILE="${REPO_ROOT}/R-package/DESCRIPTION"
-CONFIGURE_AC_FILE="${REPO_ROOT}/R-package/configure.ac"
+DESCRIPTION_FILE="./R-package/DESCRIPTION"
+CONFIGURE_AC_FILE="./R-package/configure.ac"
 
-sed_in_place \
-    -e "s|^(Version: ).*$|\\1${LGB_VERSION}|" \
-    "${DESCRIPTION_FILE}"
-sed_in_place \
-    -e "s|^(AC_INIT\\(\\[lightgbm\\], \\[)[^]]*(\\].*)$|\\1${LGB_VERSION}\\2|" \
-    "${CONFIGURE_AC_FILE}"
+update_file \
+    "${DESCRIPTION_FILE}" \
+    "s|^Version: .*$|Version: ${LGB_VERSION}|"
+update_file \
+    "${CONFIGURE_AC_FILE}" \
+    "s|^AC_INIT.*$|AC_INIT([lightgbm], [${LGB_VERSION}], [], [lightgbm], [])|"
 
 grep -Fqx "Version: ${LGB_VERSION}" "${DESCRIPTION_FILE}"
 grep -Fqx \

--- a/.ci/update-version.sh
+++ b/.ci/update-version.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(dirname "${SCRIPT_DIR}")
+LGB_VERSION=$(sed 's/rc/-/g' < "${REPO_ROOT}/VERSION.txt")
+
+if test -z "${LGB_VERSION}"; then
+    echo "VERSION.txt must contain a version" >&2
+    exit 1
+fi
+
+sed_in_place() {
+    if sed --version >/dev/null 2>&1; then
+        sed -E -i "$@"
+    else
+        sed -E -i '' "$@"
+    fi
+}
+
+DESCRIPTION_FILE="${REPO_ROOT}/R-package/DESCRIPTION"
+CONFIGURE_AC_FILE="${REPO_ROOT}/R-package/configure.ac"
+
+sed_in_place \
+    -e "s|^(Version: ).*$|\\1${LGB_VERSION}|" \
+    "${DESCRIPTION_FILE}"
+sed_in_place \
+    -e "s|^(AC_INIT\\(\\[lightgbm\\], \\[)[^]]*(\\].*)$|\\1${LGB_VERSION}\\2|" \
+    "${CONFIGURE_AC_FILE}"
+
+grep -Fqx "Version: ${LGB_VERSION}" "${DESCRIPTION_FILE}"
+grep -Fqx \
+    "AC_INIT([lightgbm], [${LGB_VERSION}], [], [lightgbm], [])" \
+    "${CONFIGURE_AC_FILE}"

--- a/.ci/update-version.sh
+++ b/.ci/update-version.sh
@@ -9,13 +9,10 @@
 
 set -e -u
 
-LGB_VERSION=$(sed 's/rc/-/g' < ./VERSION.txt)
+LGB_VERSION=$(head -1 ./VERSION.txt)
+LGB_VERSION_NO_RC=$(echo "${LGB_VERSION}" | sed 's/rc/-/g')
 
-if test -z "${LGB_VERSION}"; then
-    echo "VERSION.txt must contain a version" >&2
-    exit 1
-fi
-
+# in-place 'sed' that's compatible with GNU sed and BSD sed (the one bundled with macOS)
 update_file() {
     TARGET_FILE=$1
     SED_EXPRESSION=$2
@@ -31,10 +28,11 @@ update_file \
     ./python-package/pyproject.toml \
     "s|^version = \"[0-9a-z.]+\"$|version = \"${LGB_VERSION}\"|"
 
+# R packages cannot have versions like 3.0.0rc1, but 3.0.0-1 is acceptable
 update_file \
     ./R-package/DESCRIPTION \
-    "s|^Version: .*$|Version: ${LGB_VERSION}|"
+    "s|^Version: .*$|Version: ${LGB_VERSION_NO_RC}|"
 
 update_file \
     ./R-package/configure.ac \
-    "s|^AC_INIT.*$|AC_INIT([lightgbm], [${LGB_VERSION}], [], [lightgbm], [])|"
+    "s|^AC_INIT.*$|AC_INIT([lightgbm], [${LGB_VERSION_NO_RC}], [], [lightgbm], [])|"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,18 +35,18 @@ repos:
           - --filter=-build/include_subdir,-whitespace/line_length
   - repo: local
     hooks:
-      - id: update-version
-        name: update-version
-        entry: sh
-        args:
-          - .ci/update-version.sh
-        language: system
-        pass_filenames: false
       - id: check-omp-pragmas
         name: check-omp-pragmas
         entry: sh
         args:
           - .ci/check-omp-pragmas.sh
+        language: system
+        pass_filenames: false
+      - id: update-version
+        name: update-version
+        entry: sh
+        args:
+          - .ci/update-version.sh
         language: system
         pass_filenames: false
   - repo: https://github.com/adrienverge/yamllint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     hooks:
       - id: update-version
         name: update-version
-        entry: bash
+        entry: sh
         args:
           - .ci/update-version.sh
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,13 @@ repos:
           - --filter=-build/include_subdir,-whitespace/line_length
   - repo: local
     hooks:
+      - id: update-version
+        name: update-version
+        entry: bash
+        args:
+          - .ci/update-version.sh
+        language: system
+        pass_filenames: false
       - id: check-omp-pragmas
         name: check-omp-pragmas
         entry: sh

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lightgbm
 Type: Package
 Title: Light Gradient Boosting Machine
-Version: ~~VERSION~~
+Version: 4.7.0.99
 Date: ~~DATE~~
 Authors@R: c(
     person("Yu", "Shi", email = "yushi2@microsoft.com", role = c("aut")),

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -4,7 +4,7 @@
 #   * https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Configure-and-cleanup
 
 AC_PREREQ(2.69)
-AC_INIT([lightgbm], [~~VERSION~~], [], [lightgbm], [])
+AC_INIT([lightgbm], [4.7.0.99], [], [lightgbm], [])
 
 ###########################
 # find compiler and flags #

--- a/R-package/recreate-configure.sh
+++ b/R-package/recreate-configure.sh
@@ -6,14 +6,6 @@ set -e -E -u -o pipefail
 # this script should run on Ubuntu 22.04
 AUTOCONF_VERSION=$(cat R-package/AUTOCONF_UBUNTU_VERSION)
 
-# R packages cannot have versions like 3.0.0rc1, but
-# 3.0.0-1 is acceptable
-LGB_VERSION=$(sed "s/rc/-/g" < VERSION.txt)
-
-# this script changes configure.ac. Copying to a temporary file
-# so changes to configure.ac don't get committed in git
-TMP_CONFIGURE_AC=".configure.ac"
-
 echo "Creating 'configure' script with Autoconf ${AUTOCONF_VERSION}"
 
 apt update
@@ -24,15 +16,10 @@ apt-get install \
 
 cd R-package
 
-cp configure.ac ${TMP_CONFIGURE_AC}
-sed -i.bak -e "s/~~VERSION~~/${LGB_VERSION}/" ${TMP_CONFIGURE_AC}
-
 autoconf \
     --output configure \
-    ${TMP_CONFIGURE_AC} \
+    configure.ac \
     || exit 1
-
-rm ${TMP_CONFIGURE_AC}
 
 rm -r autom4te.cache || echo "no autoconf cache found"
 

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -121,10 +121,8 @@ cd "${TEMP_R_DIR}"
     rm src/include/LightGBM/application.h
     rm src/main.cpp
 
-    # configure.ac and DESCRIPTION have placeholders for version
-    # and date so they don't have to be updated manually
-    sed -i.bak -e "s/~~VERSION~~/${LGB_VERSION}/" configure.ac
-    sed -i.bak -e "s/~~VERSION~~/${LGB_VERSION}/" DESCRIPTION
+    # DESCRIPTION has a date placeholder so it doesn't have to be updated
+    # manually
     sed -i.bak -e "s/~~DATE~~/${CURRENT_DATE}/" DESCRIPTION
 
     # Remove 'region', 'endregion', and 'warning' pragmas.

--- a/build_r.R
+++ b/build_r.R
@@ -374,26 +374,9 @@ result <- file.copy(
 )
 .handle_result(result)
 
-# R packages cannot have versions like 3.0.0rc1, but
-# 3.0.0-1 is acceptable
-LGB_VERSION <- readLines("VERSION.txt")[1L]
-LGB_VERSION <- gsub(
-  pattern = "rc"
-  , replacement = "-"
-  , x = LGB_VERSION
-  , fixed = TRUE
-)
-
-# DESCRIPTION has placeholders for version
-# and date so it doesn't have to be updated manually
+# DESCRIPTION has a date placeholder so it doesn't have to be updated manually
 DESCRIPTION_FILE <- file.path(TEMP_R_DIR, "DESCRIPTION")
 description_contents <- readLines(DESCRIPTION_FILE)
-description_contents <- gsub(
-  pattern = "~~VERSION~~"
-  , replacement = LGB_VERSION
-  , x = description_contents
-  , fixed = TRUE
-)
 description_contents <- gsub(
   pattern = "~~DATE~~"
   , replacement = as.character(Sys.Date())


### PR DESCRIPTION
Fixes #7383

*(heavily edited by @jameslamb on August 10)*

Introduces a `pre-commit` hook that replaces a few hard-coded versions in the repo with the content of `VERSION.txt`. The main goal was to avoid needing the `~~VERSION~~` placeholder in the R package, but this updates a few other files as well.

## Benefits of this change

* fixes #7383
* moves the project one step closer to being able to support `R CMD INSTALL .` without special build scripts
* reduces the effort to update release branches

## Notes for Reviewers

### How I tested this

Confirmed that the replacements work for the version formats we expect:

```console
echo "4.8.0" > ./VERSION.txt
time pre-commit run --all-files update-version

echo "5.0.0rc1" > ./VERSION.txt
pre-commit run --all-files update-version
```

Confirmed that it's fast enough to not be noticeable:

```console
$ time pre-commit run --all-files update-version
real    0m0.175s
user    0m0.115s
sys     0m0.053s
```