### PR TITLE
[ci] keep Python tests on standard CPython ABI

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -83,9 +83,13 @@ if [[ "$TASK" == "cpp-tests" ]]; then
     exit 0
 fi
 
-# Match the standard CPython ABI exactly. A trailing wildcard also matches free-threaded
-# builds like "cp314t", which are a different runtime target from "cp314".
-CONDA_PYTHON_REQUIREMENT="python=${PYTHON_VERSION}[build=*_cp${PYTHON_VERSION/./}]"
+# The broad build match keeps compatibility with the available builds for older Python versions.
+# Python 3.14 also has free-threaded "cp314t" builds, so select the standard ABI explicitly there.
+CONDA_PYTHON_BUILD="*_cp*"
+if [[ "${PYTHON_VERSION}" == "3.14" ]]; then
+    CONDA_PYTHON_BUILD="*_cp314"
+fi
+CONDA_PYTHON_REQUIREMENT="python=${PYTHON_VERSION}[build=${CONDA_PYTHON_BUILD}]"
 
 if [[ $TASK == "if-else" ]]; then
     conda create -q -y -n "${CONDA_ENV}" "${CONDA_PYTHON_REQUIREMENT}" numpy

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -83,9 +83,9 @@ if [[ "$TASK" == "cpp-tests" ]]; then
     exit 0
 fi
 
-# including python=version=[build=*_cp*] to ensure that conda prefers CPython and doesn't fall back to
-# other implementations like pypy
-CONDA_PYTHON_REQUIREMENT="python=${PYTHON_VERSION}[build=*_cp*]"
+# Match the standard CPython ABI exactly. A trailing wildcard also matches free-threaded
+# builds like "cp314t", which are a different runtime target from "cp314".
+CONDA_PYTHON_REQUIREMENT="python=${PYTHON_VERSION}[build=*_cp${PYTHON_VERSION/./}]"
 
 if [[ $TASK == "if-else" ]]; then
     conda create -q -y -n "${CONDA_ENV}" "${CONDA_PYTHON_REQUIREMENT}" numpy
@@ -127,6 +127,10 @@ else
     # shellcheck disable=SC1091
     source activate $CONDA_ENV
 fi
+
+# Keep this check close to environment creation so an unexpected free-threaded solve fails
+# with the actual cause instead of surfacing later as an unrelated native test crash.
+python -c 'import sysconfig; assert not sysconfig.get_config_var("Py_GIL_DISABLED"), "CI selected a free-threaded CPython build"'
 
 cd "${BUILD_DIRECTORY}"
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -83,11 +83,13 @@ if [[ "$TASK" == "cpp-tests" ]]; then
     exit 0
 fi
 
-# The broad build match keeps compatibility with the available builds for older Python versions.
-# Python 3.14 also has free-threaded "cp314t" builds, so select the standard ABI explicitly there.
+# Python 3.13 and later have both standard and free-threaded conda builds.
+# Older standard builds use the "cpython" tag, so keep the broader match for them.
+PYTHON_MAJOR_VERSION="${PYTHON_VERSION%%.*}"
+PYTHON_MINOR_VERSION="${PYTHON_VERSION#*.}"
 CONDA_PYTHON_BUILD="*_cp*"
-if [[ "${PYTHON_VERSION}" == "3.14" ]]; then
-    CONDA_PYTHON_BUILD="*_cp314"
+if ((PYTHON_MAJOR_VERSION > 3 || (PYTHON_MAJOR_VERSION == 3 && PYTHON_MINOR_VERSION >= 13))); then
+    CONDA_PYTHON_BUILD="*_cp${PYTHON_MAJOR_VERSION}${PYTHON_MINOR_VERSION}"
 fi
 CONDA_PYTHON_REQUIREMENT="python=${PYTHON_VERSION}[build=${CONDA_PYTHON_BUILD}]"
 


### PR DESCRIPTION
Fixes #7391

The failing job was resolving Python 3.14 to the free-threaded `cp314t` build because the existing `*_cp*` selector matched both `cp314` and `cp314t`. The Dask `StopIteration` happened after a worker was killed by signal 11, so changing the Dask worker mapping would only hide the real failure.

This keeps the existing broad CPython build match for other Python versions and narrows only Python 3.14 to the standard `cp314` ABI. It also checks `Py_GIL_DISABLED` immediately after environment creation so the same drift fails with a clear message.

Validated with:

- `bash -n .ci/test.sh`
- selector checks for Python 3.10, 3.11, 3.12, and 3.14
- `pre-commit run --all-files`
- Python 3.14 focused Dask cases: 16 passed