### PR TITLE
[python-package] stop buffering log messages from the Python package's default logger

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -198,7 +198,7 @@ class _MissingType(Enum):
 
 class _DummyLogger:
     def info(self, msg: str) -> None:
-        print(msg)  # noqa: T201
+        print(msg, flush=True)  # noqa: T201
 
     def warning(self, msg: str) -> None:
         warnings.warn(msg, stacklevel=3)


### PR DESCRIPTION
## Description

`_DummyLogger.info()` calls `print(msg)` without `flush=True`. When stdout is piped (e.g. `python train.py 2>&1 | tee log`, common in ML training workflows), Python defaults to block-buffered stdout (~8KB buffer). This means `log_evaluation` iteration lines for a multi-thousand-round training run sit in the buffer and never reach the user until the process exits or the buffer fills.

The symptom is indistinguishable from a hang: the process is training normally (CPU active, memory growing), but the console shows no output for minutes. I hit this during production LightGBM training — it delayed diagnosis of a separate issue because training appeared stalled when it was actually running fine with buffered output. The workaround (`register_logger()`) works but requires knowing about the buffering problem before encountering it, which is exactly when you can't — "no output" gives no hint that logger registration is the cause.

## Fix

Add `flush=True` to `print()` in `_DummyLogger.info()`. This forces a flush after every line, matching interactive-terminal behavior. No change for interactive use (already line-buffered). No performance concern: `log_evaluation` fires once per `period` rounds, and the print cost is negligible vs the training iteration.

## How to reproduce (before fix)

```python
import lightgbm as lgb
import numpy as np

X = np.random.randn(1000, 10)
y = np.random.randint(0, 3, 1000)
ds = lgb.Dataset(X, y)
lgb.train(
    {"objective": "multiclass", "num_class": 3, "verbose": 1, "num_iterations": 200},
    ds,
    callbacks=[lgb.log_evaluation(10)],
)
```

```bash
# Interactive (works fine):
python repro.py

# Piped (bug — no output until completion):
python repro.py 2>&1 | tee /dev/null
```

After the fix, both produce the same line-by-line output.