### PR TITLE
[R-package] [ci] remove 'Date' field from DESCRIPTION

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -2,7 +2,6 @@ Package: lightgbm
 Type: Package
 Title: Light Gradient Boosting Machine
 Version: ~~VERSION~~
-Date: ~~DATE~~
 Authors@R: c(
     person("Yu", "Shi", email = "yushi2@microsoft.com", role = c("aut")),
     person("Guolin", "Ke", email = "guolin.ke@outlook.com", role = c("aut")),

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -125,7 +125,6 @@ cd "${TEMP_R_DIR}"
     # and date so they don't have to be updated manually
     sed -i.bak -e "s/~~VERSION~~/${LGB_VERSION}/" configure.ac
     sed -i.bak -e "s/~~VERSION~~/${LGB_VERSION}/" DESCRIPTION
-    sed -i.bak -e "s/~~DATE~~/${CURRENT_DATE}/" DESCRIPTION
 
     # Remove 'region', 'endregion', and 'warning' pragmas.
     # This won't change the correctness of the code. CRAN does

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -59,8 +59,6 @@ if test -d "${TEMP_R_DIR}"; then
 fi
 mkdir -p "${TEMP_R_DIR}"
 
-CURRENT_DATE=$(date +'%Y-%m-%d')
-
 # R packages cannot have versions like 3.0.0rc1, but
 # 3.0.0-1 is acceptable
 LGB_VERSION=$(head -1 ./VERSION.txt | sed "s/rc/-/g")

--- a/build_r.R
+++ b/build_r.R
@@ -394,12 +394,6 @@ description_contents <- gsub(
   , x = description_contents
   , fixed = TRUE
 )
-description_contents <- gsub(
-  pattern = "~~DATE~~"
-  , replacement = as.character(Sys.Date())
-  , x = description_contents
-  , fixed = TRUE
-)
 writeLines(description_contents, DESCRIPTION_FILE)
 
 # NOTE: --keep-empty-dirs is necessary to keep the deep paths expected


### PR DESCRIPTION
Contributes to #6809

Contributes to #6774

While reviewing #7392, I realized ... we probably don't need the `Date:` field in `R-package/DESCRIPTION` in source control, and could remove the machinery for updating it at build time 😁 

It looks like `Date` is not required and has not been for a long time. Look at this comment from 2016: https://github.com/r-lib/devtools/issues/1327#issuecomment-244590948

That exactly matches what I see looking around at popular R packages. For example, `{arrow}` does not have a `Date:` field in its description ([apache/arrow - r/DESCRIPTION](https://github.com/apache/arrow/blob/a7d0bfa5ad71af8500f64a0e187ab9523e5da0d5/r/DESCRIPTION)) but a `Date/Publication` date is added in the CRAN package ([code link](https://github.com/cran/arrow/blob/abfb02450495c48acdf619d1b726888f1821da5c/DESCRIPTION#L88)).

## Notes for Reviewers

If `R CMD check --as-cran` runs successfully in CI here, I think we can be confident in this change.