### PR TITLE
[fix] quantized training: leaf totals summed over wrong rows under bagging; 8-bit histogram merge misplaced under column subsetting

### DIFF
--- a/src/io/train_share_states.cpp
+++ b/src/io/train_share_states.cpp
@@ -156,6 +156,17 @@ void MultiValBinWrapper::HistMerge(std::vector<hist_t,
       }
     } else if (HIST_BITS == 16 && INNER_HIST_BITS == 8) {
       int32_t* dst = reinterpret_cast<int32_t*>(hist_buf->data()) + hist_buf->size() / 2;
+      if (is_use_subcol_) {
+        // Match HistMove<true, 16, 8>'s column-subset read location (and the
+        // 16/16 merge branch's convention): under is_use_subcol_ the moved
+        // histogram is read from num_bin_aligned_ packed entries BEFORE
+        // hist_buf->size()/2. Without this adjustment the merged 8-bit-block
+        // histogram was written num_bin_aligned_ int32s away from where
+        // HistMove reads, so column-sampled trees consumed stale buffer bytes
+        // for every small (8-bit inner) leaf — corrupt bins, phantom splits,
+        // and the best_split_info.left_count/right_count engine aborts.
+        dst -= static_cast<size_t>(num_bin_aligned_);
+      }
       std::memset(reinterpret_cast<void*>(dst), 0, num_bin_ * kInt16HistBufferEntrySize);
       #pragma omp parallel for schedule(static, 1) num_threads(num_threads_)
       for (int t = 0; t < n_bin_block; ++t) {

--- a/src/treelearner/leaf_splits.hpp
+++ b/src/treelearner/leaf_splits.hpp
@@ -184,7 +184,17 @@ class LeafSplits {
       const data_size_t idx = data_indices_[i];
       tmp_sum_gradients += int_gradients_and_hessians[2 * idx + 1] * grad_scale;
       tmp_sum_hessians += int_gradients_and_hessians[2 * idx] * hess_scale;
-      const int16_t packed_int_grad_and_hess = packed_int_gradients_and_hessians[i];
+      // Index by idx (the leaf's actual row), not the loop counter i: this
+      // partial-data overload receives the GLOBAL discretized gradient array,
+      // so packed pairs must be gathered through data_indices_ exactly like
+      // the two float sums above. Indexing by i summed the packed int totals
+      // over the wrong rows whenever data_indices_ is a proper subset (e.g.
+      // the bagged root), desynchronizing the leaf's int64 total from its
+      // histogram bins; FixHistogramInt then materializes the difference as
+      // phantom mass in most-frequent bins, which can select splits with an
+      // empty real side (the "Check failed: (best_split_info.left_count) >
+      // (0)" family, #5994/#5982 residue) or silently corrupt the model.
+      const int16_t packed_int_grad_and_hess = packed_int_gradients_and_hessians[idx];
       const int64_t packed_long_int_grad_and_hess =
         (static_cast<int64_t>(static_cast<int8_t>(packed_int_grad_and_hess >> 8)) << 32) |
         (static_cast<int64_t>(packed_int_grad_and_hess & 0x00ff));

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -4870,6 +4870,82 @@ def test_quantized_training():
     assert quant_rmse < rmse + 6.0
 
 
+def test_quantized_training_with_bagging():
+    # regression test: with bagging active, the quantized root leaf's packed
+    # int64 gradient/hessian total was gathered by loop counter instead of
+    # data_indices_, desynchronizing the leaf total from its histogram bins;
+    # FixHistogramInt then materialized the discrepancy as phantom mass in
+    # most-frequent bins, which could select splits with an empty real side:
+    # "Check failed: (best_split_info.left_count) > (0)"
+    rng = np.random.default_rng(8186409)
+    n_rows, n_features = 16_200, 200
+    X = rng.normal(0.0, 0.35, size=(n_rows, n_features)).astype(np.float32)
+    y = ((X[:, 3].astype(np.float64) * 0.7 + rng.normal(0.0, 0.35, n_rows)) > 0.0).astype(np.float32)
+
+    def logistic_fobj(preds, train_data):
+        labels = np.asarray(train_data.get_label(), dtype=np.float64)
+        p = 1.0 / (1.0 + np.exp(-np.clip(np.asarray(preds, dtype=np.float64), -60.0, 60.0)))
+        return p - labels, np.maximum(p * (1.0 - p), 1e-6)
+
+    params = {
+        "objective": logistic_fobj,
+        "use_quantized_grad": True,
+        "num_grad_quant_bins": 4,
+        "stochastic_rounding": True,
+        "bagging_fraction": 0.85,
+        "bagging_freq": 1,
+        "num_leaves": 31,
+        "learning_rate": 0.04,
+        "min_data_in_leaf": 32,
+        "feature_fraction": 0.85,
+        "force_row_wise": True,
+        "seed": 8186415,
+        "num_threads": 2,
+        "verbose": -1,
+    }
+    booster = lgb.train(params, lgb.Dataset(X, label=y), num_boost_round=256)
+    assert booster.num_trees() == 256
+    assert np.all(np.isfinite(booster.predict(X)))
+
+
+def test_quantized_training_sparse_small_leaves_feature_subsampling():
+    # regression test: HistMerge<true, 16, 8> wrote the merged 8-bit-block
+    # histogram without the is_use_subcol_ destination adjustment its reader
+    # HistMove<true, 16, 8> applies, so under column subsetting every small
+    # (8-bit inner) leaf consumed stale buffer bytes as its histogram —
+    # crashing via the left_count/right_count checks or silently degrading
+    # the model. Sparse features drive the multi-val road where column
+    # subsetting activates; tiny leaves drive the 8-bit path; bagging stays
+    # OFF to isolate this defect from the bagging one above.
+    rng = np.random.default_rng(8186409)
+    n_rows, n_features = 6_000, 400
+    dense = rng.random(size=(n_rows, n_features)) * (rng.random(size=(n_rows, n_features)) < 0.05)
+    X = csr_matrix(dense)
+    y = (dense[:, 3] * 3.0 + rng.normal(0.0, 0.35, n_rows)).astype(np.float64)
+
+    base_params = {
+        "num_leaves": 255,
+        "learning_rate": 0.04,
+        "min_data_in_leaf": 5,
+        "feature_fraction": 0.6,
+        "force_row_wise": True,
+        "seed": 8186415,
+        "num_threads": 2,
+        "verbose": -1,
+    }
+    control = lgb.train(dict(base_params), lgb.Dataset(X, label=y), num_boost_round=64)
+    control_rmse = np.sqrt(np.mean((control.predict(X) - y) ** 2))
+
+    quant_params = dict(base_params)
+    quant_params.update({"use_quantized_grad": True, "num_grad_quant_bins": 4, "stochastic_rounding": True})
+    quant_bst = lgb.train(quant_params, lgb.Dataset(X, label=y), num_boost_round=64)
+    quant_rmse = np.sqrt(np.mean((quant_bst.predict(X) - y) ** 2))
+
+    assert quant_bst.num_trees() == 64
+    # quality clause: catches silent histogram corruption, not just the crash
+    assert quant_rmse < control_rmse * 1.5 + 1e-3
+
+
 def test_bagging_by_query_in_lambdarank():
     rank_example_dir = Path(__file__).absolute().parents[2] / "examples" / "lambdarank"
     X_train, y_train = load_svmlight_file(str(rank_example_dir / "rank.train"))


### PR DESCRIPTION
## TL;DR

**CPU quantized training (`use_quantized_grad=True`) has been unreliable
ever since its introduction — sometimes aborting with the long-standing
`best_split_info.left_count > 0` check failure (#5994/#5982 family, still
reported after the #6092 fix), sometimes silently training a degraded
model (the #6703 flake signature). We root-caused it to TWO independent
one-line-class defects that both desynchronize a leaf's histogram from its
actual rows. This PR fixes both, and quantized training with bagging and
feature subsampling — the common real-world configuration — trains
cleanly.** Unquantized training is bit-for-bit unaffected by both fixes
(verified: sha256-equal serialized models against the unpatched build).

## Bug 1 — packed leaf total summed over the wrong rows under bagging

`LeafSplits::Init(leaf, data_partition, int8* int_gradients_and_hessians,
grad_scale, hess_scale)` (`src/treelearner/leaf_splits.hpp`) — the
partial-data overload that initializes the **root leaf when bagging is
active** — gathers the packed int64 gradient/hessian total with the loop
counter instead of the leaf's row indices:

```cpp
const data_size_t idx = data_indices_[i];
tmp_sum_gradients += int_gradients_and_hessians[2 * idx + 1] * grad_scale;   // idx — correct
tmp_sum_hessians  += int_gradients_and_hessians[2 * idx] * hess_scale;       // idx — correct
const int16_t packed_int_grad_and_hess = packed_int_gradients_and_hessians[i];  // i — BUG
```

The float sums iterate the leaf's actual rows; the packed int64 sum adds
the int8 pairs of global rows `0..n-1` — a different row set whenever
`data_indices_` is a proper subset, i.e. whenever bagging is on. The
whole-data overload's `[i]` is correct (identity mapping); this is the
only wrong site (grep-verified).

**Fix**: `packed_int_gradients_and_hessians[i]` → `[idx]`.

## Bug 2 — 8-bit histogram merge written where the mover doesn't read, under column subsetting

Small leaves (`num_data_in_leaf × num_grad_quant_bins < 256`) accumulate
their per-thread histogram blocks in a packed 8-bit layout, merged by
`HistMerge<true, 16, 8>` (`src/io/train_share_states.cpp`) into a scratch
region and published by `HistMove<true, 16, 8>`. Under column subsetting
(`is_use_subcol_`, i.e. `feature_fraction < 1`), the mover reads from
`hist_buf + size()/2 − num_bin_aligned_` — the same convention the 16/16
merge branch writes to — but `HistMerge<true, 16, 8>` has no
`is_use_subcol_` branch and always writes to `hist_buf + size()/2`:

```cpp
} else if (HIST_BITS == 16 && INNER_HIST_BITS == 8) {
  int32_t* dst = reinterpret_cast<int32_t*>(hist_buf->data()) + hist_buf->size() / 2;
  // (no is_use_subcol_ adjustment — every other merge branch has one)
```

Writer and reader disagree by exactly `num_bin_aligned_` packed entries,
so every column-sampled small leaf consumes **stale buffer bytes from an
earlier round** as its histogram. Observed directly with an instrumented
build: freshly constructed 8-bit leaves whose stored bins carry mass from
rows not in the leaf, then (after the parent-minus-sibling subtraction)
sibling histograms with **negative hessians**.

**Fix**: apply the same `is_use_subcol_` destination adjustment the
16/16 branch and the mover already use.

## Shared failure chain (each step observed with an instrumented build)

1. Either defect desynchronizes a leaf's (total ⇄ bins) pair — bug 1
   corrupts the root total under bagging; bug 2 corrupts small-leaf bins
   under column subsetting.
2. `FixHistogramInt` reconstructs each feature's skipped most-frequent bin
   as `leaf_total − Σ(other bins)`, materializing the discrepancy as
   phantom grad/hess mass; histogram subtraction (parent − sibling)
   propagates it to siblings and descendants.
3. The split finder estimates per-side counts from int hessian sums, so
   phantom hessian clears `min_data_in_leaf` for regions with zero real
   rows → the chosen split's real partition is empty on one side →
   `Check failed: (best_split_info.left_count) > (0)`
   (`serial_tree_learner.cpp`; the `right_count` twin equally).
4. When no check trips, training silently continues on corrupted
   histograms — degraded or garbage models with no error raised.
   Notably, raising `num_grad_quant_bins` 4→16 stopped the crash in our
   reproducer **but not the corruption** (a per-split tracer still logged
   mismatched totals): bin-count tuning is not a safe workaround.

## Relationship to known issues

- #5994 / #5982 — same check-failure family, previously addressed by
  #6092; these are **residual, distinct defects** in the same subsystem,
  which is why the crash class survived. "Randomly fails" matches the
  bagging/subsampling dependence.
- #6703 (`test_quantized_training` flaky with catastrophic RMSE) — the
  silent half of the failure chain produces exactly this signature.
- Not related to the CUDA-only quantized fixes (e.g. #7261); this is the
  CPU path.

## Reproducers (both verified deterministic on the 4.6.0 and 4.7.0 PyPI wheels, linux x86_64)

- **Bug 1** (`minimal_repro_bug1.py`): synthetic dense data, a canonical
  binary-logistic custom objective (public API), `use_quantized_grad=True`
  + bagging. Aborts 100% of runs with the `left_count`/`right_count`
  check; clean if EITHER quantized training OR bagging is disabled — the
  discriminating pair requested in #6175.
- **Bug 2** (`minimal_repro_bug2.py`): synthetic SPARSE data (sparse
  features drive the multi-val/EFB road where `is_use_subcol_`
  activates), `feature_fraction=0.6`, `min_data_in_leaf=5` (leaves small
  enough for the 8-bit inner path), **bagging OFF** — isolating this
  defect from bug 1. Aborts deterministically on stock; with the fix it
  trains clean with quantized RMSE within 0.1% of the unquantized twin.
  On dense balanced data the subcol/8-bit combination is never reached,
  which is precisely why this defect survived the existing test suite.

## Behavior guarantees

- **Unquantized training is untouched**: serialized models are
  byte-identical (sha256-equal `model_to_string()`) between unpatched and
  patched builds — both changed lines execute only on the quantized road.
- Quantized results change only where the previous numbers were computed
  from wrong rows / stale memory by construction.
- With both fixes, an instrumented build that re-bins every leaf's rows
  from raw data each round and compares against the finder's totals and
  per-bin histograms reports ZERO divergence across entire real-data
  trainings that previously aborted within seconds.

## Suggested regression tests

`test_quantized_training_with_bagging` (bug 1) and
`test_quantized_training_small_leaves_with_feature_subsampling` (bug 2) —
see the attached snippets; both fail (crash or degraded model) before the
fixes and pass after.
