### PR TITLE
[c++] fix training mismatches between CUDA and CPU

### DIFF
--- a/include/LightGBM/cuda/cuda_algorithms.hpp
+++ b/include/LightGBM/cuda/cuda_algorithms.hpp
@@ -98,7 +98,7 @@ __device__ __forceinline__ T ShufflePrefixSumExclusive(T value, T* shared_mem_bu
   if (threadIdx.x == 0) {
     exclusive_result = 0;
   } else if (threadIdx.x % warpSize == 0) {
-    exclusive_result = shared_mem_buffer[warpLane - 1];
+    exclusive_result = shared_mem_buffer[warpID - 1];
   }
   return exclusive_result;
 }

--- a/include/LightGBM/cuda/cuda_algorithms.hpp
+++ b/include/LightGBM/cuda/cuda_algorithms.hpp
@@ -187,6 +187,7 @@ __device__ __forceinline__ void GlobalMemoryPrefixSum(T* array, const size_t len
   for (size_t index = start + 1; index < end; ++index) {
     array[index] += array[index - 1];
   }
+  __syncthreads();
 }
 
 template <typename T>

--- a/include/LightGBM/cuda/cuda_split_info.hpp
+++ b/include/LightGBM/cuda/cuda_split_info.hpp
@@ -69,12 +69,14 @@ class CUDASplitInfo {
 
     left_sum_gradients = other.left_sum_gradients;
     left_sum_hessians = other.left_sum_hessians;
+    left_sum_of_gradients_hessians = other.left_sum_of_gradients_hessians;
     left_count = other.left_count;
     left_gain = other.left_gain;
     left_value = other.left_value;
 
     right_sum_gradients = other.right_sum_gradients;
     right_sum_hessians = other.right_sum_hessians;
+    right_sum_of_gradients_hessians = other.right_sum_of_gradients_hessians;
     right_count = other.right_count;
     right_gain = other.right_gain;
     right_value = other.right_value;

--- a/src/io/cuda/cuda_tree.cu
+++ b/src/io/cuda/cuda_tree.cu
@@ -359,6 +359,7 @@ __global__ void AddPredictionToScoreKernel(
       } else if (column_bit_type == 32) {
         bin = static_cast<uint32_t>((reinterpret_cast<const uint32_t*>(cuda_data_by_column[column]))[data_index]);
       }
+      const uint32_t feature_last_bin = max_bin - min_bin + offset;
       if (bin >= min_bin && bin <= max_bin) {
         bin = bin - min_bin + offset;
       } else {
@@ -377,7 +378,7 @@ __global__ void AddPredictionToScoreKernel(
         const uint32_t threshold_in_bin = cuda_threshold_in_bin[node];
         const int8_t missing_type = GetMissingTypeCUDA(decision_type);
         const bool default_left = ((decision_type & kDefaultLeftMask) > 0);
-        if ((missing_type == 1 && bin == default_bin) || (missing_type == 2 && bin == max_bin)) {
+        if ((missing_type == 1 && bin == default_bin) || (missing_type == 2 && bin == feature_last_bin)) {
           if (default_left) {
             node = cuda_left_child[node];
           } else {

--- a/src/treelearner/cuda/cuda_best_split_finder.cpp
+++ b/src/treelearner/cuda/cuda_best_split_finder.cpp
@@ -95,11 +95,11 @@ void CUDABestSplitFinder::Init() {
   CUDASUCCESS_OR_FATAL(cudaStreamCreate(&cuda_streams_[1]));
   cuda_best_split_info_buffer_.Resize(8);
   if (use_global_memory_) {
-    cuda_feature_hist_grad_buffer_.Resize(static_cast<size_t>(num_total_bin_));
-    cuda_feature_hist_hess_buffer_.Resize(static_cast<size_t>(num_total_bin_));
+    cuda_feature_hist_grad_buffer_.Resize(static_cast<size_t>(num_total_bin_) * 2);
+    cuda_feature_hist_hess_buffer_.Resize(static_cast<size_t>(num_total_bin_) * 2);
     if (has_categorical_feature_) {
-      cuda_feature_hist_stat_buffer_.Resize(static_cast<size_t>(num_total_bin_));
-      cuda_feature_hist_index_buffer_.Resize(static_cast<size_t>(num_total_bin_));
+      cuda_feature_hist_stat_buffer_.Resize(static_cast<size_t>(num_total_bin_) * 2);
+      cuda_feature_hist_index_buffer_.Resize(static_cast<size_t>(num_total_bin_) * 2);
     }
   }
 

--- a/src/treelearner/cuda/cuda_best_split_finder.cu
+++ b/src/treelearner/cuda/cuda_best_split_finder.cu
@@ -974,9 +974,9 @@ __global__ void FindBestSplitsDiscretizedForLeafKernel(
             // output parameters
             out);
         } else {
-          const int32_t* hist_ptr =
-            reinterpret_cast<const int32_t*>(IS_LARGER ? larger_leaf_splits->hist_in_leaf : smaller_leaf_splits->hist_in_leaf) + task->hist_offset;
-          FindBestSplitsDiscretizedForLeafKernelInner<USE_RAND, USE_L1, USE_SMOOTHING, false, int32_t, int64_t, false, false>(
+          const int64_t* hist_ptr =
+            reinterpret_cast<const int64_t*>(IS_LARGER ? larger_leaf_splits->hist_in_leaf : smaller_leaf_splits->hist_in_leaf) + task->hist_offset;
+          FindBestSplitsDiscretizedForLeafKernelInner<USE_RAND, USE_L1, USE_SMOOTHING, false, int64_t, int64_t, false, false>(
             // input feature information
             hist_ptr,
             // input task information
@@ -1028,9 +1028,9 @@ __global__ void FindBestSplitsDiscretizedForLeafKernel(
             // output parameters
             out);
         } else {
-          const int32_t* hist_ptr =
-            reinterpret_cast<const int32_t*>(IS_LARGER ? larger_leaf_splits->hist_in_leaf : smaller_leaf_splits->hist_in_leaf) + task->hist_offset;
-          FindBestSplitsDiscretizedForLeafKernelInner<USE_RAND, USE_L1, USE_SMOOTHING, true, int32_t, int64_t, false, false>(
+          const int64_t* hist_ptr =
+            reinterpret_cast<const int64_t*>(IS_LARGER ? larger_leaf_splits->hist_in_leaf : smaller_leaf_splits->hist_in_leaf) + task->hist_offset;
+          FindBestSplitsDiscretizedForLeafKernelInner<USE_RAND, USE_L1, USE_SMOOTHING, true, int64_t, int64_t, false, false>(
             // input feature information
             hist_ptr,
             // input task information

--- a/src/treelearner/cuda/cuda_best_split_finder.cu
+++ b/src/treelearner/cuda/cuda_best_split_finder.cu
@@ -1599,7 +1599,8 @@ __global__ void FindBestSplitsForLeafKernel_GlobalMemory(
   hist_t* feature_hist_grad_buffer,
   hist_t* feature_hist_hess_buffer,
   hist_t* feature_hist_stat_buffer,
-  data_size_t* feature_hist_index_buffer) {
+  data_size_t* feature_hist_index_buffer,
+  const int num_total_bin) {
   const unsigned int task_index = blockIdx.x;
   const SplitFindTask* task = tasks + task_index;
   const double parent_gain = IS_LARGER ? larger_leaf_splits->gain : smaller_leaf_splits->gain;
@@ -1614,10 +1615,11 @@ __global__ void FindBestSplitsForLeafKernel_GlobalMemory(
   if (is_feature_used_bytree[task->inner_feature_index]) {
     const uint32_t hist_offset = task->hist_offset;
     const hist_t* hist_ptr = (IS_LARGER ? larger_leaf_splits->hist_in_leaf : smaller_leaf_splits->hist_in_leaf) + hist_offset * 2;
-    hist_t* hist_grad_buffer_ptr = feature_hist_grad_buffer + hist_offset * 2;
-    hist_t* hist_hess_buffer_ptr = feature_hist_hess_buffer + hist_offset * 2;
-    hist_t* hist_stat_buffer_ptr = feature_hist_stat_buffer + hist_offset * 2;
-    data_size_t* hist_index_buffer_ptr = feature_hist_index_buffer + hist_offset * 2;
+    const uint32_t buffer_offset = hist_offset + (task->reverse ? static_cast<uint32_t>(num_total_bin) : 0u);
+    hist_t* hist_grad_buffer_ptr = feature_hist_grad_buffer + buffer_offset;
+    hist_t* hist_hess_buffer_ptr = feature_hist_hess_buffer + buffer_offset;
+    hist_t* hist_stat_buffer_ptr = feature_hist_stat_buffer + buffer_offset;
+    data_size_t* hist_index_buffer_ptr = feature_hist_index_buffer + buffer_offset;
     if (task->is_categorical) {
       FindBestSplitsForLeafKernelCategoricalInner_GlobalMemory<USE_RAND, USE_L1, USE_SMOOTHING>(
         // input feature information
@@ -1751,7 +1753,8 @@ __global__ void FindBestSplitsForLeafKernel_GlobalMemory(
   cuda_feature_hist_grad_buffer_.RawData(), \
   cuda_feature_hist_hess_buffer_.RawData(), \
   cuda_feature_hist_stat_buffer_.RawData(), \
-  cuda_feature_hist_index_buffer_.RawData()
+  cuda_feature_hist_index_buffer_.RawData(), \
+  num_total_bin_
 
 void CUDABestSplitFinder::LaunchFindBestSplitsForLeafKernel(LaunchFindBestSplitsForLeafKernel_PARAMS) {
   if (!is_smaller_leaf_valid && !is_larger_leaf_valid) {

--- a/src/treelearner/cuda/cuda_best_split_finder.cu
+++ b/src/treelearner/cuda/cuda_best_split_finder.cu
@@ -374,7 +374,17 @@ __device__ void FindBestSplitsDiscretizedForLeafKernelInner(
     (task->skip_default_bin && (threadIdx_x + task->mfb_offset) == static_cast<int>(task->default_bin));
   const uint32_t feature_num_bin_minus_offset = task->num_bin - task->mfb_offset;
   if (!REVERSE) {
-    if (threadIdx_x < feature_num_bin_minus_offset && !skip_sum) {
+    if (task->na_as_missing && task->mfb_offset == 1) {
+      if (threadIdx_x < static_cast<uint32_t>(task->num_bin) && threadIdx_x > 0) {
+        const unsigned int bin_offset = threadIdx_x - 1;
+        if (USE_16BIT_BIN_HIST && !USE_16BIT_ACC_HIST) {
+          const int32_t local_grad_hess_hist_int32 = feature_hist_ptr[bin_offset];
+          local_grad_hess_hist = (static_cast<int64_t>(static_cast<int16_t>(local_grad_hess_hist_int32 >> 16)) << 32) | (static_cast<int64_t>(local_grad_hess_hist_int32 & 0x0000ffff));
+        } else {
+          local_grad_hess_hist = feature_hist_ptr[bin_offset];
+        }
+      }
+    } else if (threadIdx_x < feature_num_bin_minus_offset && !skip_sum) {
       const unsigned int bin_offset = threadIdx_x;
       if (USE_16BIT_BIN_HIST && !USE_16BIT_ACC_HIST) {
         const int32_t local_grad_hess_hist_int32 = feature_hist_ptr[bin_offset];
@@ -396,6 +406,18 @@ __device__ void FindBestSplitsDiscretizedForLeafKernelInner(
     }
   }
   __syncthreads();
+  if (!REVERSE && task->na_as_missing && task->mfb_offset == 1) {
+    const ACC_HIST_TYPE sum_grad_hess_non_default = ShuffleReduceSum<ACC_HIST_TYPE>(
+      local_grad_hess_hist, reinterpret_cast<ACC_HIST_TYPE*>(shared_int_buffer), blockDim.x);
+    if (threadIdx_x == 0) {
+      const ACC_HIST_TYPE leaf_sum_grad_hess = USE_16BIT_ACC_HIST ?
+        static_cast<ACC_HIST_TYPE>((static_cast<int32_t>(sum_gradients_hessians >> 32) << 16) |
+          static_cast<int32_t>(sum_gradients_hessians & 0x000000000000ffff)) :
+        static_cast<ACC_HIST_TYPE>(sum_gradients_hessians);
+      local_grad_hess_hist += (leaf_sum_grad_hess - sum_grad_hess_non_default);
+    }
+    __syncthreads();
+  }
   local_gain = kMinScore;
   local_grad_hess_hist = ShufflePrefixSum<ACC_HIST_TYPE>(local_grad_hess_hist, reinterpret_cast<ACC_HIST_TYPE*>(shared_int_buffer));
   double sum_left_gradient = 0.0f;
@@ -434,7 +456,9 @@ __device__ void FindBestSplitsDiscretizedForLeafKernelInner(
       }
     }
   } else {
-    if (threadIdx_x <= feature_num_bin_minus_offset - 2 && !skip_sum) {
+    const uint32_t end = (task->na_as_missing && task->mfb_offset == 1) ?
+      static_cast<uint32_t>(task->num_bin - 2) : feature_num_bin_minus_offset - 2;
+    if (threadIdx_x <= end && !skip_sum) {
       sum_left_gradient_hessian = USE_16BIT_ACC_HIST ?
         (static_cast<int64_t>(static_cast<int16_t>(local_grad_hess_hist >> 16)) << 32) | static_cast<int64_t>(local_grad_hess_hist & 0x0000ffff) :
         local_grad_hess_hist;
@@ -455,7 +479,9 @@ __device__ void FindBestSplitsDiscretizedForLeafKernelInner(
         // gain with split is worse than without split
         if (current_gain > min_gain_shift) {
           local_gain = current_gain - min_gain_shift;
-          threshold_value = static_cast<uint32_t>(threadIdx_x + task->mfb_offset);
+          threshold_value = (task->na_as_missing && task->mfb_offset == 1) ?
+            static_cast<uint32_t>(threadIdx_x) :
+            static_cast<uint32_t>(threadIdx_x + task->mfb_offset);
           threshold_found = true;
         }
       }

--- a/src/treelearner/cuda/cuda_best_split_finder.cu
+++ b/src/treelearner/cuda/cuda_best_split_finder.cu
@@ -1142,8 +1142,10 @@ __device__ void FindBestSplitsForLeafKernelInner_GlobalMemory(
     }
   } else {
     for (unsigned int bin = threadIdx_x; bin < feature_num_bin_minus_offset; bin += blockDim.x) {
-      const bool skip_sum = bin >= static_cast<unsigned int>(task->na_as_missing) &&
-        (task->skip_default_bin && (task->num_bin - 1 - bin) == static_cast<int>(task->default_bin));
+      const bool skip_sum =
+        (bin < static_cast<unsigned int>(task->na_as_missing)) ||
+        (task->skip_default_bin &&
+         (task->num_bin - 1 - bin) == static_cast<int>(task->default_bin));
       if (!skip_sum) {
         const unsigned int read_index = feature_num_bin_minus_offset - 1 - bin;
         const unsigned int bin_offset = read_index << 1;
@@ -1165,8 +1167,11 @@ __device__ void FindBestSplitsForLeafKernelInner_GlobalMemory(
   GlobalMemoryPrefixSum(hist_hess_buffer_ptr, static_cast<size_t>(feature_num_bin_minus_offset));
   if (REVERSE) {
     for (unsigned int bin = threadIdx_x; bin < feature_num_bin_minus_offset; bin += blockDim.x) {
-      const bool skip_sum = (bin >= static_cast<unsigned int>(task->na_as_missing) &&
-        (task->skip_default_bin && (task->num_bin - 1 - bin) == static_cast<int>(task->default_bin)));
+      const bool skip_sum =
+        (bin < static_cast<unsigned int>(task->na_as_missing)) ||
+        (bin > static_cast<unsigned int>(task->num_bin - 2)) ||
+        (task->skip_default_bin &&
+         (task->num_bin - 1 - bin) == static_cast<int>(task->default_bin));
       if (!skip_sum) {
         const double sum_right_gradient = hist_grad_buffer_ptr[bin];
         const double sum_right_hessian = hist_hess_buffer_ptr[bin];
@@ -1183,9 +1188,12 @@ __device__ void FindBestSplitsForLeafKernelInner_GlobalMemory(
             lambda_l2, path_smooth, left_count, right_count, parent_output);
           // gain with split is worse than without split
           if (current_gain > min_gain_shift) {
-            local_gain = current_gain - min_gain_shift;
-            threshold_value = static_cast<uint32_t>(task->num_bin - 2 - bin);
-            threshold_found = true;
+            const double candidate_gain = current_gain - min_gain_shift;
+            if (!threshold_found || candidate_gain > local_gain) {
+              local_gain = candidate_gain;
+              threshold_value = static_cast<uint32_t>(task->num_bin - 2 - bin);
+              threshold_found = true;
+            }
           }
         }
       }
@@ -1211,10 +1219,13 @@ __device__ void FindBestSplitsForLeafKernelInner_GlobalMemory(
             lambda_l2, path_smooth, left_count, right_count, parent_output);
           // gain with split is worse than without split
           if (current_gain > min_gain_shift) {
-            local_gain = current_gain - min_gain_shift;
-            threshold_value = (task->na_as_missing && task->mfb_offset == 1) ?
-              bin : static_cast<uint32_t>(bin + task->mfb_offset);
-            threshold_found = true;
+            const double candidate_gain = current_gain - min_gain_shift;
+            if (!threshold_found || candidate_gain > local_gain) {
+              local_gain = candidate_gain;
+              threshold_value = (task->na_as_missing && task->mfb_offset == 1) ?
+                bin : static_cast<uint32_t>(bin + task->mfb_offset);
+              threshold_found = true;
+            }
           }
         }
       }

--- a/src/treelearner/cuda/cuda_data_partition.cu
+++ b/src/treelearner/cuda/cuda_data_partition.cu
@@ -906,7 +906,9 @@ __global__ void SplitTreeStructureKernel(const int left_leaf_index,
     } else if (global_thread_index == 13) {
       smaller_leaf_splits->data_indices_in_leaf = cuda_data_indices + cuda_leaf_num_data[left_leaf_index];
     } else if (global_thread_index == 14) {
-      cuda_hist_pool[right_leaf_index] = cuda_hist + 2 * right_leaf_index * num_total_bin;
+      cuda_hist_pool[right_leaf_index] = USE_GRAD_DISCRETIZED ?
+        cuda_hist + right_leaf_index * num_total_bin :
+        cuda_hist + 2 * right_leaf_index * num_total_bin;
       smaller_leaf_splits->hist_in_leaf = cuda_hist_pool[right_leaf_index];
     } else if (global_thread_index == 15) {
       larger_leaf_splits->hist_in_leaf = cuda_hist_pool[left_leaf_index];

--- a/src/treelearner/cuda/cuda_data_partition.cu
+++ b/src/treelearner/cuda/cuda_data_partition.cu
@@ -841,6 +841,7 @@ __global__ void SplitTreeStructureKernel(const int left_leaf_index,
       larger_leaf_splits->hist_in_leaf = cuda_hist_pool[right_leaf_index];
     } else if (global_thread_index == 1) {
       smaller_leaf_splits->sum_of_gradients = best_split_info->left_sum_gradients;
+      smaller_leaf_splits->sum_of_gradients_hessians = best_split_info->left_sum_of_gradients_hessians;
     } else if (global_thread_index == 2) {
       smaller_leaf_splits->sum_of_hessians = best_split_info->left_sum_hessians;
     } else if (global_thread_index == 3) {
@@ -855,6 +856,7 @@ __global__ void SplitTreeStructureKernel(const int left_leaf_index,
       larger_leaf_splits->leaf_index = right_leaf_index;
     } else if (global_thread_index == 8) {
       larger_leaf_splits->sum_of_gradients = best_split_info->right_sum_gradients;
+      larger_leaf_splits->sum_of_gradients_hessians = best_split_info->right_sum_of_gradients_hessians;
     } else if (global_thread_index == 9) {
       larger_leaf_splits->sum_of_hessians = best_split_info->right_sum_hessians;
     } else if (global_thread_index == 10) {
@@ -877,6 +879,7 @@ __global__ void SplitTreeStructureKernel(const int left_leaf_index,
       larger_leaf_splits->leaf_index = left_leaf_index;
     } else if (global_thread_index == 1) {
       larger_leaf_splits->sum_of_gradients = best_split_info->left_sum_gradients;
+      larger_leaf_splits->sum_of_gradients_hessians = best_split_info->left_sum_of_gradients_hessians;
     } else if (global_thread_index == 2) {
       larger_leaf_splits->sum_of_hessians = best_split_info->left_sum_hessians;
     } else if (global_thread_index == 3) {
@@ -891,6 +894,7 @@ __global__ void SplitTreeStructureKernel(const int left_leaf_index,
       smaller_leaf_splits->leaf_index = right_leaf_index;
     } else if (global_thread_index == 8) {
       smaller_leaf_splits->sum_of_gradients = best_split_info->right_sum_gradients;
+      smaller_leaf_splits->sum_of_gradients_hessians = best_split_info->right_sum_of_gradients_hessians;
     } else if (global_thread_index == 9) {
       smaller_leaf_splits->sum_of_hessians = best_split_info->right_sum_hessians;
     } else if (global_thread_index == 10) {

--- a/src/treelearner/cuda/cuda_histogram_constructor.cu
+++ b/src/treelearner/cuda/cuda_histogram_constructor.cu
@@ -756,11 +756,19 @@ __global__ void FixHistogramKernel(
   hist_t* feature_hist = cuda_smaller_leaf_splits->hist_in_leaf + feature_hist_offset * 2;
   const unsigned int threadIdx_x = threadIdx.x;
   const uint32_t num_bin = cuda_feature_num_bins[feature_index];
-  const uint32_t hist_pos = threadIdx_x << 1;
-  const hist_t bin_gradient = (threadIdx_x < num_bin && threadIdx_x != most_freq_bin) ? feature_hist[hist_pos] : 0.0f;
-  const hist_t bin_hessian = (threadIdx_x < num_bin && threadIdx_x != most_freq_bin) ? feature_hist[hist_pos + 1] : 0.0f;
-  const hist_t sum_gradient = ShuffleReduceSum<hist_t>(bin_gradient, shared_mem_buffer, num_bin_aligned);
-  const hist_t sum_hessian = ShuffleReduceSum<hist_t>(bin_hessian, shared_mem_buffer, num_bin_aligned);
+  hist_t bin_gradient = 0.0f;
+  hist_t bin_hessian = 0.0f;
+  for (uint32_t bin = threadIdx_x; bin < num_bin; bin += blockDim.x) {
+    if (bin != most_freq_bin) {
+      const uint32_t hist_pos = bin << 1;
+      bin_gradient += feature_hist[hist_pos];
+      bin_hessian += feature_hist[hist_pos + 1];
+    }
+  }
+  const uint32_t reduce_len = min(num_bin_aligned, static_cast<uint32_t>(blockDim.x));
+  const hist_t sum_gradient = ShuffleReduceSum<hist_t>(bin_gradient, shared_mem_buffer, reduce_len);
+  __syncthreads();
+  const hist_t sum_hessian = ShuffleReduceSum<hist_t>(bin_hessian, shared_mem_buffer, reduce_len);
   if (threadIdx_x == 0) {
     feature_hist[most_freq_bin << 1] = leaf_sum_gradients - sum_gradient;
     feature_hist[(most_freq_bin << 1) + 1] = leaf_sum_hessians - sum_hessian;
@@ -849,11 +857,16 @@ __global__ void FixHistogramDiscretizedKernel(
     int32_t* feature_hist = reinterpret_cast<int32_t*>(cuda_smaller_leaf_splits->hist_in_leaf) + feature_hist_offset;
     const unsigned int threadIdx_x = threadIdx.x;
     const uint32_t num_bin = cuda_feature_num_bins[feature_index];
-    const int32_t bin_gradient_hessian = (threadIdx_x < num_bin && threadIdx_x != most_freq_bin) ? feature_hist[threadIdx_x] : 0;
+    int32_t bin_gradient_hessian = 0;
+    for (uint32_t bin = threadIdx_x; bin < num_bin; bin += blockDim.x) {
+      if (bin != most_freq_bin) {
+        bin_gradient_hessian += feature_hist[bin];
+      }
+    }
     const int32_t sum_gradient_hessian = ShuffleReduceSum<int32_t>(
       bin_gradient_hessian,
       reinterpret_cast<int32_t*>(shared_mem_buffer),
-      num_bin_aligned);
+      min(num_bin_aligned, static_cast<uint32_t>(blockDim.x)));
     if (threadIdx_x == 0) {
       feature_hist[most_freq_bin] = leaf_sum_gradients_hessians - sum_gradient_hessian;
     }
@@ -862,8 +875,14 @@ __global__ void FixHistogramDiscretizedKernel(
     int64_t* feature_hist = reinterpret_cast<int64_t*>(cuda_smaller_leaf_splits->hist_in_leaf) + feature_hist_offset;
     const unsigned int threadIdx_x = threadIdx.x;
     const uint32_t num_bin = cuda_feature_num_bins[feature_index];
-    const int64_t bin_gradient_hessian = (threadIdx_x < num_bin && threadIdx_x != most_freq_bin) ? feature_hist[threadIdx_x] : 0;
-    const int64_t sum_gradient_hessian = ShuffleReduceSum<int64_t>(bin_gradient_hessian, shared_mem_buffer, num_bin_aligned);
+    int64_t bin_gradient_hessian = 0;
+    for (uint32_t bin = threadIdx_x; bin < num_bin; bin += blockDim.x) {
+      if (bin != most_freq_bin) {
+        bin_gradient_hessian += feature_hist[bin];
+      }
+    }
+    const int64_t sum_gradient_hessian = ShuffleReduceSum<int64_t>(
+      bin_gradient_hessian, shared_mem_buffer, min(num_bin_aligned, static_cast<uint32_t>(blockDim.x)));
     if (threadIdx_x == 0) {
       feature_hist[most_freq_bin] = leaf_sum_gradients_hessians - sum_gradient_hessian;
     }

--- a/tests/python_package_test/test_cuda.py
+++ b/tests/python_package_test/test_cuda.py
@@ -1,0 +1,190 @@
+# coding: utf-8
+"""Tests for CUDA training correctness versus CPU."""
+
+import numpy as np
+import pytest
+from sklearn.metrics import log_loss, roc_auc_score
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import scale
+
+import lightgbm as lgb
+
+from .utils import BuildInfo
+
+pytestmark = pytest.mark.skipif(not BuildInfo.has_cuda, reason="Requires a CUDA build (TASK=cuda)")
+
+
+def _make_binary_data(n_samples, n_features, zeros=0.0, nans=0.0, random_state=42):
+    """Binary labels from a linear predictor; zeros/NaNs can also predict y.
+
+    After scale(), 1.2 weights the value signal and 0.8 the missingness signal.
+    When zeros>0, draws are |N(5, 2)|+1 so the injected 0s sit outside the dense mass.
+    """
+    rng = np.random.RandomState(random_state)
+    if zeros:
+        X = (np.abs(rng.normal(5.0, 2.0, size=(n_samples, n_features))) + 1.0).astype(np.float32)
+    else:
+        X = rng.normal(size=(n_samples, n_features)).astype(np.float32)
+    u = rng.uniform(size=X.shape)
+    zero_mask = (u < zeros) if zeros else None
+    if zero_mask is not None:
+        X[zero_mask] = 0.0
+    nan_mask = ((u >= zeros) & (u < zeros + nans)) if nans else None
+
+    logits = 1.2 * scale(np.nan_to_num(X, nan=0.0) @ rng.normal(size=n_features))
+    src = zero_mask if (zeros and nans) else nan_mask
+    if src is not None:
+        logits = logits + 0.8 * scale(src[:, : max(1, n_features // 2)].sum(axis=1))
+    y = (rng.uniform(size=n_samples) < 1.0 / (1.0 + np.exp(-logits))).astype(np.float32)
+    if nan_mask is not None:
+        X[nan_mask] = np.nan
+    return X, y
+
+
+def _make_exclusive_nan_data(n_samples, n_groups, group_size, n_values=8, random_state=42):
+    """One finite value per group so LightGBM packs the group into one column.
+
+    n_values=8 keeps per-feature bins small enough to share a column.
+    1.5 / -4.5 make y rare and driven by the last (packed) feature in each group.
+    """
+    rng = np.random.RandomState(random_state)
+    n_features = n_groups * group_size
+    X = np.full((n_samples, n_features), np.nan, dtype=np.float32)
+    which = rng.randint(0, group_size, size=(n_samples, n_groups))
+    vals = rng.randint(1, n_values + 1, size=(n_samples, n_groups)).astype(np.float32)
+    for g in range(n_groups):
+        cols = which[:, g] + g * group_size
+        X[np.arange(n_samples), cols] = vals[:, g]
+    later = np.zeros(n_samples, dtype=np.float64)
+    for g in range(n_groups):
+        later += np.nan_to_num(X[:, g * group_size + group_size - 1], nan=0.0)
+    logits = 1.5 * scale(later) - 4.5
+    y = (rng.uniform(size=n_samples) < 1.0 / (1.0 + np.exp(-logits))).astype(np.float32)
+    return X, y
+
+
+def _train(
+    X,
+    y,
+    device,
+    max_bin,
+    quantized,
+    num_leaves,
+    num_boost_round,
+    min_data_in_leaf=20,
+    # When True, also record LightGBM's own valid binary_logloss (CUDA score
+    # updates on binned data) for comparison with sklearn log_loss on predict().
+    internal_metric=False,
+):
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    params = {
+        "objective": "binary",
+        "metric": "binary_logloss" if internal_metric else "None",
+        "device_type": device,
+        "learning_rate": 0.1,
+        "num_leaves": num_leaves,
+        "max_bin": max_bin,
+        "use_quantized_grad": quantized,
+        "num_grad_quant_bins": 4,
+        "min_data_in_leaf": min_data_in_leaf,
+        "num_threads": 1,
+        "seed": 42,
+        "deterministic": True,
+        "verbose": -1,
+    }
+    lgb_train = lgb.Dataset(X_train, label=y_train, params={"max_bin": max_bin})
+    evals_result = {}
+    if internal_metric:
+        lgb_eval = lgb.Dataset(X_test, label=y_test, reference=lgb_train, params={"max_bin": max_bin})
+        gbm = lgb.train(
+            params,
+            lgb_train,
+            num_boost_round=num_boost_round,
+            valid_sets=lgb_eval,
+            callbacks=[lgb.record_evaluation(evals_result)],
+        )
+    else:
+        gbm = lgb.train(params, lgb_train, num_boost_round=num_boost_round)
+    pred = gbm.predict(X_test)
+    return {
+        "auc": roc_auc_score(y_test, pred),
+        "logloss": log_loss(y_test, pred),
+        "internal_logloss": evals_result["valid_0"]["binary_logloss"][-1] if internal_metric else None,
+    }
+
+
+def _assert_cuda_matches_cpu(
+    X,
+    y,
+    max_bin,
+    quantized,
+    num_leaves,
+    num_boost_round,
+    min_data_in_leaf=20,
+):
+    params = {
+        "max_bin": max_bin,
+        "quantized": quantized,
+        "num_leaves": num_leaves,
+        "num_boost_round": num_boost_round,
+        "min_data_in_leaf": min_data_in_leaf,
+    }
+    cpu = _train(X, y, device="cpu", **params)
+    cuda = _train(X, y, device="cuda", **params)
+    assert abs(cuda["auc"] - cpu["auc"]) < 0.01
+    assert abs(cuda["logloss"] / cpu["logloss"] - 1.0) < 0.02
+
+
+def test_cuda_quantized_multi_leaf():
+    """num_leaves=31 so several splits compound stale packed leaf totals / hist-pool stride."""
+    X, y = _make_binary_data(n_samples=15_000, n_features=20)
+    _assert_cuda_matches_cpu(X, y, max_bin=255, quantized=True, num_leaves=31, num_boost_round=25)
+
+
+def test_cuda_quantized_32bit_histogram():
+    """50k rows so quantized histogram counts exceed 16-bit and must be read as int64."""
+    X, y = _make_binary_data(n_samples=50_000, n_features=20)
+    _assert_cuda_matches_cpu(X, y, max_bin=255, quantized=True, num_leaves=2, num_boost_round=25)
+
+
+def test_cuda_missing_nan_global_split():
+    """max_bin=300 takes the global-memory split finder; nans=0.25 exercises the NaN skip path."""
+    X, y = _make_binary_data(n_samples=60_000, n_features=32, nans=0.25)
+    _assert_cuda_matches_cpu(X, y, max_bin=300, quantized=False, num_leaves=15, num_boost_round=30)
+
+
+def test_cuda_high_max_bin_histogram():
+    """max_bin=768 is past FixHistogram's 512-thread block, so extra bins must be included."""
+    X, y = _make_binary_data(n_samples=80_000, n_features=16)
+    _assert_cuda_matches_cpu(
+        X,
+        y,
+        max_bin=768,
+        quantized=False,
+        num_leaves=2,
+        num_boost_round=30,
+        min_data_in_leaf=100,
+    )
+
+
+def test_cuda_nan_eval_matches_predict():
+    """Packed-column NaNs: internal logloss must match predict() (rtol=0.5)."""
+    X, y = _make_exclusive_nan_data(n_samples=50_000, n_groups=16, group_size=8)
+    result = _train(
+        X, y, device="cuda", max_bin=255, quantized=False, num_leaves=15, num_boost_round=20, internal_metric=True
+    )
+    np.testing.assert_allclose(result["internal_logloss"], result["logloss"], rtol=0.5)
+
+
+def test_cuda_quantized_nan_and_zero():
+    """zeros=0.60 / nans=0.20 so most_freq_bin is 0 (mfb_offset==1) and NaNs are present."""
+    X, y = _make_binary_data(n_samples=50_000, n_features=40, zeros=0.60, nans=0.20)
+    _assert_cuda_matches_cpu(
+        X,
+        y,
+        max_bin=255,
+        quantized=True,
+        num_leaves=31,
+        num_boost_round=25,
+        min_data_in_leaf=50,
+    )


### PR DESCRIPTION
### Summary

This pr fixes a few bugs uncovered when I was playing with gradient quantization and comparing its results with CPU counterpart. Since each fix is relatively small, instead of spamming with prs, I thought it's probably better to lump them all together. For the fixes here to work, changes introduced in https://github.com/lightgbm-org/LightGBM/pull/7374 need to be applied first. It was purposely left out in this pr to avoid duplication.

### Bugs and Fixes

#### `798ee9a3`
`exclusive_result = shared_mem_buffer[warpLane - 1];` will be triggered when `threadIdx.x % warpSize == 0`. However this implies `warpLane` will also be 0 so the access will always be out of bound. The `threadIdx.x % warpSize == 0` branch is the first lane of a given warp. Its exclusive value is all earlier warps, i.e. `shared_mem_buffer[warpID - 1]`.

#### `7b00d44c`
Threads own disjoint chunks of the array. The gain loop after the last `GlobalMemoryPrefixSum` reads `hist_*_buffer_ptr[bin]` across chunks with no barrier. The existing `__syncthreads()` sits before the second call, so it orders the gradient chunk writes against those reads but not the hessian ones written during that call. `__syncthreads()` is therefore added at the end of `GlobalMemoryPrefixSum`, which covers every caller and both calls.

#### `477e2fd7`
`left_sum_of_gradients_hessians` and `right_sum_of_gradients_hessians` are defined in `CUDASplitInfo` but are left out in `SplitTreeStructureKernel` and `CUDASplitInfo::operator=`. 

#### `a8adf0cd`
When `!left_is_smaller && (global_thread_index == 14)`, `cuda_hist_pool[right_leaf_index]` is always set to `cuda_hist + 2 * right_leaf_index * num_total_bin`. Under `USE_GRAD_DISCRETIZED` each bin is one packed entry, so the stride should be `num_total_bin` as shown in the `left_is_smaller` branch.

#### `225cdd09`
Non–16-bit quantized bins are packed int64. `FindBestSplitsDiscretizedForLeafKernel` does `reinterpret_cast<const int32_t*>(hist_in_leaf)` and instantiates `BIN_HIST_TYPE = int32_t`, so pointer arithmetic and loads only see half of each bin.

#### `ecc9974c`
`feature_hist_*_buffer` was indexed as `hist_offset * 2` and sized `num_total_bin`. `hist_offset` is already a bin offset, so * 2 is out of bound for features past the halfway point even with a single task. When `MissingType != None`, forward and reverse for the same feature also share that slot, so reverse overwrites forward. The buffer is now sized `2 * num_total_bin` and indexed with `buffer_offset` (hist_offset, plus num_total_bin for reverse). This arguably wastes space as not all features scan in both directions. I feel this is fine here as 1) the space used overall is small 2) it retains the original way of keeping the buffer so less change is required.

#### `c5e89091`
In `FindBestSplitsForLeafKernelInner_GlobalMemory`, reverse `skip_sum` uses `bin >= na_as_missing`. The shared kernel skips `bin < na_as_missing`. Separately, the `bin += blockDim.x` loop overwrites `local_gain` / `threshold_value` with the last valid bin; `ReduceBestGain` needs each thread’s max.

#### `de24ae49`
`FixHistogramKernel` and `FixHistogramDiscretizedKernel` use `threadIdx_x` as the bin index. When `num_bin > blockDim.x`, higher bins never enter the most frequent bin reconstruction. `ShuffleReduceSum` is also clamped to `min(num_bin_aligned, blockDim.x)`, and `__syncthreads()` is added between the full precision grad and hess reductions which share `shared_mem_buffer`. This only triggers at large `max_bin`, which is rare, but since it is not prohibited I figured it is probably best fixed.

#### `6f7b5c92`
`AddPredictionToScoreKernel` remaps `bin = bin - min_bin + offset`, then tests `MissingType::NaN` against column-space max_bin. After remap the last feature bin is `max_bin - min_bin + offset`.

#### `11e3db47`
When gradient quantization is not used, `FindBestSplitsForLeafKernelInner` recovers omitted bin 0 when `na_as_missing && mfb_offset == 1`. `FindBestSplitsDiscretizedForLeafKernelInner` has no such path, so implicit bin-0 mass is missing from the quantized prefix sum. The changes are mostly adapted from the code path without quantization. 

### Validation

Attached is a script I used to show the bugs and confirm the fixes worked. Instructions on how to run and test are included. As a reminder, changes in https://github.com/lightgbm-org/LightGBM/pull/7374 need to be incorporated first. While the fixes in `798ee9a3` and `7b00d44c` are unit-testable, there are no existing C++ tests for the CUDA path, so I omitted adding those tests here. The script has six cases for the eight remaining fixes: `477e2fd7`+`a8adf0cd` share `quantized_multi_leaf`, and `ecc9974c`+`c5e89091` share `global_nan`; those pairs cannot be separated end-to-end.

<details>
  <summary>full test script</summary>

```python
#!/usr/bin/env python
"""CUDA quantization / correctness checks.

Uncomment cases from top to bottom as matching fixes are applied.
Fail on unfixed code; pass after the fix.

    python run.py
"""

from __future__ import annotations

import os
from pathlib import Path

import numpy as np
import pandas as pd
from sklearn.metrics import log_loss, roc_auc_score
from sklearn.preprocessing import scale

HERE = Path(__file__).resolve().parent
SEED = 42
QUANT_BINS = 4
# Bosch dataset is downloaded from kaggle: https://www.kaggle.com/c/bosch-production-line-performance
BOSCH_CSV = Path(os.environ.get("BOSCH_CSV", HERE.parent / "train_numeric.csv"))


def synth(rows: int, feats: int, zeros: float = 0.0, nans: float = 0.0, seed: int = SEED):
    """Synthetic binary data; optional zero/NaN fractions are also predictive of y."""
    rng = np.random.RandomState(seed)
    if zeros:
        x = (np.abs(rng.normal(5.0, 2.0, size=(rows, feats))) + 1.0).astype(np.float32)
    else:
        x = rng.normal(size=(rows, feats)).astype(np.float32)
    u = rng.uniform(size=x.shape)
    zero_mask = (u < zeros) if zeros else None
    if zero_mask is not None:
        x[zero_mask] = 0.0
    nan_mask = ((u >= zeros) & (u < zeros + nans)) if nans else None

    logits = 1.2 * scale(np.nan_to_num(x, nan=0.0) @ rng.normal(size=feats))
    src = zero_mask if (zeros and nans) else nan_mask
    if src is not None:
        logits = logits + 0.8 * scale(src[:, : max(1, feats // 2)].sum(axis=1))
    y = (rng.uniform(size=rows) < 1 / (1 + np.exp(-logits))).astype(np.float32)
    if nan_mask is not None:
        x[nan_mask] = np.nan
    return x, y


def load_bosch(rows: int = 80_000, n_features: int = 120):
    if not BOSCH_CSV.exists():
        raise FileNotFoundError(
            f"missing Bosch CSV: {BOSCH_CSV}\n"
            "place train_numeric.csv under higgs_training/ or set BOSCH_CSV="
        )
    header = pd.read_csv(BOSCH_CSV, nrows=0)
    feature_cols = [c for c in header.columns if c not in ("Id", "Response")][:n_features]
    df = pd.read_csv(BOSCH_CSV, usecols=feature_cols + ["Response"], nrows=rows,
                     dtype=np.float32)
    return df[feature_cols].to_numpy(), df["Response"].to_numpy()


def train(x, y, device, max_bin, quantized, num_leaves, rounds,
          min_data_in_leaf=20, internal_metric=False):
    import lightgbm as lgb

    split = int(0.8 * x.shape[0])
    params = {
        "objective": "binary",
        "metric": "binary_logloss" if internal_metric else "None",
        "device_type": device, "gpu_device_id": 0,
        "learning_rate": 0.1, "num_leaves": num_leaves, "max_bin": max_bin,
        "use_quantized_grad": quantized, "num_grad_quant_bins": QUANT_BINS,
        "min_data_in_leaf": min_data_in_leaf, "num_threads": 8,
        "seed": SEED, "deterministic": True, "verbosity": -1,
    }
    ds_params = {"max_bin": max_bin}
    train_set = lgb.Dataset(x[:split], label=y[:split], params=ds_params)
    result = {}
    if internal_metric:
        valid = lgb.Dataset(x[split:], label=y[split:], reference=train_set, params=ds_params)
        booster = lgb.train(params, train_set, num_boost_round=rounds, valid_sets=[valid],
                            valid_names=["v"], callbacks=[lgb.record_evaluation(result)])
    else:
        booster = lgb.train(params, train_set, num_boost_round=rounds)
    pred = booster.predict(x[split:])
    return {
        "auc": float(roc_auc_score(y[split:], pred)),
        "logloss": float(log_loss(y[split:], pred)),
        "internal_logloss": float(result["v"]["binary_logloss"][-1]) if internal_metric else None,
    }


def cpu_vs_cuda(name, x, y, max_bin, quantized, num_leaves, rounds,
                min_data_in_leaf=20):
    """Shared bounds with test_cuda.py: |ΔAUC| < 0.01 and |logloss ratio − 1| < 0.02 (needs #7374 for quantized)."""
    kw = dict(max_bin=max_bin, quantized=quantized, num_leaves=num_leaves,
              rounds=rounds, min_data_in_leaf=min_data_in_leaf)
    cpu = train(x, y, device="cpu", **kw)
    cuda = train(x, y, device="cuda", **kw)
    auc_delta = cuda["auc"] - cpu["auc"]
    ratio = cuda["logloss"] / max(cpu["logloss"], 1e-12)
    ok = abs(auc_delta) < 0.01 and abs(ratio - 1.0) < 0.02
    print(f"{'PASS' if ok else 'FAIL'}  {name}  "
          f"auc_delta={auc_delta:+.4f}  logloss_ratio={ratio:.4f}")
    assert ok, name


def bosch_score(name="bosch_score"):
    x, y = load_bosch(80_000, n_features=120)
    r = train(x, y, device="cuda", max_bin=255, quantized=False,
              num_leaves=15, rounds=20, internal_metric=True)
    ratio = r["internal_logloss"] / max(r["logloss"], 1e-12)
    ok = abs(ratio - 1.0) < 0.5
    print(f"{'PASS' if ok else 'FAIL'}  {name}  "
          f"internal_over_predict={ratio:.4f}  internal_logloss={r['internal_logloss']:.4f}")
    np.testing.assert_allclose(r["internal_logloss"], r["logloss"], rtol=0.5)


if __name__ == "__main__":
    # Uncomment top → bottom as matching fixes are applied on
    # gpu-quantization-bug-fixes (798ee9a3+7b00d44c, then 477e2fd7, a8adf0cd,
    # 225cdd09, ecc9974c, c5e89091, de24ae49, 6f7b5c92, 11e3db47).
    # Baseline needs PR #7374.

    # quantized_multi_leaf  (477e2fd7+a8adf0cd)
    cpu_vs_cuda("quantized_multi_leaf", *synth(15_000, 20),
                max_bin=255, quantized=True, num_leaves=31, rounds=25)

    # quantized_32bit  (225cdd09)
    # cpu_vs_cuda("quantized_32bit", *synth(50_000, 20),
    #             max_bin=255, quantized=True, num_leaves=2, rounds=25)

    # global_nan  (ecc9974c + c5e89091) — covers both; a global-path NaN test
    # necessarily exercises the REVERSE skip predicate and the strided
    # per-thread best-bin loop, so the two cannot be separated end-to-end.
    # cpu_vs_cuda("global_nan", *synth(60_000, 32, nans=0.25),
    #             max_bin=300, quantized=False, num_leaves=15, rounds=30)

    # fixhistogram_high_bins (de24ae49) — after 798ee9a3+7b00d44c and through c5e89091;
    # dense features so most_freq_bin != 0 and FixHistogram actually runs.
    # cpu_vs_cuda("fixhistogram_high_bins", *synth(80_000, 16),
    #             max_bin=768, quantized=False, num_leaves=2, rounds=30,
    #             min_data_in_leaf=100)

    # bosch_score  (6f7b5c92)
    # bosch_score()

    # quantized_nan_zero  (11e3db47)
    # cpu_vs_cuda("quantized_nan_zero", *synth(50_000, 40, zeros=0.60, nans=0.20),
    #             max_bin=255, quantized=True, num_leaves=31, rounds=25,
    #             min_data_in_leaf=50)

```
</details>