### PR TITLE
[ci] check-omp-pragmas: limit to files in source control

### DIFF
--- a/.ci/check-omp-pragmas.sh
+++ b/.ci/check-omp-pragmas.sh
@@ -4,15 +4,10 @@ set -e -u
 
 echo "checking that all OpenMP pragmas specify num_threads()"
 get_omp_pragmas_without_num_threads() {
-    grep \
+    git grep \
         -n \
-        -R \
-        --include='*.c' \
-        --include='*.cc' \
-        --include='*.cpp' \
-        --include='*.h' \
-        --include='*.hpp' \
         'pragma omp parallel' \
+        -- '*.c' '*.cc' '*.cpp' '*.cu' '*.cuh' '*.h' '*.hpp' '*.tpp' \
     | grep -v ' num_threads'
 }
 


### PR DESCRIPTION
This PR ensures that the `check-omp-pragmas` check only checks LightGBM's own first-party source code, not:

* code pulled in via submodules
* other untracked code in the repo (e.g. code in Python virtual environments)

For some situations, this makes local runs of `pre-commit run --all-files` faster and removes a source of false positives.

While touching this, also added a few more C/C++ extension types to the check:

* `.cu` (CUDA C++ source files)
* `.cuh` (CUDA C++ headers)
* `.tpp` (C++ template files)

## Notes for Reviewers

### How I found this

I've recently switched from using `conda` for Python development here to virtualenvs, and frequently do stuff like this:

```shell
python -m venv .venv
source .venv/bin/activate
pip install numpy scipy scikit-learn
# etc., etc.
```

When I started doing that, I found that `check-omp-pragmas` at time was noticably slower, and occasionally reported findings in files that weren't part of LightGBM.

### How I tested this

Manually removed a `num_threads()` class from the following places:

* `include/LightGBM/bin.h` here
* some places in `external_libs/eigen`
* a copy of `bin.h` placed in `.venv/`

Saw what I expected... only the first-party LightGBM one was reported and the hook failed.

```console
$ pre-commit run --all-files check-omp-pragmas
check-omp-pragmas........................................................Failed
- hook id: check-omp-pragmas
- exit code: 1

checking that all OpenMP pragmas specify num_threads()
include/LightGBM/bin.h:68:  #pragma omp parallel for schedule(static)
Found '#pragma omp parallel' not using explicit num_threads() configuration. Fix those.
For details, see https://www.openmp.org/spec-html/5.0/openmpse14.html#x54-800002.6
```