### PR TITLE
[python-package] resolve pytest deprecation warning about generator use

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1520,21 +1520,21 @@ def test_init_score(task, output, cluster, rng):
             assert_eq(pred, pred_init_score)
 
 
-def sklearn_checks_to_run():
-    check_names = ["check_estimator_get_tags_default_keys", "check_get_params_invariance", "check_set_params"]
-    for check_name in check_names:
-        check_func = getattr(sklearn_checks, check_name, None)
-        if check_func:
-            yield check_func
-
-
-def _tested_estimators():
-    for Estimator in [lgb.DaskLGBMClassifier, lgb.DaskLGBMRegressor]:
-        yield Estimator()
-
-
-@pytest.mark.parametrize("estimator", _tested_estimators())
-@pytest.mark.parametrize("check", sklearn_checks_to_run())
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        lgb.DaskLGBMClassifier(),
+        lgb.DaskLGBMRanker(),
+        lgb.DaskLGBMRegressor(),
+    ],
+)
+@pytest.mark.parametrize(
+    "check",
+    [
+        sklearn_checks.check_get_params_invariance,
+        sklearn_checks.check_set_params,
+    ],
+)
 def test_sklearn_integration(estimator, check, cluster):
     with Client(cluster):
         estimator.set_params(local_listen_port=18000, time_out=5)
@@ -1543,7 +1543,14 @@ def test_sklearn_integration(estimator, check, cluster):
 
 
 # this test is separate because it takes a not-yet-constructed estimator
-@pytest.mark.parametrize("estimator", list(_tested_estimators()))
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        lgb.DaskLGBMClassifier,
+        lgb.DaskLGBMRanker,
+        lgb.DaskLGBMRegressor,
+    ],
+)
 def test_parameters_default_constructible(estimator):
     name = estimator.__class__.__name__
     Estimator = estimator

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1532,6 +1532,7 @@ def test_init_score(task, output, cluster, rng):
     "check",
     [
         sklearn_checks.check_get_params_invariance,
+        sklearn_checks.check_parameters_default_constructible,
         sklearn_checks.check_set_params,
     ],
 )
@@ -1540,21 +1541,6 @@ def test_sklearn_integration(estimator, check, cluster):
         estimator.set_params(local_listen_port=18000, time_out=5)
         name = type(estimator).__name__
         check(name, estimator)
-
-
-# this test is separate because it takes a not-yet-constructed estimator
-@pytest.mark.parametrize(
-    "estimator",
-    [
-        lgb.DaskLGBMClassifier,
-        lgb.DaskLGBMRanker,
-        lgb.DaskLGBMRegressor,
-    ],
-)
-def test_parameters_default_constructible(estimator):
-    name = estimator.__class__.__name__
-    Estimator = estimator
-    sklearn_checks.check_parameters_default_constructible(name, Estimator)
 
 
 @pytest.mark.parametrize("task", tasks)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1860,12 +1860,28 @@ def test_feature_names_in_and_predict_warning(
 # can be compatible with scikit-learn <1.6 and >=1.6.
 #
 # This should be removed once minimum supported scikit-learn version is at least 1.6.
-if SKLEARN_VERSION_GTE_1_6:
-    parametrize_with_checks = sklearn_parametrize_with_checks
-else:
+def parametrize_with_checks(estimator, *args, **kwargs):
+    if SKLEARN_VERSION_GTE_1_6:
+        mark_decorator = sklearn_parametrize_with_checks(estimator, *args, **kwargs)
+    else:
+        mark_decorator = sklearn_parametrize_with_checks(estimator)
 
-    def parametrize_with_checks(estimator, *args, **kwargs):
-        return sklearn_parametrize_with_checks(estimator)
+    # Some time around pytest 9.1, 'pytest' started raising a deprecation warning
+    # when 'pytest.parametrize()` inputs used generators.
+    #
+    # see: https://github.com/scikit-learn/scikit-learn/issues/34738
+    #
+    # scikit-learn's `sklearn.utils.estimator_checks.parametrize_with_checks()`
+    # returns a generator of checks.
+    #
+    # This make's LightGBM's use of `sklearn.utils.estimator_checks.parametrize_with_checks()`
+    # compatible with newer and older versions of 'pytest', so tests won't be broken
+    # when pytest '10.x' starts raising an exception for those inputs.
+    #
+    # This workaround can be removed if LightGBM drops its use of parametrize_with_checks()
+    # or its minimum scikit-learn version contains https://github.com/scikit-learn/scikit-learn/pull/34448
+    argnames, argvalues = mark_decorator.args
+    return pytest.mark.parametrize(argnames, list(argvalues), **mark_decorator.kwargs)
 
 
 def _get_expected_failed_tests(estimator):


### PR DESCRIPTION
Recent `pytest` releases raise this warning:

> ../../../opt/miniforge/envs/test-env/lib/python3.11/site-packages/_pytest/python.py:124
  /opt/miniforge/envs/test-env/lib/python3.11/site-packages/_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: tests/python_package_test/test_dask.py::test_sklearn_integration, argvalues type: generator
  Please convert to a list or tuple.
  See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)

([build link](https://github.com/lightgbm-org/LightGBM/actions/runs/32676330021/job/97285093294?pr=7405#step:7:2526))

One of those comes from `lightgbm`'s own test code, one from `scikit-learn`'s `parametrize_with_checks()`.

This fixes both, so LightGBM's Python test suite will continue to work whenever `pytest` 10.x is released and turns this warning to an error.