### PR TITLE
[c++] Initialize uninitialized member variables flagged by cppcheck

### DIFF
--- a/src/network/linker_topo.cpp
+++ b/src/network/linker_topo.cpp
@@ -48,12 +48,17 @@ BruckMap BruckMap::Construct(int rank, int num_machines) {
 
 RecursiveHalvingMap::RecursiveHalvingMap() {
   k = 0;
+  type = RecursiveHalvingNodeType::Other;
+  is_power_of_2 = false;
+  neighbor = -1;
 }
 
 RecursiveHalvingMap::RecursiveHalvingMap(int in_k, RecursiveHalvingNodeType _type, bool _is_power_of_2) {
   type = _type;
   k = in_k;
   is_power_of_2 = _is_power_of_2;
+  // default set as -1, may be overwritten below depending on node type
+  neighbor = -1;
   if (type != RecursiveHalvingNodeType::Other) {
     for (int i = 0; i < k; ++i) {
       // default set as -1

--- a/src/network/linkers.h
+++ b/src/network/linkers.h
@@ -39,6 +39,12 @@ class Linkers {
  public:
   Linkers() {
     is_init_ = false;
+    rank_ = 0;
+    num_machines_ = 1;
+    #ifdef USE_SOCKET
+    socket_timeout_ = 0;
+    local_listen_port_ = 0;
+    #endif
   }
   /*!
   * \brief Constructor


### PR DESCRIPTION
## Summary

Fixes `uninitMemberVar` warnings in `src/network/` found by running `cppcheck` as described in #4539.

- `RecursiveHalvingMap`'s default constructor left `type`, `is_power_of_2`, and `neighbor` uninitialized. `Network::recursive_halving_map_` is a `THREAD_LOCAL` instance of this class, and `is_power_of_2`/`type`/`neighbor` are read directly in `Network`'s allreduce/allgather code paths (e.g. `network.cpp:153,246,256-263,268-296`), so an uninitialized read is reachable before the map is populated by `Network::Init`.
- `RecursiveHalvingMap`'s parameterized constructor also never set `neighbor` — it's only assigned later in `Construct()` for `GroupLeader`/`Other` node types, so `Normal`-type instances left it uninitialized.
- `Linkers`' default constructor left `rank_`, `num_machines_`, `socket_timeout_`, and `local_listen_port_` uninitialized.

Defaults chosen to match existing conventions in the same files (`Network::rank_`/`num_machines_` already default to `0`/`1`; `-1` is already used elsewhere in `linker_topo.cpp` as the "unset" sentinel for rank-like fields).

## How I found this

Ran cppcheck per the instructions in #4539:
```
cppcheck --force --enable=all --std=c++11 -I include/ \
    -UDEBUG -ULABEL_T_USE_DOUBLE -ULGB_R_BUILD -USCORE_T_USE_DOUBLE \
    -Usun -U__sun -U__SVR4 -U__svr4__ -UTIMETAG -UUSE_CUDA -UUSE_GPU -UUSE_MPI \
    src/network/
```

## Testing

- Confirmed the `uninitMemberVar` warnings for these two classes no longer appear after the fix (re-ran the same cppcheck command against `src/network/`).
- Verified `src/network/linker_topo.cpp`, `src/network/network.cpp` (no `USE_SOCKET`), and `src/network/linkers_socket.cpp` (`-DUSE_SOCKET`) all still compile (`g++ -fsyntax-only`) with submodules (`fast_double_parser`, `fmt`, `eigen`) initialized.

Contributes to #4539.