### PR TITLE
[c++] Initialize TrainingShareStates::bagging_use_indices / bagging_indices_cnt

### DIFF
--- a/include/LightGBM/train_share_states.h
+++ b/include/LightGBM/train_share_states.h
@@ -275,6 +275,8 @@ struct TrainingShareStates {
 
   TrainingShareStates() {
     multi_val_bin_wrapper_.reset(nullptr);
+    bagging_use_indices = nullptr;
+    bagging_indices_cnt = 0;
   }
 
   int num_hist_total_bin() const { return num_hist_total_bin_; }


### PR DESCRIPTION
## Summary

Fixes an `uninitMemberVar` warning from `cppcheck` (#4539) for `TrainingShareStates`'s default constructor, which left `bagging_use_indices` (a raw pointer) and `bagging_indices_cnt` uninitialized.

## Why this is worth fixing even though it's not currently reachable

`bagging_use_indices`/`bagging_indices_cnt` are only ever assigned together, in `SerialTreeLearner::SetBaggingData` (`src/treelearner/serial_tree_learner.h`), at the same time `is_use_subrow_` is set via `SetUseSubrow(true)`. They're only read (in `MultiValBinWrapper::CopyMultiValBinSubset`) when `is_use_subrow_` is true, so today the gating flag and the pointer/count are always set together and there's no live bug.

Still, leaving a raw pointer member uninitialized is fragile — any future refactor that reads `bagging_use_indices` before that invariant is established, or that decouples the two, would silently dereference garbage memory instead of failing loudly on a null pointer. Initializing to `nullptr`/`0` costs nothing and removes the footgun (and the cppcheck warning).

## Testing

- `cppcheck` no longer reports `uninitMemberVar` for `TrainingShareStates` on `src/io/train_share_states.cpp`.
- Verified `src/io/train_share_states.cpp` and `src/treelearner/serial_tree_learner.cpp` still compile (`g++ -fsyntax-only`) with submodules initialized.

Contributes to #4539.