### PR TITLE
[ci] [python-package] add Windows arm64 (win-arm64) support

### DIFF
--- a/.ci/create-nuget.py
+++ b/.ci/create-nuget.py
@@ -23,6 +23,17 @@ if __name__ == "__main__":
     copyfile(source / "lib_lightgbm.dylib", osx_folder_path / "lib_lightgbm.dylib")
     copyfile(source / "lib_lightgbm.dll", windows_folder_path / "lib_lightgbm.dll")
     copyfile(source / "lightgbm.exe", windows_folder_path / "lightgbm.exe")
+
+    # win-arm64 build artifacts live in their own 'win-arm64' subfolder so they don't collide
+    # with the win-x64 ones above when both get merged into the same source directory (see
+    # the 'arm64' branch of the 'regular' task in '.ci/test-windows.ps1')
+    windows_arm64_dll = source / "win-arm64" / "lib_lightgbm.dll"
+    windows_arm64_exe = source / "win-arm64" / "lightgbm.exe"
+    if windows_arm64_dll.exists() and windows_arm64_exe.exists():
+        windows_arm64_folder_path = nuget_dir / "runtimes" / "win-arm64" / "native"
+        windows_arm64_folder_path.mkdir(parents=True, exist_ok=True)
+        copyfile(windows_arm64_dll, windows_arm64_folder_path / "lib_lightgbm.dll")
+        copyfile(windows_arm64_exe, windows_arm64_folder_path / "lightgbm.exe")
     version = (nuget_dir.parents[1] / "VERSION.txt").read_text(encoding="utf-8").strip().replace("rc", "-rc")
     print(f"Setting version to '{version}'")
     nuget_str = rf"""<?xml version="1.0"?>
@@ -61,6 +72,16 @@ if __name__ == "__main__":
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Visible>false</Visible>
         </Content>
+        <Content Include="$(MSBuildThisFileDirectory)/../runtimes/win-arm64/native/*.dll"
+                Condition="'$(PlatformTarget)' == 'ARM64'">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Visible>false</Visible>
+        </Content>
+        <Content Include="$(MSBuildThisFileDirectory)/../runtimes/win-arm64/native/*.exe"
+                Condition="'$(PlatformTarget)' == 'ARM64'">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Visible>false</Visible>
+        </Content>
     </ItemGroup>
     </Project>
     """
@@ -72,10 +93,10 @@ if __name__ == "__main__":
     <Target Name="_LightGBMCheckForUnsupportedPlatformTarget"
             Condition="'$(EnableLightGBMUnsupportedPlatformTargetCheck)' == 'true'"
             AfterTargets="_CheckForInvalidConfigurationAndPlatform">
-        <Error Condition="'$(PlatformTarget)' != 'x64' AND
+        <Error Condition="'$(PlatformTarget)' != 'x64' AND '$(PlatformTarget)' != 'ARM64' AND
                         ('$(OutputType)' == 'Exe' OR '$(OutputType)'=='WinExe') AND
                         !('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(PlatformTarget)' == '')"
-            Text="LightGBM currently supports 'x64' processor architectures. Please ensure your application is targeting 'x64'." />
+            Text="LightGBM currently supports 'x64' and 'ARM64' processor architectures. Please ensure your application is targeting one of those." />
     </Target>
     </Project>
     """

--- a/.ci/install-python-arm64-windows.ps1
+++ b/.ci/install-python-arm64-windows.ps1
@@ -1,0 +1,51 @@
+# [description]
+#
+#   Installs a native win-arm64 CPython on the 'windows-11-arm' CI runner.
+#
+#   That runner's pre-installed Miniconda targets x64 (conda-forge / Miniforge don't yet
+#   support win-arm64: https://conda-forge.org/blog/2026/02/09/win-arm64/) and would run
+#   under emulation, and 'actions/setup-python' does not yet resolve an arm64 interpreter
+#   on Windows (https://github.com/actions/setup-python/issues/976). python.org has
+#   published native win-arm64 installers since Python 3.11, so install directly from there.
+#
+# [usage]
+#
+#   pwsh -File .ci/install-python-arm64-windows.ps1
+
+function Assert-Output {
+    param( [Parameter(Mandatory = $true)][bool]$success )
+    if (-not $success) {
+        $host.SetShouldExit(-1)
+        exit 1
+    }
+}
+
+$PythonVersion = "3.13.1"
+$InstallDir = "$env:USERPROFILE\python-arm64"
+$Installer = "python-$PythonVersion-arm64.exe"
+$Uri = "https://www.python.org/ftp/python/$PythonVersion/$Installer"
+
+Write-Output "Downloading $Uri"
+$ProgressPreference = "SilentlyContinue"  # progress bar bug extremely slows down download speed
+Invoke-WebRequest -Uri $Uri -OutFile $Installer ; Assert-Output $?
+
+Write-Output "Installing Python $PythonVersion (arm64) to $InstallDir"
+$installArgs = @(
+    "/quiet",
+    "InstallAllUsers=0",
+    "PrependPath=0",
+    "Include_launcher=0",
+    "Include_test=0",
+    "TargetDir=$InstallDir"
+)
+Start-Process -FilePath ".\$Installer" -ArgumentList $installArgs -Wait
+
+if (-not (Test-Path "$InstallDir\python.exe")) {
+    Write-Output "Python installation failed"
+    $host.SetShouldExit(-1)
+    exit 1
+}
+
+# make this Python (and 'pip'-installed console scripts) available to later steps in this job
+Add-Content -Path $env:GITHUB_PATH -Value $InstallDir
+Add-Content -Path $env:GITHUB_PATH -Value "$InstallDir\Scripts"

--- a/.ci/pip-envs/requirements-windows-arm64.txt
+++ b/.ci/pip-envs/requirements-windows-arm64.txt
@@ -1,0 +1,57 @@
+# [description]
+#
+#   Test dependencies for the 'windows-11-arm' CI job.
+#
+#   conda-forge / Miniforge do not yet support win-arm64 (still experimental,
+#   cross-compiled, and missing packages like 'numpy':
+#   https://conda-forge.org/blog/2026/02/09/win-arm64/), so that job uses a native
+#   win-arm64 CPython (installed by '.ci/install-python-arm64-windows.ps1') and pip
+#   instead of conda, unlike every other Windows CI job.
+#
+#   This intentionally excludes 'pyarrow' and 'python-graphviz': PyPI doesn't publish a
+#   'win_arm64' wheel for pyarrow, and the Graphviz binary that 'python-graphviz' wraps
+#   isn't known to be available for win-arm64 yet. Every test that needs either of them
+#   guards itself with a skip (see 'is_windows_arm64()' / 'SKIP_PYARROW_REASON' in
+#   tests/python_package_test/utils.py, and their use in test_arrow.py, test_sklearn.py,
+#   and test_plotting.py), so not installing them here just means those specific tests
+#   are skipped on this runner instead of failing.
+#
+#   'lightgbm's own polars ingestion (see 'basic.py') reads the Arrow C Data Interface
+#   capsule that polars exposes natively, via raw ctypes pointers, so it needs no pyarrow
+#   at all. A handful of test_polars.py tests still need it, though, because THEY call
+#   polars' own '.to_pandas()' (which does require pyarrow) to build a reference pandas
+#   Dataset for a round-trip equality check; those specific tests skip on this runner
+#   too (see 'test_dataset_construct_fuzzy', 'test_dataset_construct_fuzzy_boolean',
+#   'test_dataset_construct_fields_fuzzy', and 'assert_equal_predict_polars_pandas').
+#
+#   For the same reason, 'dask' below is installed with only its 'array' and 'distributed'
+#   extras, not 'dataframe': the 'dataframe' extra hard-depends on 'pyarrow>=16.0'
+#   (see its PyPI project page), which would silently drag pyarrow back in. dask.dataframe
+#   still works on top of the plain 'pandas' install below; it just won't use
+#   pyarrow-backed string columns.
+#
+# [usage]
+#
+#   pip install -r ./.ci/pip-envs/requirements-windows-arm64.txt
+#
+
+# direct imports
+cffi
+cloudpickle
+dask[array,distributed]
+joblib
+matplotlib
+narwhals
+numpy
+pandas
+polars
+psutil
+pytest
+scikit-learn
+scipy
+
+# build-time dependencies
+build
+pip
+setuptools
+wheel

--- a/.ci/test-windows.ps1
+++ b/.ci/test-windows.ps1
@@ -23,8 +23,12 @@ if ($env:TASK -eq "r-package") {
     exit 0
 }
 
+# native arm64 runners report PROCESSOR_ARCHITECTURE=ARM64; everything else builds for x64
+$IsArm64 = ($env:PROCESSOR_ARCHITECTURE -eq "ARM64")
+$CmakePlatform = if ($IsArm64) { "ARM64" } else { "x64" }
+
 if ($env:TASK -eq "cpp-tests") {
-    cmake -B build -S . -DBUILD_CPP_TEST=ON -DUSE_DEBUG=ON -A x64
+    cmake -B build -S . -DBUILD_CPP_TEST=ON -DUSE_DEBUG=ON -A $CmakePlatform
     cmake --build build --target testlightgbm --config Debug ; Assert-Output $?
     .\Debug\testlightgbm.exe ; Assert-Output $?
     exit 0
@@ -67,8 +71,22 @@ if ($env:TASK -eq "swig") {
     exit 0
 }
 
+if ($IsArm64) {
+    # conda-forge / Miniforge don't support win-arm64 yet (still experimental,
+    # untested, and missing packages like 'numpy': https://conda-forge.org/blog/2026/02/09/win-arm64/).
+    # Use the native win-arm64 CPython installed by '.ci/install-python-arm64-windows.ps1'
+    # (already on PATH) and pip instead.
+    #
+    # NOTE: 'pyarrow' is intentionally not installed here. PyPI does not publish a
+    # 'win_arm64' wheel for it, so it's left out of requirements-windows-arm64.txt on
+    # purpose. Every test that needs it guards itself with 'pytest.importorskip("pyarrow")'
+    # (see tests/python_package_test/test_arrow.py and test_sklearn.py), so those tests
+    # are automatically skipped on this runner instead of failing.
+    pip install -q -U pip "build>=0.10" ; Assert-Output $?
+    pip install -q -r "$env:BUILD_SOURCESDIRECTORY/.ci/pip-envs/requirements-windows-arm64.txt" ; Assert-Output $?
+}
 # 'pixi' is used for end-of-life Python versions
-if ($env:PYTHON_VERSION -eq "3.10") {
+elseif ($env:PYTHON_VERSION -eq "3.10") {
     $activation = ((& pixi shell-hook --locked -e py310 --shell powershell) -join "`n")
     Invoke-Expression $activation ; Assert-Output $?
 } else {
@@ -124,33 +142,49 @@ if ($env:PYTHON_VERSION -eq "3.10") {
 
 Set-Location "$env:BUILD_SOURCESDIRECTORY"
 if ($env:TASK -eq "regular") {
-    cmake -B build -S . -A x64 ; Assert-Output $?
+    cmake -B build -S . -A $CmakePlatform ; Assert-Output $?
     cmake --build build --target ALL_BUILD --config Release ; Assert-Output $?
     sh ./build-python.sh install --precompile ; Assert-Output $?
-    cp ./Release/lib_lightgbm.dll "$env:BUILD_ARTIFACTSTAGINGDIRECTORY"
-    cp ./Release/lightgbm.exe "$env:BUILD_ARTIFACTSTAGINGDIRECTORY"
+    if ($IsArm64) {
+        # put these in their own subfolder so this artifact's files don't collide with the
+        # win-x64 build's identically-named ones once both get merged into one directory
+        # later (see '.ci/create-nuget.py'); the workflow's 'Upload artifacts' step keeps
+        # this subfolder intact because its *.dll/*.exe patterns match paths below it
+        [Void][System.IO.Directory]::CreateDirectory("$env:BUILD_ARTIFACTSTAGINGDIRECTORY/win-arm64")
+        cp ./Release/lib_lightgbm.dll "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/win-arm64/lib_lightgbm.dll"
+        cp ./Release/lightgbm.exe "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/win-arm64/lightgbm.exe"
+    } else {
+        cp ./Release/lib_lightgbm.dll "$env:BUILD_ARTIFACTSTAGINGDIRECTORY"
+        cp ./Release/lightgbm.exe "$env:BUILD_ARTIFACTSTAGINGDIRECTORY"
+    }
 } elseif ($env:TASK -eq "sdist") {
     sh ./build-python.sh sdist ; Assert-Output $?
     sh ./.ci/check-python-dists.sh ./dist ; Assert-Output $?
     Set-Location dist; pip install --no-deps @(Get-ChildItem *.gz) -v ; Assert-Output $?
 } elseif ($env:TASK -eq "bdist") {
-    # Import the Chocolatey profile module so that the RefreshEnv command
-    # invoked below properly updates the current PowerShell session environment.
-    $module = "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
-    Import-Module "$module" ; Assert-Output $?
-    RefreshEnv
+    if ($IsArm64) {
+        $WheelPlatformTag = "win_arm64"
+    } else {
+        # Import the Chocolatey profile module so that the RefreshEnv command
+        # invoked below properly updates the current PowerShell session environment.
+        $module = "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+        Import-Module "$module" ; Assert-Output $?
+        RefreshEnv
 
-    Write-Output "Current OpenCL drivers:"
-    Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors
+        Write-Output "Current OpenCL drivers:"
+        Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors
 
-    # (re-) activate conda environment, in case any activation logic was overridden by that 'RefreshEnv' call above
-    conda activate $env:CONDA_ENV
+        # (re-) activate conda environment, in case any activation logic was overridden by that 'RefreshEnv' call above
+        conda activate $env:CONDA_ENV
+
+        $WheelPlatformTag = "win_amd64"
+    }
 
     # TODO: restore --integrated-opencl as part of https://github.com/lightgbm-org/LightGBM/issues/6968
     sh "build-python.sh" bdist_wheel ; Assert-Output $?
     sh ./.ci/check-python-dists.sh ./dist ; Assert-Output $?
-    Set-Location dist; pip install --no-deps @(Get-ChildItem *py3-none-win_amd64.whl) ; Assert-Output $?
-    cp @(Get-ChildItem *py3-none-win_amd64.whl) "$env:BUILD_ARTIFACTSTAGINGDIRECTORY"
+    Set-Location dist; pip install --no-deps @(Get-ChildItem "*py3-none-$WheelPlatformTag.whl") ; Assert-Output $?
+    cp @(Get-ChildItem "*py3-none-$WheelPlatformTag.whl") "$env:BUILD_ARTIFACTSTAGINGDIRECTORY"
 } elseif (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python")) {
     if ($env:COMPILER -eq "MINGW") {
         sh ./build-python.sh install --mingw ; Assert-Output $?
@@ -173,7 +207,9 @@ if ($env:TASK -eq "bdist") {
 
 pytest -ra $tests ; Assert-Output $?
 
-if (($env:TASK -eq "regular") -or (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python"))) {
+if ((($env:TASK -eq "regular") -and (-not $IsArm64)) -or (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python"))) {
+    # TODO(arm64): this block needs 'jupyter'/'notebook'/'ipywidgets'/'h5py' and a working
+    # Graphviz binary, none of which are wired up yet for the pip-based win-arm64 environment
     Set-Location "$env:BUILD_SOURCESDIRECTORY/examples/python-guide"
     @("import matplotlib", "matplotlib.use('Agg')") + (Get-Content "plot_example.py") | Set-Content "plot_example.py"
     # Prevent interactive window mode

--- a/.ci/test-windows.ps1
+++ b/.ci/test-windows.ps1
@@ -82,7 +82,7 @@ if ($IsArm64) {
     # purpose. Every test that needs it guards itself with 'pytest.importorskip("pyarrow")'
     # (see tests/python_package_test/test_arrow.py and test_sklearn.py), so those tests
     # are automatically skipped on this runner instead of failing.
-    pip install -q -U pip "build>=0.10" ; Assert-Output $?
+    python -m pip install -q -U pip "build>=0.10" ; Assert-Output $?
     pip install -q -r "$env:BUILD_SOURCESDIRECTORY/.ci/pip-envs/requirements-windows-arm64.txt" ; Assert-Output $?
 }
 # 'pixi' is used for end-of-life Python versions

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -58,6 +58,10 @@ jobs:
             task: cpp-tests
             compiler: msvc
             container: null
+          - os: windows-11-arm
+            task: cpp-tests
+            compiler: msvc
+            container: null
           - os: ubuntu-24.04-ppc64le
             task: cpp-tests
             compiler: gcc

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -264,6 +264,20 @@ jobs:
             produces-artifacts: 'true'
             artifact-name: 'windows-amd64-cli-and-liblightgbm'
             python_version: '3.11'
+          # keep this Python version in sync with '.ci/install-python-arm64-windows.ps1'
+          - os: windows-11-arm
+            task: bdist
+            compiler: MSVC
+            method: wheel
+            produces-artifacts: 'true'
+            artifact-name: 'windows-arm64-wheel'
+            python_version: '3.13'
+          - os: windows-11-arm
+            task: regular
+            compiler: MSVC
+            produces-artifacts: 'true'
+            artifact-name: 'windows-arm64-cli-and-liblightgbm'
+            python_version: '3.13'
     steps:
       - name: Install packages used by third-party actions
         if: ${{ matrix.in-ubuntu-base-container == 'true' }}
@@ -328,15 +342,23 @@ jobs:
           export PRODUCES_ARTIFACTS="${{ matrix.produces-artifacts }}"
           $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
           $GITHUB_WORKSPACE/.ci/test.sh || exit 1
+      # the runner's pre-installed Miniconda targets x64 and conda-forge doesn't support
+      # win-arm64 yet, so this job uses a native win-arm64 CPython + pip instead of conda
+      # (see '.ci/install-python-arm64-windows.ps1' and '.ci/test-windows.ps1')
+      - name: Install Python for Windows arm64
+        if: matrix.os == 'windows-11-arm'
+        shell: pwsh -command ". {0}"
+        run: |
+          & "$env:GITHUB_WORKSPACE/.ci/install-python-arm64-windows.ps1"
       - name: Install OpenCL on Windows
-        if: startsWith(matrix.os, 'windows') && (matrix.task == 'bdist')
+        if: startsWith(matrix.os, 'windows') && (matrix.task == 'bdist') && (matrix.os != 'windows-11-arm')
         shell: pwsh -command ". {0}"
         run: |
           & "$env:GITHUB_WORKSPACE/.ci/install-opencl.ps1"
       # 'conda init powershell' needs to be run in a separate process
       # ref: https://docs.conda.io/projects/conda/en/stable/dev-guide/deep-dives/activation.html
       - name: Initialize conda on Windows
-        if: startsWith(matrix.os, 'windows')
+        if: startsWith(matrix.os, 'windows') && (matrix.os != 'windows-11-arm')
         shell: pwsh -command ". {0}"
         run: |
           $env:PATH = "$env:CONDA/Scripts;$env:PATH"
@@ -356,10 +378,14 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ${{ matrix.artifact-name }}
+          # '**' lets these also match the 'win-arm64/' subfolder that the 'regular' task
+          # writes to on windows-11-arm (see '.ci/test-windows.ps1'); the artifact's root
+          # stays 'artifacts/' either way, since that's the literal path segment before the
+          # first wildcard in each pattern
           path: |
-            artifacts/*.dll
+            artifacts/**/*.dll
             artifacts/*.dylib
-            artifacts/*.exe
+            artifacts/**/*.exe
             artifacts/*.so
             artifacts/*.tar.gz
             artifacts/*.whl
@@ -382,7 +408,7 @@ jobs:
         with:
           merge-multiple: true
           path: ${{ env.BUILD_ARTIFACTSTAGINGDIRECTORY }}
-          pattern: '*amd64*-liblightgbm'
+          pattern: '*-liblightgbm'
           run-id: ${{ github.run_id }}
       - name: Setup NuGet CLI
         uses: NuGet/setup-nuget@fd55a6f3b34392fa83fde1454582407d8c714123  # v4.0

--- a/tests/python_package_test/test_arrow.py
+++ b/tests/python_package_test/test_arrow.py
@@ -6,7 +6,10 @@ import pytest
 
 import lightgbm as lgb
 
-from .utils import assert_datasets_equal, np_assert_array_equal
+from .utils import SKIP_PYARROW_REASON, assert_datasets_equal, is_windows_arm64, np_assert_array_equal
+
+if is_windows_arm64():
+    pytest.skip(SKIP_PYARROW_REASON, allow_module_level=True)
 
 pa = pytest.importorskip("pyarrow")
 

--- a/tests/python_package_test/test_polars.py
+++ b/tests/python_package_test/test_polars.py
@@ -6,7 +6,7 @@ import pytest
 
 import lightgbm as lgb
 
-from .utils import assert_datasets_equal, np_assert_array_equal
+from .utils import SKIP_PYARROW_REASON, assert_datasets_equal, is_windows_arm64, np_assert_array_equal
 
 pl = pytest.importorskip("polars")
 
@@ -112,6 +112,10 @@ def dummy_dataset_params() -> Dict[str, Any]:
     ],
 )
 def test_dataset_construct_fuzzy(tmp_path, polars_frame_fn, dataset_params):
+    # polars' own '.to_pandas()' needs pyarrow, unlike lightgbm's own polars ingestion path
+    if is_windows_arm64():
+        pytest.skip(SKIP_PYARROW_REASON)
+
     polars_frame = polars_frame_fn()
 
     polars_dataset = lgb.Dataset(polars_frame, params=dataset_params)
@@ -124,6 +128,10 @@ def test_dataset_construct_fuzzy(tmp_path, polars_frame_fn, dataset_params):
 
 
 def test_dataset_construct_fuzzy_boolean(tmp_path):
+    # polars' own '.to_pandas()' needs pyarrow, unlike lightgbm's own polars ingestion path
+    if is_windows_arm64():
+        pytest.skip(SKIP_PYARROW_REASON)
+
     boolean_data = generate_random_polars_frame(
         num_columns=10, num_datapoints=10000, seed=42, generate_nulls=False, values=np.array([True, False])
     )
@@ -142,6 +150,10 @@ def test_dataset_construct_fuzzy_boolean(tmp_path):
 
 
 def test_dataset_construct_fields_fuzzy():
+    # polars' own '.to_pandas()' needs pyarrow, unlike lightgbm's own polars ingestion path
+    if is_windows_arm64():
+        pytest.skip(SKIP_PYARROW_REASON)
+
     polars_frame = generate_random_polars_frame(num_columns=3, num_datapoints=1000, seed=42)
     polars_labels = generate_random_polars_series(num_datapoints=1000, seed=42, generate_nulls=False)
     polars_weights = generate_random_polars_series(num_datapoints=1000, seed=42, generate_nulls=False)
@@ -304,6 +316,10 @@ def test_dataset_construct_init_scores_table():
 
 
 def assert_equal_predict_polars_pandas(booster: lgb.Booster, data: pl.DataFrame):
+    # polars' own '.to_pandas()' needs pyarrow, unlike lightgbm's own polars ingestion path
+    if is_windows_arm64():
+        pytest.skip(SKIP_PYARROW_REASON)
+
     pandas_data = data.to_pandas()
 
     p_polars = booster.predict(data)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -33,8 +33,10 @@ from lightgbm.compat import (
 )
 
 from .utils import (
+    SKIP_PYARROW_REASON,
     BuildInfo,
     assert_silent,
+    is_windows_arm64,
     load_breast_cancer,
     load_digits,
     load_iris,
@@ -1750,6 +1752,8 @@ def test_feature_names_in_and_predict_warning(
     Regression test for https://github.com/lightgbm-org/LightGBM/issues/6798.
     """
     if fit_X_type.startswith("pa_") or predict_X_type.startswith("pa_"):
+        if is_windows_arm64():
+            pytest.skip(SKIP_PYARROW_REASON)
         pa = pytest.importorskip("pyarrow")
         pd = pytest.importorskip("pandas")
     if fit_X_type.startswith("pd_") or predict_X_type.startswith("pd_"):
@@ -2083,6 +2087,8 @@ def test_predict_rejects_inputs_with_incorrect_number_of_features(predict_disabl
 
 def _run_minimal_test(*, X_type, y_type, g_type, task, rng):
     if any(t.startswith("pa_") for t in [X_type, y_type, g_type]):
+        if is_windows_arm64():
+            pytest.skip(SKIP_PYARROW_REASON)
         pa = pytest.importorskip("pyarrow")
     if any(t.startswith("pl_") for t in [X_type, y_type, g_type]):
         pl = pytest.importorskip("polars")

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -2,6 +2,8 @@
 import filecmp
 import os
 import pickle
+import platform
+import sys
 from functools import lru_cache
 from inspect import getfullargspec
 from pathlib import Path
@@ -15,6 +17,17 @@ from sklearn.utils import check_random_state
 import lightgbm as lgb
 
 SERIALIZERS = ["pickle", "joblib", "cloudpickle"]
+
+# PyPI does not currently publish 'win_arm64' wheels for pyarrow, so it's deliberately
+# left out of that CI job's environment (see '.ci/pip-envs/requirements-windows-arm64.txt').
+# Tests that need pyarrow check this and skip explicitly there, instead of relying on
+# 'pytest.importorskip' to turn an ImportError into a skip.
+SKIP_PYARROW_REASON = "pyarrow does not publish 'win_arm64' wheels yet"
+
+
+def is_windows_arm64() -> bool:
+    """Whether tests are running on a native Windows arm64 machine."""
+    return sys.platform == "win32" and platform.machine() == "ARM64"
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
## Summary

- Add `windows-11-arm` CI coverage: a `cpp-tests` job in `cpp.yml`, and `regular` (core lib + CLI) / `bdist` (wheel) jobs in `python_package.yml`.
- Since conda-forge/Miniforge don't support win-arm64 yet, the new Python jobs install a native win-arm64 CPython from python.org and use pip instead of conda, unlike every other Windows CI job (`.ci/install-python-arm64-windows.ps1`, `.ci/pip-envs/requirements-windows-arm64.txt`).
- `.ci/create-nuget.py` now bundles a `runtimes/win-arm64/native/` folder into the NuGet package alongside the existing win-x64 one, so the release artifact covers both architectures.
- `pyarrow` doesn't publish `win_arm64` wheels on PyPI yet, so it's left out of that job's environment. Tests that need it explicitly skip on that runner instead of failing (`tests/python_package_test/utils.py::is_windows_arm64()`), covering `test_arrow.py`, the `pa_`-prefixed cases in `test_sklearn.py`, and the handful of `test_polars.py` tests that call polars' own `.to_pandas()` (which needs pyarrow) to build a pandas-based reference for a round-trip equality check.

## Test plan

- [x] `cpp-tests`, `regular`, and `bdist` all pass on `windows-11-arm` (validated on a fork before opening this PR)
- [x] `create-nuget` still succeeds and produces a `.nupkg` with both `runtimes/win-x64/native/` and `runtimes/win-arm64/native/`
- [x] Existing win-x64/win-amd64 jobs are unaffected
