### PR TITLE
[c++] use global initial scores for additive objectives

### DIFF
--- a/src/objective/regression_objective.hpp
+++ b/src/objective/regression_objective.hpp
@@ -7,6 +7,7 @@
 #define LIGHTGBM_SRC_OBJECTIVE_REGRESSION_OBJECTIVE_HPP_
 
 #include <LightGBM/meta.h>
+#include <LightGBM/network.h>
 #include <LightGBM/objective_function.h>
 #include <LightGBM/utils/array_args.h>
 
@@ -186,6 +187,10 @@ class RegressionL2loss: public ObjectiveFunction {
       for (data_size_t i = 0; i < num_data_; ++i) {
         suml += label_[i];
       }
+    }
+    if (Network::num_machines() > 1) {
+      suml = Network::GlobalSyncUpBySum(suml);
+      sumw = Network::GlobalSyncUpBySum(sumw);
     }
     return suml / sumw;
   }

--- a/src/objective/xentropy_objective.hpp
+++ b/src/objective/xentropy_objective.hpp
@@ -7,6 +7,7 @@
 #define LIGHTGBM_SRC_OBJECTIVE_XENTROPY_OBJECTIVE_HPP_
 
 #include <LightGBM/meta.h>
+#include <LightGBM/network.h>
 #include <LightGBM/objective_function.h>
 #include <LightGBM/utils/common.h>
 
@@ -162,6 +163,10 @@ class CrossEntropy: public ObjectiveFunction {
         suml += label_[i];
       }
     }
+    if (Network::num_machines() > 1) {
+      suml = Network::GlobalSyncUpBySum(suml);
+      sumw = Network::GlobalSyncUpBySum(sumw);
+    }
     double pavg = suml / sumw;
     pavg = std::min(pavg, 1.0 - kEpsilon);
     pavg = std::max<double>(pavg, kEpsilon);
@@ -291,6 +296,10 @@ class CrossEntropyLambda: public ObjectiveFunction {
       for (data_size_t i = 0; i < num_data_; ++i) {
         suml += label_[i];
       }
+    }
+    if (Network::num_machines() > 1) {
+      suml = Network::GlobalSyncUpBySum(suml);
+      sumw = Network::GlobalSyncUpBySum(sumw);
     }
     double havg = suml / sumw;
     double initscore = std::log(std::expm1(havg));


### PR DESCRIPTION
This is a non-closing partial contribution toward #4405, following the additive synchronization pattern established in #4332.

Data-parallel workers currently calculate regression and cross-entropy initial scores from local label and weight totals, after which the resulting scores are averaged. Averaging locally derived scores is incorrect when workers have unequal sizes or different target distributions.

This synchronizes the additive label and weight totals before calculating initial scores for regression L2 and its inheritors, cross-entropy, and cross-entropy-lambda objectives. Single-machine behavior is unchanged.

This intentionally does not attempt to change regression L1, quantile, or MAPE objectives. Those require a distributed percentile calculation; averaging local percentiles is not correct and needs a separate design.

## Verification

- Full C++ build with `USE_OPENMP=OFF`
- `python -m pytest tests/distributed/_test_distributed.py --execfile ./lightgbm -q`: 2 passed
- Targeted two-worker checks with unequal partitions:
  - regression initial score: 7.5
  - cross-entropy initial score: 0.6500000097
  - cross-entropy-lambda initial score: 0.6500000097
- `git diff --check`

No tests were changed. The implementation mirrors the synchronization already accepted for the binary objective in #4332.
