### PR TITLE
[c++] Handle empty input in ParallelPartitionRunner

### DIFF
--- a/include/LightGBM/utils/threading.h
+++ b/include/LightGBM/utils/threading.h
@@ -120,6 +120,9 @@ class ParallelPartitionRunner {
       INDEX_T cnt,
       const std::function<INDEX_T(int, INDEX_T, INDEX_T, INDEX_T*, INDEX_T*)>& func,
       INDEX_T* out) {
+    if (cnt == 0) {
+      return 0;
+    }
     int nblock = 1;
     INDEX_T inner_size = cnt;
     if (FORCE_SIZE) {

--- a/tests/cpp_tests/test_common.cpp
+++ b/tests/cpp_tests/test_common.cpp
@@ -6,8 +6,10 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <vector>
 
 #include "../include/LightGBM/utils/common.h"
+#include "../include/LightGBM/utils/threading.h"
 
 
 // This is a basic test for floating number parsing.
@@ -151,4 +153,23 @@ TEST_F(AtofPreciseTest, Inf) {
     EXPECT_EQ(memcmp(&got, &test.expected, sizeof(test.expected)), 0)
               << "parsed infinite is not the same for every bit: " << test.data;
   }
+}
+
+TEST(ParallelPartitionRunnerTest, EmptyInputReturnsZero) {
+  LightGBM::ParallelPartitionRunner<LightGBM::data_size_t, false> runner(8, 1);
+  bool callback_called = false;
+  std::vector<LightGBM::data_size_t> output(1, -1);
+
+  const auto left_count = runner.Run<false>(
+      0,
+      [&](int, LightGBM::data_size_t, LightGBM::data_size_t,
+          LightGBM::data_size_t*, LightGBM::data_size_t*) {
+        callback_called = true;
+        return 0;
+      },
+      output.data());
+
+  EXPECT_EQ(left_count, 0);
+  EXPECT_FALSE(callback_called);
+  EXPECT_EQ(output[0], -1);
 }


### PR DESCRIPTION
Fixes #5222.

We encountered a native crash while training a large sparse dataset with
distributed LightGBM through SynapseML.

In distributed training, a leaf can have data globally while a particular
worker has no local rows for that leaf. In that case,
`ParallelPartitionRunner::Run()` is called with `cnt == 0`.

`Threading::BlockInfo()` consequently sets `nblock` to zero, but `Run()` later
accesses:

```cpp
left_write_pos_[nblock - 1]
left_cnts_[nblock - 1]
```

This reads index `-1` and results in undefined behavior. In our Linux release
build, the invalid access did not fail immediately. It surfaced later as
corrupted partition ranges and a native crash during histogram construction.

This change returns zero before calculating block information when the input
partition is empty. That matches the partitioning contract: empty input
produces zero rows on the left, does not invoke the partition callback, and
does not modify the output buffer.

A focused C++ regression test covers this behavior.
