### PR TITLE
[python-package]  re-enable early stopping when an early_stopping() callback is re-used

### DIFF
--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -323,12 +323,12 @@ class _EarlyStoppingCallback:
         return False
 
     def _init(self, env: CallbackEnv) -> None:
+        if env.evaluation_result_list is None or env.evaluation_result_list == []:
+            raise ValueError("For early stopping, at least one dataset and eval metric is required for evaluation")
+
         # re-evaluate here, so a callback re-used across training runs is not left
         # permanently disabled by an earlier run (for example, one using dart boosting)
         self.enabled = _should_enable_early_stopping(self.stopping_rounds)
-
-        if env.evaluation_result_list is None or env.evaluation_result_list == []:
-            raise ValueError("For early stopping, at least one dataset and eval metric is required for evaluation")
 
         is_dart = any(env.params.get(alias, "") == "dart" for alias in _ConfigAliases.get("boosting"))
         if is_dart:

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -323,6 +323,10 @@ class _EarlyStoppingCallback:
         return False
 
     def _init(self, env: CallbackEnv) -> None:
+        # re-evaluate here, so a callback re-used across training runs is not left
+        # permanently disabled by an earlier run (for example, one using dart boosting)
+        self.enabled = _should_enable_early_stopping(self.stopping_rounds)
+
         if env.evaluation_result_list is None or env.evaluation_result_list == []:
             raise ValueError("For early stopping, at least one dataset and eval metric is required for evaluation")
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -968,6 +968,48 @@ def test_early_stopping_ignores_training_set(use_valid):
         assert bst.best_iteration == 0
 
 
+@pytest.mark.parametrize("disabling_run", ["dart", "train_set_only"])
+def test_early_stopping_callback_can_be_reused_after_it_disabled_itself(disabling_run):
+    x = np.linspace(-1, 1, 100)
+    X = x.reshape(-1, 1)
+    y = x**2
+    X_train, X_valid = X[:80], X[80:]
+    y_train, y_valid = y[:80], y[80:]
+    num_boost_round = 10
+
+    def train_with_valid_set(callback):
+        return lgb.train(
+            {"num_leaves": 5},
+            lgb.Dataset(X_train, y_train),
+            num_boost_round=num_boost_round,
+            valid_sets=[lgb.Dataset(X_valid, y_valid)],
+            callbacks=[callback],
+        )
+
+    # a first run where early stopping is not possible, so the callback disables itself
+    callback = lgb.early_stopping(1, verbose=False)
+    train_ds = lgb.Dataset(X_train, y_train)
+    if disabling_run == "dart":
+        params = {"num_leaves": 5, "boosting": "dart"}
+        valid_sets = [lgb.Dataset(X_valid, y_valid)]
+        warning_match = "Early stopping is not available in dart mode"
+    else:
+        params = {"num_leaves": 5}
+        valid_sets = [train_ds]
+        warning_match = "Only training set found, disabling early stopping."
+    with pytest.warns(UserWarning, match=warning_match):
+        lgb.train(params, train_ds, num_boost_round=2, valid_sets=valid_sets, callbacks=[callback])
+    assert callback.enabled is False
+
+    # the same callback object must still early stop on a later run that has a validation set
+    reused = train_with_valid_set(callback)
+    fresh = train_with_valid_set(lgb.early_stopping(1, verbose=False))
+    assert reused.current_iteration() < num_boost_round
+    assert reused.current_iteration() == fresh.current_iteration()
+    assert reused.best_iteration == fresh.best_iteration
+    assert callback.enabled is True
+
+
 @pytest.mark.parametrize("first_metric_only", [True, False])
 def test_early_stopping_via_global_params(first_metric_only):
     X, y = load_breast_cancer(return_X_y=True)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -970,44 +970,45 @@ def test_early_stopping_ignores_training_set(use_valid):
 
 @pytest.mark.parametrize("disabling_run", ["dart", "train_set_only"])
 def test_early_stopping_callback_can_be_reused_after_it_disabled_itself(disabling_run):
-    x = np.linspace(-1, 1, 100)
-    X = x.reshape(-1, 1)
-    y = x**2
-    X_train, X_valid = X[:80], X[80:]
-    y_train, y_valid = y[:80], y[80:]
-    num_boost_round = 10
-
-    def train_with_valid_set(callback):
-        return lgb.train(
-            {"num_leaves": 5},
-            lgb.Dataset(X_train, y_train),
-            num_boost_round=num_boost_round,
-            valid_sets=[lgb.Dataset(X_valid, y_valid)],
-            callbacks=[callback],
-        )
-
-    # a first run where early stopping is not possible, so the callback disables itself
+    X, y = make_synthetic_regression()
+    X_train, X_valid, y_train, y_valid = train_test_split(X, y, test_size=0.1, random_state=42)
+    params = {"objective": "regression", "verbose": -1, "num_leaves": 2, "metric": "None"}
+    num_boost_round = 5
     callback = lgb.early_stopping(1, verbose=False)
     train_ds = lgb.Dataset(X_train, y_train)
+
     if disabling_run == "dart":
-        params = {"num_leaves": 5, "boosting": "dart"}
-        valid_sets = [lgb.Dataset(X_valid, y_valid)]
+        disabling_params = {**params, "boosting": "dart"}
+        disabling_valid_sets = [lgb.Dataset(X_valid, y_valid)]
         warning_match = "Early stopping is not available in dart mode"
     else:
-        params = {"num_leaves": 5}
-        valid_sets = [train_ds]
+        disabling_params = params
+        disabling_valid_sets = [train_ds]
         warning_match = "Only training set found, disabling early stopping."
+
     with pytest.warns(UserWarning, match=warning_match):
-        lgb.train(params, train_ds, num_boost_round=2, valid_sets=valid_sets, callbacks=[callback])
+        lgb.train(
+            disabling_params,
+            train_ds,
+            num_boost_round=num_boost_round,
+            valid_sets=disabling_valid_sets,
+            feval=constant_metric,
+            callbacks=[callback],
+        )
     assert callback.enabled is False
 
-    # the same callback object must still early stop on a later run that has a validation set
-    reused = train_with_valid_set(callback)
-    fresh = train_with_valid_set(lgb.early_stopping(1, verbose=False))
-    assert reused.current_iteration() < num_boost_round
-    assert reused.current_iteration() == fresh.current_iteration()
-    assert reused.best_iteration == fresh.best_iteration
+    # the same callback object must still early stop on a later run that does have a validation set
+    bst = lgb.train(
+        params,
+        lgb.Dataset(X_train, y_train),
+        num_boost_round=num_boost_round,
+        valid_sets=[lgb.Dataset(X_valid, y_valid)],
+        feval=constant_metric,
+        callbacks=[callback],
+    )
     assert callback.enabled is True
+    assert bst.best_iteration == 1
+    assert bst.current_iteration() < num_boost_round
 
 
 @pytest.mark.parametrize("first_metric_only", [True, False])

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -968,16 +968,22 @@ def test_early_stopping_ignores_training_set(use_valid):
         assert bst.best_iteration == 0
 
 
-@pytest.mark.parametrize("disabling_run", ["dart", "train_set_only"])
-def test_early_stopping_callback_can_be_reused_after_it_disabled_itself(disabling_run):
+@pytest.mark.parametrize("disabling_reason", ["dart", "train_set_only"])
+def test_early_stopping_callback_can_be_reused_after_it_disabled_itself(disabling_reason):
     X, y = make_synthetic_regression()
     X_train, X_valid, y_train, y_valid = train_test_split(X, y, test_size=0.1, random_state=42)
-    params = {"objective": "regression", "verbose": -1, "num_leaves": 2, "metric": "None"}
+    params = {
+        "metric": "None",
+        "min_data": 1,
+        "num_leaves": 2,
+        "objective": "regression",
+        "verbose": -1,
+    }
     num_boost_round = 5
     callback = lgb.early_stopping(1, verbose=False)
     train_ds = lgb.Dataset(X_train, y_train)
 
-    if disabling_run == "dart":
+    if disabling_reason == "dart":
         disabling_params = {**params, "boosting": "dart"}
         disabling_valid_sets = [lgb.Dataset(X_valid, y_valid)]
         warning_match = "Early stopping is not available in dart mode"
@@ -987,7 +993,7 @@ def test_early_stopping_callback_can_be_reused_after_it_disabled_itself(disablin
         warning_match = "Only training set found, disabling early stopping."
 
     with pytest.warns(UserWarning, match=warning_match):
-        lgb.train(
+        bst0 = lgb.train(
             disabling_params,
             train_ds,
             num_boost_round=num_boost_round,
@@ -995,10 +1001,14 @@ def test_early_stopping_callback_can_be_reused_after_it_disabled_itself(disablin
             feval=constant_metric,
             callbacks=[callback],
         )
-    assert callback.enabled is False
 
-    # the same callback object must still early stop on a later run that does have a validation set
-    bst = lgb.train(
+    # early stopping should not have been triggered
+    assert callback.enabled is False
+    assert bst0.best_iteration == 0
+    assert bst0.current_iteration() == num_boost_round
+
+    # re-using the same callback object in a later training call, early stopping is successfully enabled
+    bst1 = lgb.train(
         params,
         lgb.Dataset(X_train, y_train),
         num_boost_round=num_boost_round,
@@ -1007,8 +1017,8 @@ def test_early_stopping_callback_can_be_reused_after_it_disabled_itself(disablin
         callbacks=[callback],
     )
     assert callback.enabled is True
-    assert bst.best_iteration == 1
-    assert bst.current_iteration() < num_boost_round
+    assert bst1.best_iteration == 1
+    assert bst1.current_iteration() == 1
 
 
 @pytest.mark.parametrize("first_metric_only", [True, False])


### PR DESCRIPTION
`_EarlyStoppingCallback.enabled` is set once, in `__init__`. Both early-return paths in `_init()` then set it to `False` for good: dart boosting, and a `valid_sets` holding only the training data. `_init()` runs on every training run and calls `_reset_storages()` precisely so one callback object can be re-used, but nothing restores `enabled`. Re-use is a normal pattern, and `LGBMModel.fit` does `copy.copy(callbacks)`, a shallow copy, so the same objects reach every fit.

One callback, three `lgb.train()` calls on current main:

```
run1 (train-set only)      trees: 30   cb.enabled: False
run2 (real valid, REUSED)  trees: 300  best_iteration: 0
run3 (real valid, FRESH)   trees: 20   best_iteration: 20
```

Run 2 skips early stopping and prints no warning. The fix re-evaluates `enabled` at the top of `_init()`.

The new test fails on main (`assert 10 < 10`) and passes with the fix. `test_callback.py` + `test_engine.py`: 191 passed / 1 failed before, 193 / 1 after, the same pre-existing failure (`test_train_raises_informative_error_for_unknown_metric`, from the prebuilt lib in my sandbox). `test_sklearn.py`: 587 passed. `ruff check` and `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
