### PR TITLE
[c++] Check bin index before accessing upper bound

### DIFF
--- a/src/io/bin.cpp
+++ b/src/io/bin.cpp
@@ -402,7 +402,7 @@ void BinMapper::FindBin(double* values, int num_sample_values, size_t total_samp
       cnt_in_bin.resize(num_bin_, 0);
       int i_bin = 0;
       for (int i = 0; i < num_distinct_values; ++i) {
-        while (distinct_values[i] > bin_upper_bound_[i_bin] && i_bin < num_bin_ - 1) {
+        while (i_bin < num_bin_ - 1 && distinct_values[i] > bin_upper_bound_[i_bin]) {
           ++i_bin;
         }
         cnt_in_bin[i_bin] += counts[i];


### PR DESCRIPTION
## Summary

- evaluate `i_bin < num_bin_ - 1` before reading `bin_upper_bound_[i_bin]`
- clear the Cppcheck `arrayIndexThenCheck` diagnostic without changing bin assignments under the loop's current invariants

Contributes to #4539.

## Cppcheck evidence

Baseline: LightGBM `a6d48a604ea5421703ee3c9098190ddab677274f` and Cppcheck 2.21.0. The full C++17 command from #4539 reproduced the diagnostic. The before/after comparison below uses the same flags with the input scoped to `src/io/bin.cpp`.

Before:

```text
src/io/bin.cpp:405:53: style: Array index 'i_bin' is used before limits check. [arrayIndexThenCheck]
```

After the operand reorder, the scoped scan reports no `[arrayIndexThenCheck]` diagnostic. The issue-style filtered diagnostic count decreases from 339 to 338; the removed line is this diagnostic, and the remaining 338 diagnostic lines are unchanged.

## Testing

- [x] Cppcheck 2.21.0, same flags, scoped to `src/io/bin.cpp`
- [x] `git diff --check`
- [ ] `./testlightgbm --gtest_filter='Serialization.JustWorks:Stream.PushDenseRowsWithMetadata'` (not run: required submodules could not be fetched because Git pack transfers were reset by the network proxy)
- [ ] `./testlightgbm` (not run: same dependency blocker)
- [ ] `pre-commit run --all-files` (not run: the task-local bootstrap was blocked by network proxy resets before any hook ran)

No new test is added because, under the loop's current invariants, this operand reorder does not change the observable bin assignment, so a result-based test would pass before and after the change. The Cppcheck before/after comparison specifically validates the changed evaluation order.
