### PR TITLE
[c++] Fix NaN handling in split info comparisons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,6 +703,7 @@ if(BUILD_CPP_TEST)
       tests/cpp_tests/test_main.cpp
       tests/cpp_tests/test_serialize.cpp
       tests/cpp_tests/test_single_row.cpp
+      tests/cpp_tests/test_split_info.cpp
       tests/cpp_tests/test_stream.cpp
       tests/cpp_tests/testutils.cpp
     )

--- a/src/treelearner/split_info.hpp
+++ b/src/treelearner/split_info.hpp
@@ -139,11 +139,11 @@ struct SplitInfo {
     double local_gain = this->gain;
     double other_gain = si.gain;
     // replace nan with -inf
-    if (local_gain == NAN) {
+    if (std::isnan(local_gain)) {
       local_gain = kMinScore;
     }
     // replace nan with -inf
-    if (other_gain == NAN) {
+    if (std::isnan(other_gain)) {
       other_gain = kMinScore;
     }
     if (local_gain != other_gain) {
@@ -169,11 +169,11 @@ struct SplitInfo {
     double local_gain = this->gain;
     double other_gain = si.gain;
     // replace nan with -inf
-    if (local_gain == NAN) {
+    if (std::isnan(local_gain)) {
       local_gain = kMinScore;
     }
     // replace nan with -inf
-    if (other_gain == NAN) {
+    if (std::isnan(other_gain)) {
       other_gain = kMinScore;
     }
     if (local_gain != other_gain) {
@@ -234,11 +234,11 @@ struct LightSplitInfo {
     double local_gain = this->gain;
     double other_gain = si.gain;
     // replace nan with -inf
-    if (local_gain == NAN) {
+    if (std::isnan(local_gain)) {
       local_gain = kMinScore;
     }
     // replace nan with -inf
-    if (other_gain == NAN) {
+    if (std::isnan(other_gain)) {
       other_gain = kMinScore;
     }
     if (local_gain != other_gain) {
@@ -264,11 +264,11 @@ struct LightSplitInfo {
     double local_gain = this->gain;
     double other_gain = si.gain;
     // replace nan with -inf
-    if (local_gain == NAN) {
+    if (std::isnan(local_gain)) {
       local_gain = kMinScore;
     }
     // replace nan with -inf
-    if (other_gain == NAN) {
+    if (std::isnan(other_gain)) {
       other_gain = kMinScore;
     }
     if (local_gain != other_gain) {

--- a/tests/cpp_tests/test_split_info.cpp
+++ b/tests/cpp_tests/test_split_info.cpp
@@ -1,5 +1,4 @@
 /*!
- * Copyright (c) 2026 Microsoft Corporation. All rights reserved.
  * Copyright (c) 2026 The LightGBM developers. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */

--- a/tests/cpp_tests/test_split_info.cpp
+++ b/tests/cpp_tests/test_split_info.cpp
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (c) 2026 Microsoft Corporation. All rights reserved.
+ * Copyright (c) 2026 The LightGBM developers. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for license information.
+ */
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "../../src/treelearner/split_info.hpp"
+
+namespace {
+
+template <typename SplitInfoType>
+void ExpectNaNGainTreatedAsMinScore() {
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+
+  SplitInfoType finite;
+  finite.feature = 3;
+  finite.gain = 0.0;
+
+  SplitInfoType nan_smaller_feature;
+  nan_smaller_feature.feature = 1;
+  nan_smaller_feature.gain = nan;
+
+  SplitInfoType nan_larger_feature;
+  nan_larger_feature.feature = 2;
+  nan_larger_feature.gain = nan;
+
+  SplitInfoType nan_same_feature;
+  nan_same_feature.feature = nan_smaller_feature.feature;
+  nan_same_feature.gain = nan;
+
+  SplitInfoType min_score;
+  min_score.feature = nan_smaller_feature.feature;
+  min_score.gain = LightGBM::kMinScore;
+
+  EXPECT_TRUE(finite > nan_smaller_feature);
+  EXPECT_FALSE(nan_smaller_feature > finite);
+  EXPECT_TRUE(nan_smaller_feature > nan_larger_feature);
+  EXPECT_FALSE(nan_larger_feature > nan_smaller_feature);
+  EXPECT_TRUE(nan_smaller_feature == nan_same_feature);
+  EXPECT_TRUE(nan_smaller_feature == min_score);
+  EXPECT_FALSE(nan_smaller_feature == nan_larger_feature);
+}
+
+TEST(SplitInfo, NaNGainIsTreatedAsMinScore) {
+  ExpectNaNGainTreatedAsMinScore<LightGBM::SplitInfo>();
+}
+
+TEST(LightSplitInfo, NaNGainIsTreatedAsMinScore) {
+  ExpectNaNGainTreatedAsMinScore<LightGBM::LightSplitInfo>();
+}
+
+}  // namespace


### PR DESCRIPTION
Replace the eight `gain == NAN` checks in `SplitInfo` and
`LightSplitInfo` with `std::isnan()`.

The previous checks were always false, so NaN gains were not normalized to
`kMinScore`. This could make distributed best-split reduction depend on
operand order. We encountered this in a distributed Spark workload using
SynapseML.

Add regression tests for ordering, feature tie-breaking, and equality.