### PR TITLE
[ci] [R-package] test without suggested dependencies

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -293,6 +293,7 @@ jobs:
           - clang21
           - clang22
           - gcc16
+          - nosuggests
           - rchk
           - ubuntu-clang
           - ubuntu-gcc12
@@ -345,8 +346,13 @@ jobs:
       - name: Install packages and run tests
         shell: bash
         run: |
-          Rscript ./.ci/install-r-deps.R --build --test --exclude=testthat
-          sh build-cran-package.sh
+          if [[ "${{ matrix.image }}" == "nosuggests" ]]; then
+            Rscript ./.ci/install-r-deps.R
+            sh build-cran-package.sh --no-build-vignettes
+          else
+            Rscript ./.ci/install-r-deps.R --build --test --exclude=testthat
+            sh build-cran-package.sh
+          fi
 
           # 'rchk' isn't run through 'R CMD check', use the approach documented at
           # https://r-hub.github.io/containers/local.html
@@ -378,6 +384,13 @@ jobs:
             repos = 'https://cran.rstudio.com',
             Ncpus = parallel::detectCores())
           "
+
+          if [[ "${{ matrix.image }}" == "nosuggests" ]]; then
+            Rscript -e "
+              suggests <- trimws(strsplit(read.dcf('lightgbm_r/DESCRIPTION')[, 'Suggests'], ',')[[1]])
+              stopifnot(identical(intersect(suggests, rownames(installed.packages())), 'testthat'))
+            "
+          fi
 
           if [[ "${{ matrix.image }}" =~ "clang" ]]; then
             # allowing the following NOTEs (produced by default in the clang images):


### PR DESCRIPTION
Title: [ci] [R-package] test without suggested dependencies

## Summary

- add the R-hub `nosuggests` image to the R-package extra-check matrix
- avoid installing vignette and optional test dependencies in that matrix entry
- verify that only `testthat` from the built package's Suggests is installed before `R CMD check`
- duplicate-work check found no related implementation PR

Fixes #7367

## Test evidence

- `rtk python3 -c 'from pathlib import Path; import yaml; w=yaml.safe_load(Path(".github/workflows/r_package.yml").read_text()); job=w["jobs"]["test-r-extra-checks"]; run=next(s["run"] for s in job["steps"] if s["name"]=="Install packages and run tests"); assert job["strategy"]["matrix"]["image"].count("nosuggests")==1; assert "build-cran-package.sh --no-build-vignettes" in run; assert "intersect(suggests, rownames(installed.packages()))" in run; print("nosuggests workflow path verified")'`
- `rtk python3 -c 'from pathlib import Path; import yaml; w=yaml.safe_load(Path(".github/workflows/r_package.yml").read_text()); run=next(s["run"] for s in w["jobs"]["test-r-extra-checks"]["steps"] if s["name"]=="Install packages and run tests"); branch=run.split("\nelse\n", 1)[0]; assert "--build" not in branch and "--test" not in branch; assert "Rscript ./.ci/install-r-deps.R\n" in branch and "--no-build-vignettes" in branch; print("nosuggests avoids optional build/test dependency installation")'`
- `rtk git diff --check`

## Risks or notes for maintainers

The full check runs only in GitHub Actions because the R-hub container and R are unavailable locally. `testthat` requires `processx`, but the existing package-build script removes `processx` from the CRAN tarball's Suggests; the runtime assertion therefore checks the DESCRIPTION of the package actually passed to `R CMD check`.
