### PR TITLE
[python package] fix flaky test case on ppc64le

### DIFF
--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2084,7 +2084,7 @@ def test_contribs_sparse_multiclass():
     contribs_csr_arr_re = contribs_csr_array.reshape(
         (contribs_csr_array.shape[0], contribs_csr_array.shape[1] * contribs_csr_array.shape[2])
     )
-    if platform.machine() == "aarch64":
+    if platform.machine() in {"aarch64", "ppc64le"}:
         np.testing.assert_allclose(contribs_csr_arr_re, contribs_dense, rtol=1, atol=1e-12)
     else:
         np.testing.assert_allclose(contribs_csr_arr_re, contribs_dense)
@@ -2101,7 +2101,7 @@ def test_contribs_sparse_multiclass():
     contribs_csc_array = contribs_csc_array.reshape(
         (contribs_csc_array.shape[0], contribs_csc_array.shape[1] * contribs_csc_array.shape[2])
     )
-    if platform.machine() == "aarch64":
+    if platform.machine() in {"aarch64", "ppc64le"}:
         np.testing.assert_allclose(contribs_csc_array, contribs_dense, rtol=1, atol=1e-12)
     else:
         np.testing.assert_allclose(contribs_csc_array, contribs_dense)


### PR DESCRIPTION
This solves #7426 

The test fails on ppc64le because the sparse and dense prediction paths produce near-zero SHAP values that differ at ~1e-17 scale due to floating-point rounding differences, causing the relative error to hit 1.0 and exceed the default rtol=1e-7.

We fixed it by extending the existing aarch64 workaround to also cover ppc64le, applying the relaxed tolerance rtol=1, atol=1e-12 on both architectures.

@jameslamb @sandeepgupta12